### PR TITLE
add lms user id field in user summary component

### DIFF
--- a/src/users/UserSummary.jsx
+++ b/src/users/UserSummary.jsx
@@ -45,6 +45,10 @@ export default function UserSummary({
       dataValue: userData.username,
     },
     {
+      dataName: 'LMS User ID',
+      dataValue: userData.id,
+    },
+    {
       dataName: 'Email',
       dataValue: userData.email,
     },
@@ -347,6 +351,7 @@ UserSummary.propTypes = {
   userData: PropTypes.shape({
     name: PropTypes.string,
     username: PropTypes.string,
+    id: PropTypes.number,
     email: PropTypes.string,
     isActive: PropTypes.bool,
     country: PropTypes.string,


### PR DESCRIPTION
### [PROD-2281](https://openedx.atlassian.net/browse/PROD-2281)

### Description
Adds lms user id in user summary component. The field was added in user_api in https://github.com/edx/edx-platform/pull/26797

![image](https://user-images.githubusercontent.com/47540683/109813330-069ac900-7c4f-11eb-97a8-4342b377b3d2.png)
