### PR TITLE
Fix table sorting bug

### DIFF
--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -131,13 +131,19 @@ export default class Table extends React.Component {
                   className: classNames(this.props.hasFixedColumnWidths ? width : null),
                   scope: (key === this.props.rowHeaderColumnKey) ? 'row' : null,
                 },
-                date && row[key] !== null ? moment(row[key]).format('lll') : row[key],
-              )
-            ))}
+                date ? this.getDate(row[key]) : row[key],
+              )))}
           </tr>
         ))}
       </tbody>
     );
+  }
+
+  getDate(value) {
+    if (value) {
+      return moment(value).format('lll');
+    }
+    return 'N/A';
   }
 
   render() {

--- a/src/users/Enrollments.jsx
+++ b/src/users/Enrollments.jsx
@@ -30,11 +30,13 @@ export default function Enrollments({
       courseId: <a href={`${getConfig().LMS_BASE_URL}/courses/${result.courseId}`} rel="noopener noreferrer" target="_blank">{result.courseId}</a>,
       courseStart: result.courseStart,
       courseEnd: result.courseEnd,
-      upgradeDeadline: result.verifiedUpgradeDeadline,
+      // Set upgrade deadline to null if it doesn't exist to work around https://github.com/moment/moment/issues/3180
+      upgradeDeadline: result.verifiedUpgradeDeadline || null,
       created: result.created,
       reason: result.manualEnrollment ? result.manualEnrollment.reason : '',
       lastModifiedBy: result.manualEnrollment ? result.manualEnrollment.enrolledBy : '',
-      lastModified: result.manualEnrollment ? result.manualEnrollment.timeStamp : '',
+      // Set last modified to null if the timestamp doesn't exist to work around https://github.com/moment/moment/issues/3180
+      lastModified: result.manualEnrollment ? result.manualEnrollment.timeStamp || null : '',
       active: result.isActive ? 'True' : 'False',
       mode: result.mode,
       actions: (

--- a/src/users/Enrollments.jsx
+++ b/src/users/Enrollments.jsx
@@ -30,13 +30,11 @@ export default function Enrollments({
       courseId: <a href={`${getConfig().LMS_BASE_URL}/courses/${result.courseId}`} rel="noopener noreferrer" target="_blank">{result.courseId}</a>,
       courseStart: result.courseStart,
       courseEnd: result.courseEnd,
-      // Set upgrade deadline to null if it doesn't exist to work around https://github.com/moment/moment/issues/3180
-      upgradeDeadline: result.verifiedUpgradeDeadline || null,
+      upgradeDeadline: result.verifiedUpgradeDeadline,
       created: result.created,
       reason: result.manualEnrollment ? result.manualEnrollment.reason : '',
       lastModifiedBy: result.manualEnrollment ? result.manualEnrollment.enrolledBy : '',
-      // Set last modified to null if the timestamp doesn't exist to work around https://github.com/moment/moment/issues/3180
-      lastModified: result.manualEnrollment ? result.manualEnrollment.timeStamp || null : '',
+      lastModified: result.manualEnrollment ? result.manualEnrollment.timeStamp : '',
       active: result.isActive ? 'True' : 'False',
       mode: result.mode,
       actions: (

--- a/src/users/sort.js
+++ b/src/users/sort.js
@@ -1,10 +1,27 @@
+/**
+ * Given a keyed value from an element on the table, returns its internal value for sorting if it exists.
+ * This lets us properly support course ids that are embedded in links, as well as other objects.
+ */
+function getInternalValue(keyedValue) {
+  if (keyedValue) {
+    const { props = {} } = keyedValue;
+    return props.children;
+  }
+  return undefined;
+}
+
 export default function sort(firstElement, secondElement, key, direction) {
   const directionIsAsc = direction === 'asc';
 
-  if (firstElement[key] > secondElement[key]) {
+  const firstKeyedValue = firstElement[key];
+  const firstInternalValue = getInternalValue(firstKeyedValue);
+  const secondKeyedValue = secondElement[key];
+  const secondInternalValue = getInternalValue(secondKeyedValue);
+
+  if (firstKeyedValue > secondKeyedValue || firstInternalValue > secondInternalValue) {
     return directionIsAsc ? 1 : -1;
   }
-  if (firstElement[key] < secondElement[key]) {
+  if (firstKeyedValue < secondKeyedValue || firstInternalValue < secondInternalValue) {
     return directionIsAsc ? -1 : 1;
   }
   return 0;


### PR DESCRIPTION
This provides a fix for the issue where some columns of the table were
not being sorted correctly. The issue is that some of the columns have
objects, so they would never be sorted differently when keyed into.
This adds a utility method for getting the internal value of an element
in the table, which lets us appropriately sort things like the
courseId.
Additionally changes to displaying N/A for missing dates in the table.

CR-2058

UI after:
![image](https://user-images.githubusercontent.com/14864970/79578811-ba758300-8094-11ea-93d2-39094e6f396a.png)
