### PR TITLE
add special chars in email regex check

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,4 @@
-const EMAIL_REGEX = '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$';
+const EMAIL_REGEX = '^[a-zA-Z0-9\'!#$&*._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$';
 const USERNAME_REGEX = '^[\\w.@_+-]+$';
 
 // todo: No need for !!. This operation is not affecting the value.

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -1,7 +1,7 @@
 import { isEmail, isValidUsername } from './index';
 
 describe('Test Utils', () => {
-  const validEmails = ['staff@email.com', 'admin@email.co.og'];
+  const validEmails = ['staff@email.com', 'admin@email.co.og', 'test\'1@email.com'];
   const invalidEmails = [
     '',
     ' ',


### PR DESCRIPTION
### [PROD-2265](https://openedx.atlassian.net/browse/PROD-2265)

### Description
Email regex does not include special characters that are allowed in the emails. The PR adds a few of them, taking reference from [django email validator](https://github.com/django/django/blob/83fbaa92311dd96e330496a0e443ea71b9c183e2/django/core/validators.py#L157).