### PR TITLE
fix long course_id breaking enrollment table

### DIFF
--- a/src/users/Enrollments.jsx
+++ b/src/users/Enrollments.jsx
@@ -29,7 +29,7 @@ export default function Enrollments({
     }
     return data.map(result => ({
       courseId: {
-        displayValue: <a href={`${getConfig().LMS_BASE_URL}/courses/${result.courseId}`} rel="noopener noreferrer" target="_blank">{result.courseId}</a>,
+        displayValue: <a href={`${getConfig().LMS_BASE_URL}/courses/${result.courseId}`} rel="noopener noreferrer" target="_blank" className="word_break">{result.courseId}</a>,
         value: result.courseId,
       },
       courseStart: {

--- a/src/users/index.scss
+++ b/src/users/index.scss
@@ -5,3 +5,7 @@ button.toggle-password {
 button.neg-margin-top{
   margin-top: -7px;
 }
+
+a.word_break {
+word-break:break-word;
+}

--- a/src/users/index.scss
+++ b/src/users/index.scss
@@ -7,5 +7,5 @@ button.neg-margin-top{
 }
 
 a.word_break {
-word-break:break-word;
+  word-break:break-word;
 }


### PR DESCRIPTION
### [PROD-2272](https://openedx.atlassian.net/browse/PROD-2272)

### Description
Fix the table overflowing due to long course id by adding word-break on course_id a tag

#### Before
<img width="1679" alt="Screenshot 2021-01-27 at 6 56 45 PM" src="https://user-images.githubusercontent.com/40599381/106004080-a99e7700-60d4-11eb-932e-2a278c50fa88.png">

#### After
<img width="1679" alt="Screenshot 2021-01-27 at 6 56 55 PM" src="https://user-images.githubusercontent.com/40599381/106004089-ac00d100-60d4-11eb-8c6a-811cdff701c0.png">

