### PR TITLE
WIP: Add 'Create new enrollment' button

### DIFF
--- a/src/users/EnrollmentForm.jsx
+++ b/src/users/EnrollmentForm.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useContext } from 'react';
+import React, { useCallback, useState, useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
   Button, Input, InputSelect,
@@ -6,8 +6,11 @@ import {
 import classNames from 'classnames';
 
 import AlertList from '../user-messages/AlertList';
-import { postEnrollmentChange } from './api';
+import { postEnrollmentChange, postEnrollmentCreation } from './api';
 import UserMessagesContext from '../user-messages/UserMessagesContext';
+
+export const CREATE = 'create';
+export const CHANGE = 'change';
 
 const getModes = function getModes(enrollment) {
   const modeList = [];
@@ -18,12 +21,14 @@ const getModes = function getModes(enrollment) {
 };
 
 export default function EnrollmentForm({
+  formType,
   user,
   enrollment,
   changeHandler,
   closeHandler,
   forwardedRef,
 }) {
+  const [courseId, setCourseId] = useState(undefined);
   const [mode, setMode] = useState(enrollment.mode);
   const [reason, setReason] = useState('');
   const [comments, setComments] = useState('');
@@ -31,20 +36,66 @@ export default function EnrollmentForm({
 
   const submit = useCallback(() => {
     const sendReason = (reason === 'other') ? comments : reason;
-    postEnrollmentChange({
-      user,
-      courseID: enrollment.courseId,
-      oldMode: enrollment.mode,
-      newMode: mode,
-      reason: sendReason,
-    }).then((result) => {
-      if (result.errors !== undefined) {
-        result.errors.forEach(error => add(error));
-      } else {
-        changeHandler();
-      }
-    });
+    if (formType === CREATE) {
+      console.log('Send post request to create the new enrollment');
+      postEnrollmentCreation({
+        user,
+        mode,
+        courseID: courseId,
+        reason: sendReason,
+      }).then((result) => {
+        if (result.errors !== undefined) {
+          result.errors.forEach(error => add(error));
+        } else {
+          changeHandler();
+        }
+      });
+    } else if (formType === CHANGE) {
+      postEnrollmentChange({
+        user,
+        courseID: enrollment.courseId,
+        oldMode: enrollment.mode,
+        newMode: mode,
+        reason: sendReason,
+      }).then((result) => {
+        if (result.errors !== undefined) {
+          result.errors.forEach(error => add(error));
+        } else {
+          changeHandler();
+        }
+      });
+    }
   });
+
+  const renderCreationFields = () => (
+    <>
+      <div className="form-group">
+        <label htmlFor="courseUuid">Course Run ID</label>
+        <Input
+          type="text"
+          id="courseId"
+          name="courseId"
+          onChange={(event) => setCourseId(event.target.value)}
+        />
+      </div>
+      <div className="form-group">
+        <label htmlFor="mode">Mode</label>
+        <Input
+          type="select"
+          id="mode"
+          name="mode"
+          defaultValue={mode}
+          options={[
+            { label: '--', value: '' },
+            { label: 'Verified', value: 'verified' },
+            { label: 'Professional', value: 'professional' },
+            { label: 'No ID Professional', value: 'no-id-professional' },
+          ]}
+          onChange={(event) => setMode(event.target.value)}
+        />
+      </div>
+    </>
+  );
 
   const reasons = [
     { label: '--', value: '' },
@@ -54,29 +105,38 @@ export default function EnrollmentForm({
     { label: 'Other', value: 'other' },
   ];
 
+  const isChangeForm = formType === CHANGE;
+  const title = isChangeForm ? 'Change Enrollment' : 'Create Enrollment';
+
   return (
     <section className="card mb-3">
       <form className="card-body">
         <AlertList topic="enrollments" className="mb-3" />
-        <h4 className="card-title">Change Enrollment</h4>
-        <div className="form-group">
-          <h5>Current Enrollment Data</h5>
-          <div className="mb-1"><strong>Course Run ID:</strong> {enrollment.courseId}</div>
-          <div className="mb-1"><strong>Mode:</strong> {enrollment.mode}</div>
-          <div className="mb-1"><strong>Active:</strong> {enrollment.isActive.toString()}</div>
-        </div>
+        <h4 className="card-title">{title}</h4>
+        {isChangeForm && (
+          <div className="form-group">
+            <h5>Current Enrollment Data</h5>
+            <div className="mb-1"><strong>Course Run ID:</strong> {enrollment.courseId}</div>
+            <div className="mb-1"><strong>Mode:</strong> {enrollment.mode}</div>
+            <div className="mb-1"><strong>Active:</strong> {enrollment.isActive.toString()}</div>
+          </div>
+        )}
         <hr />
         <div className="form-group">
           <h5 className="card-subtitle">All fields are required</h5>
-          <InputSelect
-            label="New Mode"
-            type="select"
-            options={getModes(enrollment)}
-            id="mode"
-            name="mode"
-            value={enrollment.mode}
-            onChange={(event) => setMode(event)}
-          />
+          {isChangeForm ? (
+            <InputSelect
+              label="New Mode"
+              type="select"
+              options={getModes(enrollment)}
+              id="mode"
+              name="mode"
+              value={enrollment.mode}
+              onChange={(event) => setMode(event)}
+            />
+          ) : (
+            renderCreationFields()
+          )}
         </div>
         <div className="form-group">
           <InputSelect
@@ -123,6 +183,7 @@ export default function EnrollmentForm({
 }
 
 EnrollmentForm.propTypes = {
+  formType: PropTypes.string.isRequired,
   enrollment: PropTypes.shape({
     courseId: PropTypes.string.isRequired,
     mode: PropTypes.string.isRequired,

--- a/src/users/Enrollments.jsx
+++ b/src/users/Enrollments.jsx
@@ -9,7 +9,7 @@ import React, {
 import { Button, TransitionReplace, Collapsible } from '@edx/paragon';
 import { getConfig } from '@edx/frontend-platform';
 import PropTypes from 'prop-types';
-import EnrollmentForm from './EnrollmentForm';
+import EnrollmentForm, { CREATE, CHANGE } from './EnrollmentForm';
 import sort from './sort';
 import Table from '../Table';
 import formatDate from '../dates/formatDate';
@@ -70,7 +70,7 @@ export default function Enrollments({
             type="button"
             onClick={() => {
               setEnrollmentToChange(result);
-              setFormType('CHANGE');
+              setFormType(CHANGE);
             }}
             className="btn-outline-primary"
           >
@@ -136,7 +136,20 @@ export default function Enrollments({
   const tableDataSortable = [...tableData];
   return (
     <section className="mb-3">
-      <h3>Enrollments</h3>
+      <div className="d-flex flex-row justify-content-between mb-2">
+        <h3>Enrollments</h3>
+        {!formType && (
+          <Button
+            type="button"
+            className="btn-outline-primary"
+            onClick={() => {
+              setFormType(CREATE);
+            }}
+          >
+            Create New Enrollment
+          </Button>
+        )}
+      </div>
       <TransitionReplace>
         {formType != null ? (
           <EnrollmentForm
@@ -147,6 +160,7 @@ export default function Enrollments({
             changeHandler={changeHandler}
             closeHandler={() => setFormType(null)}
             forwardedRef={formRef}
+            formType={formType}
           />
         ) : (<React.Fragment key="nothing" />) }
       </TransitionReplace>

--- a/src/users/api.js
+++ b/src/users/api.js
@@ -304,7 +304,44 @@ export async function postEnrollmentChange({
         {
           code: null,
           dismissible: true,
-          text: 'There was an error submitting this entitlement. Check the JavaScript console for detailed errors.',
+          text: 'There was an error changing this enrollment. Check the JavaScript console for detailed errors.',
+          type: 'danger',
+          topic: 'enrollments',
+        },
+      ],
+    };
+  }
+}
+
+// TODO: Note that the API currently does not supporting creating an enrollment.
+// The API will need to be updated to support this
+export async function postEnrollmentCreation({
+  user, courseID, mode, reason,
+}) {
+  try {
+    const { data } = await getAuthenticatedHttpClient().post(
+      `${getConfig().LMS_BASE_URL}/support/enrollment/${user}`,
+      {
+        course_id: courseID,
+        mode,
+        reason,
+      },
+    );
+    return data;
+  } catch (error) {
+    if (error.customAttributes.httpErrorStatus === 400) {
+      // We don't have good error handling in the app for any errors that may have come back
+      // from the API, so we log them to the console and tell the user to go look.  We would
+      // never do this in a customer-facing app.
+      // eslint-disable-next-line no-console
+      console.log(JSON.parse(error.customAttributes.httpErrorResponseData));
+    }
+    return {
+      errors: [
+        {
+          code: null,
+          dismissible: true,
+          text: 'There was an error creating this enrollment. Check the JavaScript console for detailed errors.',
           type: 'danger',
           topic: 'enrollments',
         },


### PR DESCRIPTION
This adds in most of the frontend code needed to support the 'Create
new enrollment' button/action. An important thing to note is that the
API that we plan to use: /support/enrollment/{user} does not currently
support creating new enrollments, only updating them. To get this work
across the line, we'll have to update that API in the LMS.

CR-2068


![image](https://user-images.githubusercontent.com/14864970/79603751-e99eeb00-80ba-11ea-8e00-36af8ef8a071.png)
