### PR TITLE
Add ability to expire Entitlements

### DIFF
--- a/src/users/UserPage.jsx
+++ b/src/users/UserPage.jsx
@@ -11,7 +11,7 @@ import UserMessagesContext from '../user-messages/UserMessagesContext';
 import { isEmail, isValidUsername } from '../utils/index';
 import { getAllUserData } from './data/api';
 import Enrollments from './Enrollments';
-import Entitlements from './Entitlements';
+import Entitlements from './entitlements/Entitlements';
 import UserSearch from './UserSearch';
 import UserSummary from './UserSummary';
 

--- a/src/users/data/api.js
+++ b/src/users/data/api.js
@@ -221,24 +221,11 @@ export async function getCourseData(courseUUID) {
 }
 
 export async function patchEntitlement({
-  uuid,
-  action,
-  unenrolledRun = null,
-  comments = null,
+  uuid, requestData,
 }) {
   try {
     const { data } = await getAuthenticatedHttpClient().patch(
-      `${getConfig().LMS_BASE_URL}/api/entitlements/v1/entitlements/${uuid}/`,
-      {
-        expired_at: null,
-        support_details: [
-          {
-            unenrolled_run: unenrolledRun,
-            action,
-            comments,
-          },
-        ],
-      },
+      `${getConfig().LMS_BASE_URL}/api/entitlements/v1/entitlements/${uuid}/`, requestData,
     );
     return data;
   } catch (error) {
@@ -265,27 +252,11 @@ export async function patchEntitlement({
 }
 
 export async function postEntitlement({
-  user,
-  courseUuid,
-  mode,
-  action,
-  comments = null,
+  requestData,
 }) {
   try {
     const { data } = await getAuthenticatedHttpClient().post(
-      `${getConfig().LMS_BASE_URL}/api/entitlements/v1/entitlements/`,
-      {
-        course_uuid: courseUuid,
-        user,
-        mode,
-        refund_locked: true,
-        support_details: [
-          {
-            action,
-            comments,
-          },
-        ],
-      },
+      `${getConfig().LMS_BASE_URL}/api/entitlements/v1/entitlements/`, requestData,
     );
     return data;
   } catch (error) {

--- a/src/users/entitlements/CreateEntitlementForm.jsx
+++ b/src/users/entitlements/CreateEntitlementForm.jsx
@@ -5,15 +5,13 @@ import {
 } from '@edx/paragon';
 import classNames from 'classnames';
 
-import UserMessagesContext from '../user-messages/UserMessagesContext';
-import AlertList from '../user-messages/AlertList';
-import { postEntitlement, patchEntitlement } from './data/api';
+import UserMessagesContext from '../../user-messages/UserMessagesContext';
+import AlertList from '../../user-messages/AlertList';
+import { postEntitlement } from '../data/api';
+import { CREATE } from './EntitlementActions';
+import { EntitlementPropTypes, EntitlementDefaultProps } from './PropTypes';
 
-export const REISSUE = 'reissue';
-export const CREATE = 'create';
-
-export default function EntitlementForm({
-  formType,
+export default function CreateEntitlementForm({
   entitlement,
   changeHandler,
   closeHandler,
@@ -27,50 +25,36 @@ export default function EntitlementForm({
 
   const submit = useCallback(() => {
     clear('entitlements');
-    if (formType === CREATE) {
-      postEntitlement({
+    postEntitlement({
+      requestData: {
+        course_uuid: courseUuid,
         user,
-        courseUuid,
         mode,
-        action: CREATE,
-        comments,
-      }).then((result) => {
-        if (result.errors !== undefined) {
-          result.errors.forEach(error => add(error));
-        } else {
-          changeHandler();
-        }
-      });
-    } else if (formType === REISSUE) {
-      patchEntitlement({
-        uuid: entitlement.uuid,
-        action: REISSUE,
-        unenrolledRun: entitlement.enrollmentCourseRun,
-        comments,
-      }).then((result) => {
-        if (result.errors !== undefined) {
-          result.errors.forEach(error => add(error));
-        } else {
-          changeHandler();
-        }
-      });
-    }
+        refund_locked: true,
+        support_details: [{
+          action: CREATE,
+          comments,
+        }],
+      },
+    }).then((result) => {
+      if (result.errors !== undefined) {
+        result.errors.forEach(error => add(error));
+      } else {
+        changeHandler();
+      }
+    });
   });
-
-  const isReissue = formType === REISSUE;
-  const title = isReissue ? 'Re-issue Entitlement' : 'Create Entitlement';
 
   return (
     <section className="card mb-3">
       <form className="card-body">
         <AlertList topic="entitlements" className="mb-3" />
-        <h4 className="card-title">{title}</h4>
+        <h4 className="card-title">Create Entitlement</h4>
         <h5 className="card-subtitle">All fields are required</h5>
         <div className="form-group">
           <label htmlFor="courseUuid">Course UUID</label>
           <Input
             type="text"
-            disabled={isReissue}
             id="courseUuid"
             name="courseUuid"
             value={courseUuid}
@@ -81,7 +65,6 @@ export default function EntitlementForm({
           <label htmlFor="mode">Mode</label>
           <Input
             type="select"
-            disabled={isReissue}
             id="mode"
             name="mode"
             defaultValue={mode}
@@ -128,42 +111,15 @@ export default function EntitlementForm({
   );
 }
 
-EntitlementForm.propTypes = {
-  formType: PropTypes.string.isRequired,
-  entitlement: PropTypes.shape({
-    uuid: PropTypes.string.isRequired,
-    courseUuid: PropTypes.string.isRequired,
-    enrollmentCourseRun: PropTypes.string,
-    created: PropTypes.string.isRequired,
-    modified: PropTypes.string.isRequired,
-    expiredAt: PropTypes.string,
-    mode: PropTypes.string.isRequired,
-    orderNumber: PropTypes.string,
-    supportDetails: PropTypes.arrayOf(PropTypes.shape({
-      supportUser: PropTypes.string,
-      action: PropTypes.string,
-      comments: PropTypes.string,
-      unenrolledRun: PropTypes.string,
-    })),
-    user: PropTypes.string.isRequired,
-  }),
+CreateEntitlementForm.propTypes = {
+  entitlement: EntitlementPropTypes,
   user: PropTypes.string.isRequired,
   changeHandler: PropTypes.func.isRequired,
   closeHandler: PropTypes.func.isRequired,
   forwardedRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
 };
 
-EntitlementForm.defaultProps = {
-  entitlement: {
-    uuid: '',
-    courseUuid: '',
-    created: '',
-    modified: '',
-    expiredAt: '',
-    mode: 'verified',
-    orderNumber: '',
-    supportDetails: [],
-    user: '',
-  },
+CreateEntitlementForm.defaultProps = {
+  entitlement: EntitlementDefaultProps,
   forwardedRef: null,
 };

--- a/src/users/entitlements/EntitlementActions.jsx
+++ b/src/users/entitlements/EntitlementActions.jsx
@@ -1,0 +1,3 @@
+export const REISSUE = 'reissue';
+export const EXPIRE = 'expire';
+export const CREATE = 'create';

--- a/src/users/entitlements/EntitlementForm.jsx
+++ b/src/users/entitlements/EntitlementForm.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { CREATE, REISSUE, EXPIRE } from './EntitlementActions';
+import CreateEntitlementForm from './CreateEntitlementForm';
+import ReissueEntitlementForm from './ReissueEntitlementForm';
+import ExpireEntitlementForm from './ExpireEntitlementForm';
+import { EntitlementPropTypes, EntitlementDefaultProps } from './PropTypes';
+
+export default function EntitlementForm({
+  formType,
+  entitlement,
+  changeHandler,
+  closeHandler,
+  user,
+  forwardedRef,
+}) {
+  if (formType === CREATE) {
+    return (
+      <CreateEntitlementForm
+        key="entitlement-create-form"
+        user={user}
+        entitlement={entitlement}
+        changeHandler={changeHandler}
+        closeHandler={closeHandler}
+        forwardedRef={forwardedRef}
+      />
+    );
+  } if (formType === EXPIRE) {
+    return (
+      <ExpireEntitlementForm
+        key="entitlement-expire-form"
+        user={user}
+        entitlement={entitlement}
+        changeHandler={changeHandler}
+        closeHandler={closeHandler}
+        forwardedRef={forwardedRef}
+      />
+    );
+  } if (formType === REISSUE) {
+    return (
+      <ReissueEntitlementForm
+        key="entitlement-reissue-form"
+        user={user}
+        entitlement={entitlement}
+        changeHandler={changeHandler}
+        closeHandler={closeHandler}
+        forwardedRef={forwardedRef}
+      />
+    );
+  }
+}
+
+EntitlementForm.propTypes = {
+  formType: PropTypes.string.isRequired,
+  entitlement: EntitlementPropTypes,
+  user: PropTypes.string.isRequired,
+  changeHandler: PropTypes.func.isRequired,
+  closeHandler: PropTypes.func.isRequired,
+  forwardedRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+};
+
+EntitlementForm.defaultProps = {
+  entitlement: EntitlementDefaultProps,
+  forwardedRef: null,
+};

--- a/src/users/entitlements/ExpireEntitlementForm.jsx
+++ b/src/users/entitlements/ExpireEntitlementForm.jsx
@@ -1,0 +1,117 @@
+import React, { useCallback, useState, useContext } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button, Input,
+} from '@edx/paragon';
+import classNames from 'classnames';
+
+import UserMessagesContext from '../../user-messages/UserMessagesContext';
+import AlertList from '../../user-messages/AlertList';
+import { patchEntitlement } from '../data/api';
+import { EXPIRE } from './EntitlementActions';
+import { EntitlementPropTypes, EntitlementDefaultProps } from './PropTypes';
+import makeRequestData from './utils';
+
+export default function ExpireEntitlementForm({
+  entitlement,
+  changeHandler,
+  closeHandler,
+  forwardedRef,
+}) {
+  const [courseUuid, setCourseUuid] = useState(entitlement.courseUuid);
+  const [mode, setMode] = useState(entitlement.mode);
+  const [comments, setComments] = useState('');
+  const { add, clear } = useContext(UserMessagesContext);
+
+  const submit = useCallback(() => {
+    const now = new Date().toISOString();
+    clear('entitlements');
+    patchEntitlement({
+      uuid: entitlement.uuid,
+      requestData: makeRequestData({
+        expiredAt: now,
+        enrollmentCourseRun: entitlement.enrollmentCourseRun,
+        action: EXPIRE,
+        comments,
+      }),
+    }).then((result) => {
+      if (result.errors !== undefined) {
+        result.errors.forEach(error => add(error));
+      } else {
+        changeHandler();
+      }
+    });
+  });
+
+  return (
+    <section className="card mb-3">
+      <form className="card-body">
+        <AlertList topic="entitlements" className="mb-3" />
+        <h4 className="card-title">Expire Entitlement</h4>
+        <h5 className="card-subtitle">All fields are required</h5>
+        <div className="form-group">
+          <label htmlFor="courseUuid">Course UUID</label>
+          <Input
+            type="text"
+            id="courseUuid"
+            name="courseUuid"
+            value={courseUuid}
+            onChange={(event) => setCourseUuid(event.target.value)}
+            disabled
+          />
+        </div>
+        <div className="form-group">
+          <label htmlFor="mode">Mode</label>
+          <Input
+            type="text"
+            id="mode"
+            name="mode"
+            defaultValue={mode}
+            onChange={(event) => setMode(event.target.value)}
+            disabled
+          />
+        </div>
+        <div className="form-group">
+          <label htmlFor="comments">Comments</label>
+          <Input
+            type="textarea"
+            id="comments"
+            name="comments"
+            defaultValue={comments}
+            onChange={(event) => setComments(event.target.value)}
+            ref={forwardedRef}
+          />
+        </div>
+        <div>
+          <Button
+            className={classNames(
+              'btn-primary mr-3',
+              { disabled: !(courseUuid && mode && comments) },
+            )}
+            onClick={submit}
+          >
+            Submit
+          </Button>
+          <Button
+            onClick={closeHandler}
+            variant="outline-secondary"
+          >
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </section>
+  );
+}
+
+ExpireEntitlementForm.propTypes = {
+  entitlement: EntitlementPropTypes,
+  changeHandler: PropTypes.func.isRequired,
+  closeHandler: PropTypes.func.isRequired,
+  forwardedRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+};
+
+ExpireEntitlementForm.defaultProps = {
+  entitlement: EntitlementDefaultProps,
+  forwardedRef: null,
+};

--- a/src/users/entitlements/PropTypes.jsx
+++ b/src/users/entitlements/PropTypes.jsx
@@ -1,0 +1,31 @@
+import PropTypes from 'prop-types';
+
+export const EntitlementPropTypes = PropTypes.shape({
+  uuid: PropTypes.string.isRequired,
+  courseUuid: PropTypes.string.isRequired,
+  enrollmentCourseRun: PropTypes.string,
+  created: PropTypes.string.isRequired,
+  modified: PropTypes.string.isRequired,
+  expiredAt: PropTypes.string,
+  mode: PropTypes.string.isRequired,
+  orderNumber: PropTypes.string,
+  supportDetails: PropTypes.arrayOf(PropTypes.shape({
+    supportUser: PropTypes.string,
+    action: PropTypes.string,
+    comments: PropTypes.string,
+    unenrolledRun: PropTypes.string,
+  })),
+  user: PropTypes.string.isRequired,
+});
+
+export const EntitlementDefaultProps = {
+  uuid: '',
+  courseUuid: '',
+  created: '',
+  modified: '',
+  expiredAt: '',
+  mode: 'verified',
+  orderNumber: '',
+  supportDetails: [],
+  user: '',
+};

--- a/src/users/entitlements/ReissueEntitlementForm.jsx
+++ b/src/users/entitlements/ReissueEntitlementForm.jsx
@@ -1,0 +1,115 @@
+import React, { useCallback, useState, useContext } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button, Input,
+} from '@edx/paragon';
+import classNames from 'classnames';
+
+import UserMessagesContext from '../../user-messages/UserMessagesContext';
+import AlertList from '../../user-messages/AlertList';
+import { patchEntitlement } from '../data/api';
+import { REISSUE } from './EntitlementActions';
+import { EntitlementPropTypes, EntitlementDefaultProps } from './PropTypes';
+import makeRequestData from './utils';
+
+export default function ReissueEntitlementForm({
+  entitlement,
+  changeHandler,
+  closeHandler,
+  forwardedRef,
+}) {
+  const [courseUuid, setCourseUuid] = useState(entitlement.courseUuid);
+  const [mode, setMode] = useState(entitlement.mode);
+  const [comments, setComments] = useState('');
+  const { add, clear } = useContext(UserMessagesContext);
+
+  const submit = useCallback(() => {
+    clear('entitlements');
+    patchEntitlement({
+      uuid: entitlement.uuid,
+      requestData: makeRequestData({
+        enrollmentCourseRun: entitlement.enrollmentCourseRun,
+        action: REISSUE,
+        comments,
+      }),
+    }).then((result) => {
+      if (result.errors !== undefined) {
+        result.errors.forEach(error => add(error));
+      } else {
+        changeHandler();
+      }
+    });
+  });
+
+  return (
+    <section className="card mb-3">
+      <form className="card-body">
+        <AlertList topic="entitlements" className="mb-3" />
+        <h4 className="card-title">Reissue Entitlement</h4>
+        <h5 className="card-subtitle">All fields are required</h5>
+        <div className="form-group">
+          <label htmlFor="courseUuid">Course UUID</label>
+          <Input
+            type="text"
+            id="courseUuid"
+            name="courseUuid"
+            value={courseUuid}
+            onChange={(event) => setCourseUuid(event.target.value)}
+            disabled
+          />
+        </div>
+        <div className="form-group">
+          <label htmlFor="mode">Mode</label>
+          <Input
+            type="text"
+            id="mode"
+            name="mode"
+            defaultValue={mode}
+            onChange={(event) => setMode(event.target.value)}
+            disabled
+          />
+        </div>
+        <div className="form-group">
+          <label htmlFor="comments">Comments</label>
+          <Input
+            type="textarea"
+            id="comments"
+            name="comments"
+            defaultValue={comments}
+            onChange={(event) => setComments(event.target.value)}
+            ref={forwardedRef}
+          />
+        </div>
+        <div>
+          <Button
+            className={classNames(
+              'btn-primary mr-3',
+              { disabled: !(courseUuid && mode && comments) },
+            )}
+            onClick={submit}
+          >
+            Submit
+          </Button>
+          <Button
+            onClick={closeHandler}
+            variant="outline-secondary"
+          >
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </section>
+  );
+}
+
+ReissueEntitlementForm.propTypes = {
+  entitlement: EntitlementPropTypes,
+  changeHandler: PropTypes.func.isRequired,
+  closeHandler: PropTypes.func.isRequired,
+  forwardedRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+};
+
+ReissueEntitlementForm.defaultProps = {
+  entitlement: EntitlementDefaultProps,
+  forwardedRef: null,
+};

--- a/src/users/entitlements/utils.js
+++ b/src/users/entitlements/utils.js
@@ -1,0 +1,12 @@
+export default function makeRequestData({
+  expiredAt = null, enrollmentCourseRun, action, comments,
+}) {
+  return {
+    expired_at: expiredAt,
+    support_details: [{
+      unenrolled_run: enrollmentCourseRun,
+      action,
+      comments,
+    }],
+  };
+}


### PR DESCRIPTION
## Add ability to expire entitlements in support tool 
[PROD-2132](https://openedx.atlassian.net/browse/PROD-2132)

An `Expire` button is added in the action column of Entitlements as shown in the image:

<img width="1399" alt="Screenshot 2021-01-21 at 6 49 58 PM" src="https://user-images.githubusercontent.com/52413434/105363257-a3fce900-5c1d-11eb-950f-734a730531d8.png">

A form will be shown upon clicking the `Expire` button. The user can add a comment about the reason to expire the entitlement.
<img width="1405" alt="Screenshot 2021-01-21 at 6 51 00 PM" src="https://user-images.githubusercontent.com/52413434/105364634-32259f00-5c1f-11eb-9d32-a4f77778de83.png">

Submitting this will send a patch request to api to set `expiredAt` field. Note that the button will be disabled once the entitlement is expired. 
<img width="1406" alt="Screenshot 2021-01-21 at 6 52 52 PM" src="https://user-images.githubusercontent.com/52413434/105364890-803aa280-5c1f-11eb-9561-c79422869ac3.png">

