### PR TITLE
Updating Renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,12 @@
 {
   "extends": [
     "config:base",
-    "schedule:earlyMondays"
+    ":automergeLinters",
+    ":automergeTesters",
+    ":automergeMinor",
+    ":noUnscheduledUpdates"
   ],
-  "patch": {
-    "automerge": true
-  },
-  "rebaseStalePrs": true
+  "rebaseStalePrs": true,
+  "schedule": ["after 12am and before 08:30am on Monday"],
+  "timezone": "America/New_York"
 }


### PR DESCRIPTION
This renovate configuration adds the following:


- only renovate on Monday morning at 12 am.
- automerge minor and patch versions if they pass tests
- automerge major, minor, and patch versions of linters and testers, if they pass tests
- Turns out the default is UTC so set the timezone to `America/New_York` 
- Make no updates to branches when not scheduled



I think the automerge still needs some repo permissions set up to be able to work right.





## Schedule Config Issue: 
Adding `schedule` as defined in the docs.  => https://docs.renovatebot.com/faq/


### Screenshot 1: 
<img width="714" alt="Screen Shot 2020-09-21 at 2 55 18 PM"  src="https://user-images.githubusercontent.com/4252738/93754279-e801c200-fc1a-11ea-890c-6216fa9430b5.png">

## rebaseStalePrs Config Issue: 
Also, there is a setting int the file, `"rebaseStalePrs": true,` I am not sure if this is applied because in the docs they recommended using `rebaseWhen` settings. 
https://docs.renovatebot.com/configuration-options/

### Screenshot 2:
<img width="683" alt="Screen Shot 2020-09-21 at 2 54 32 PM" src="https://user-images.githubusercontent.com/4252738/93754468-3a42e300-fc1b-11ea-981e-277ae7362b8d.png">
