### PR TITLE
Give support the ability to disable/enable user accounts

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1,3 +1,5 @@
 @import '~@edx/paragon/scss/edx/theme.scss';
 
 @import "./support-header/index.scss";
+
+@import "./users/index.scss";

--- a/src/users/UserPage.jsx
+++ b/src/users/UserPage.jsx
@@ -104,6 +104,11 @@ export default function UserPage({ location }) {
     handleFetchSearchResults(searchValue);
   });
 
+  const handleUserSummaryChange = useCallback(() => {
+    setSearching(true);
+    handleFetchSearchResults(userIdentifier);
+  });
+
   const handleEntitlementsChange = useCallback(() => {
     setShowEntitlements(true);
     setShowEnrollments(false);
@@ -150,6 +155,7 @@ export default function UserPage({ location }) {
             userData={data.user}
             verificationData={data.verificationStatus}
             ssoRecords={data.ssoRecords}
+            changeHandler={handleUserSummaryChange}
           />
           <Entitlements
             user={data.user.username}

--- a/src/users/UserSummary.jsx
+++ b/src/users/UserSummary.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Modal, Button } from '@edx/paragon';
 
+import { postTogglePasswordStatus } from './api';
 import Table from '../Table';
 import formatDate from '../dates/formatDate';
 
@@ -9,10 +10,21 @@ export default function UserSummary({
   userData,
   verificationData,
   ssoRecords,
+  changeHandler,
 }) {
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const [extraDataTitle, setExtraDataTitle] = useState('');
   const [ssoExtraData, setSsoExtraData] = useState([]);
+
+  const PASSWORD_STATUS = {
+    USABLE: 'Usable',
+    UNUSABLE: 'Unusable',
+  };
+
+  const togglePasswordStatus = () => {
+    postTogglePasswordStatus(userData.username);
+    changeHandler();
+  };
 
   const userAccountData = [
     {
@@ -38,6 +50,10 @@ export default function UserSummary({
     {
       dataName: 'Join Date/Time',
       dataValue: formatDate(userData.dateJoined),
+    },
+    {
+      dataName: 'Password Status',
+      dataValue: userData.passwordStatus,
     },
   ];
 
@@ -116,27 +132,35 @@ export default function UserSummary({
 
   return (
     <section className="mb-3">
-      <div className="d-flex flex-row ">
+      <div className="d-flex flex-row flex-wrap">
         <div className="flex-column p-4 m-3 card">
           <h4>Account</h4>
           <Table
             data={userAccountData}
             columns={columns}
           />
+          <Button
+            className={`${userData.passwordStatus === PASSWORD_STATUS.USABLE ? 'btn-outline-danger' : 'btn-outline-primary'} toggle-password`}
+            onClick={togglePasswordStatus}
+          >
+            {userData.passwordStatus === PASSWORD_STATUS.USABLE ? 'Disable User' : 'Enable User'}
+          </Button>
         </div>
-        <div className="flex-column p-4 m-3 card">
-          <h4>ID Verification Status</h4>
-          <Table
-            data={userIDVerificationData}
-            columns={columns}
-          />
-        </div>
-        <div className="flex-column p-4 m-3 card">
-          <h4>SSO Records</h4>
-          <Table
-            data={ssoData}
-            columns={ssoColumns}
-          />
+        <div className="flex-column">
+          <div className="flex-column p-4 m-3 card">
+            <h4>ID Verification Status</h4>
+            <Table
+              data={userIDVerificationData}
+              columns={columns}
+            />
+          </div>
+          <div className="flex-column p-4 m-3 card">
+            <h4>SSO Records</h4>
+            <Table
+              data={ssoData}
+              columns={ssoColumns}
+            />
+          </div>
         </div>
         <Modal
           open={modalIsOpen}
@@ -162,6 +186,7 @@ UserSummary.propTypes = {
     isActive: PropTypes.bool,
     country: PropTypes.string,
     dateJoined: PropTypes.string,
+    passwordStatus: PropTypes.string,
   }),
   verificationData: PropTypes.shape({
     status: PropTypes.string,
@@ -169,6 +194,7 @@ UserSummary.propTypes = {
     isVerified: PropTypes.bool,
   }),
   ssoRecords: PropTypes.shape([]),
+  changeHandler: PropTypes.func.isRequired,
 };
 
 UserSummary.defaultProps = {

--- a/src/users/api.js
+++ b/src/users/api.js
@@ -104,6 +104,13 @@ export async function getUserVerificationStatus(username) {
   }
 }
 
+export async function getUserPasswordStatus(userIdentifier) {
+  const { data } = await getAuthenticatedHttpClient().get(
+    `${getConfig().LMS_BASE_URL}/support/manage_user/${userIdentifier}`,
+  );
+  return data.status;
+}
+
 export async function getAllUserData(userIdentifier) {
   const errors = [];
   let user = null;
@@ -126,6 +133,7 @@ export async function getAllUserData(userIdentifier) {
     enrollments = await getEnrollments(user.username);
     verificationStatus = await getUserVerificationStatus(user.username);
     ssoRecords = await getSsoRecords(user.username);
+    user.passwordStatus = await getUserPasswordStatus(user.username);
   }
 
   return {
@@ -281,4 +289,11 @@ export async function postEnrollmentChange({
       ],
     };
   }
+}
+
+export async function postTogglePasswordStatus(user) {
+  const { data } = await getAuthenticatedHttpClient().post(
+    `${getConfig().LMS_BASE_URL}/support/manage_user/${user}`,
+  );
+  return data;
 }

--- a/src/users/index.scss
+++ b/src/users/index.scss
@@ -1,0 +1,3 @@
+button.toggle-password {
+  max-width: 150px;
+}


### PR DESCRIPTION
[MST-307: Add manage user tool to MFE](https://openedx.atlassian.net/browse/MST-307)

@edx/masters-devs-cosmonauts 

In the "Search Users" tool, shows the password status for the user ("Usable" or "Unusable") and adds a button to toggle this status. Also includes some styling fixes to fit this information.

---

![Screen Shot 2020-07-29 at 12 00 51 PM](https://user-images.githubusercontent.com/10442143/88824222-11125300-d194-11ea-9ef9-45f22762ac49.png)
