### PR TITLE
Added disable user history/confirmation

### DIFF
--- a/src/users/api.js
+++ b/src/users/api.js
@@ -136,7 +136,7 @@ export async function getUserPasswordStatus(userIdentifier) {
   const { data } = await getAuthenticatedHttpClient().get(
     `${getConfig().LMS_BASE_URL}/support/manage_user/${userIdentifier}`,
   );
-  return data.status;
+  return data;
 }
 
 export async function getAllUserData(userIdentifier) {
@@ -319,9 +319,12 @@ export async function postEnrollmentChange({
   }
 }
 
-export async function postTogglePasswordStatus(user) {
+export async function postTogglePasswordStatus(user, comment) {
   const { data } = await getAuthenticatedHttpClient().post(
     `${getConfig().LMS_BASE_URL}/support/manage_user/${user}`,
+    {
+      comment,
+    },
   );
   return data;
 }


### PR DESCRIPTION
## [PROD-2106](https://openedx.atlassian.net/browse/PROD-2106)

### Description
Added Disable user button with a confirmation pop up that allow you to add a comment/reason. Also added user enable/disable history

UI Images
<img width="1345" alt="Screenshot 2020-10-15 at 3 37 00 PM" src="https://user-images.githubusercontent.com/10988308/96113183-3d20b300-0efd-11eb-8139-e707c1438886.png">
<img width="1350" alt="Screenshot 2020-10-15 at 3 36 49 PM" src="https://user-images.githubusercontent.com/10988308/96113206-4447c100-0efd-11eb-9d20-4da7831bc007.png">


**Sandbox**
N/A


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @awaisdar001 
- [ ] @DawoudSheraz 

### Post-review
- [ ] Rebase and squash commits