### PR TITLE
add last login field in user summary component

### DIFF
--- a/src/users/UserSummary.jsx
+++ b/src/users/UserSummary.jsx
@@ -61,6 +61,10 @@ export default function UserSummary({
       dataValue: formatDate(userData.dateJoined),
     },
     {
+      dataName: 'Last Login',
+      dataValue: formatDate(userData.lastLogin),
+    },
+    {
       dataName: 'Password Status',
       dataValue: userData.passwordStatus.status,
     },
@@ -340,6 +344,7 @@ UserSummary.propTypes = {
     isActive: PropTypes.bool,
     country: PropTypes.string,
     dateJoined: PropTypes.string,
+    lastLogin: PropTypes.string,
     passwordStatus: PropTypes.shape({
       status: PropTypes.string,
       passwordToggleHistory: PropTypes.shape([]),


### PR DESCRIPTION
### [PROD-2258](https://openedx.atlassian.net/browse/PROD-2258)

### Description
Adds last login time for user summary component. The field was added in user_api in https://github.com/edx/edx-platform/pull/26087

<img width="1680" alt="Screenshot 2021-01-20 at 3 27 14 PM" src="https://user-images.githubusercontent.com/40599381/105164468-fdd6b380-5b36-11eb-8797-5aabd1ca95cf.png">
<img width="1680" alt="Screenshot 2021-01-20 at 3 27 33 PM" src="https://user-images.githubusercontent.com/40599381/105164485-0202d100-5b37-11eb-8884-8889f7fbe850.png">
