### PR TITLE
Fix enrollment tool.

### DIFF
--- a/src/users/EnrollmentForm.jsx
+++ b/src/users/EnrollmentForm.jsx
@@ -14,7 +14,10 @@ const getModes = function getModes(enrollment) {
   enrollment.courseModes.map(mode => (
     modeList.push(mode.slug)
   ));
-  return modeList;
+  if (!modeList.some(mode => mode === enrollment.mode)) {
+    modeList.push(enrollment.mode);
+  }
+  return modeList.sort();
 };
 
 export default function EnrollmentForm({


### PR DESCRIPTION
If course has only one mode (e.g. professional) and enrollment mode is different from it (e.g. audit), there is no way to trigger onChange leading to submitting the old mode again instead of new mode.

PROD-1548