### PR TITLE
api calls tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5798,6 +5798,24 @@
         "lodash": "^4.17.11"
       }
     },
+    "axios-mock-adapter": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.19.0.tgz",
+      "integrity": "sha512-D+0U4LNPr7WroiBDvWilzTMYPYTuZlbo6BI8YHZtj7wYQS8NkARlP9KBt8IWWHTQJ0q/8oZ0ClPBtKCCkx8cQg==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.3",
+        "is-buffer": "^2.0.3"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -12881,6 +12899,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.1.tgz",
       "integrity": "sha512-TqZuVwa/sppcrhUCAYkGBk7w0yxfQQnxq28fjkO53tnK9FQXmdwz2JS5+GjsWQ6RByES1K40nI+yDic5c9/aAQ==",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
       "dev": true
     },
     "is-callable": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@edx/frontend-build": "^5.5.1",
+    "axios-mock-adapter": "^1.19.0",
     "check-prop-types": "1.1.2",
     "codecov": "3.8.1",
     "enzyme": "3.11.0",

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -2,8 +2,27 @@ import 'babel-polyfill';
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import checkPropTypes from 'check-prop-types';
+import { initialize, mergeConfig } from '@edx/frontend-platform';
+import { MockAuthService } from '@edx/frontend-platform/auth';
 
 Enzyme.configure({ adapter: new Adapter() });
+
+initialize({
+  handlers: {
+    config: () => {
+      mergeConfig({
+        authenticatedUser: {
+          userId: 'abc123',
+          username: 'Mock User',
+          roles: [],
+          administrator: false,
+        },
+      });
+    },
+  },
+  messages: [],
+  authService: MockAuthService,
+});
 
 // eslint-disable-next-line import/prefer-default-export
 export function checkProps(component, expectedProps) {

--- a/src/users/data/api.js
+++ b/src/users/data/api.js
@@ -314,7 +314,7 @@ export async function postEnrollmentChange({
           code: null,
           dismissible: true,
           text:
-            'There was an error submitting this entitlement. Check the JavaScript console for detailed errors.',
+            'There was an error submitting this enrollment. Check the JavaScript console for detailed errors.',
           type: 'danger',
           topic: 'enrollments',
         },

--- a/src/users/data/api.test.js
+++ b/src/users/data/api.test.js
@@ -4,7 +4,6 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 import enrollmentsData from './test/enrollments';
 import * as api from './api';
-import { del } from 'request';
 
 describe('API', () => {
   const testUsername = 'username';

--- a/src/users/data/api.test.js
+++ b/src/users/data/api.test.js
@@ -1,0 +1,40 @@
+import MockAdapter from 'axios-mock-adapter';
+import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+import * as api from './api';
+
+describe('API', () => {
+  const testUsername = 'username';
+  let mockAdapter;
+
+  beforeEach(() => {
+    mockAdapter = new MockAdapter(getAuthenticatedHttpClient());
+  });
+
+  afterEach(() => {
+    mockAdapter.reset();
+  });
+
+  describe('SSO', () => {
+    const ssoRecordsApiUrl = `${getConfig().LMS_BASE_URL}/support/sso_records/${testUsername}`;
+
+    it('No SSO data', async () => {
+      mockAdapter.onGet(ssoRecordsApiUrl).reply(200, []);
+      const response = await api.getSsoRecords(testUsername);
+      expect(response).toEqual([]);
+    });
+
+    it('Valid SSO data', async () => {
+      const expectedData = [{
+        provider: 'edX',
+        uid: 'uid',
+        modified: null,
+        extraData: '{}',
+      }];
+      mockAdapter.onGet(ssoRecordsApiUrl).reply(200, expectedData);
+      const response = await api.getSsoRecords(testUsername);
+      expect(response).toEqual(expectedData);
+    });
+  });
+});

--- a/src/users/data/api.test.js
+++ b/src/users/data/api.test.js
@@ -2,7 +2,9 @@ import MockAdapter from 'axios-mock-adapter';
 import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
+import enrollmentsData from './test/enrollments';
 import * as api from './api';
+import { del } from 'request';
 
 describe('API', () => {
   const testUsername = 'username';
@@ -16,24 +18,47 @@ describe('API', () => {
     mockAdapter.reset();
   });
 
-  describe('SSO', () => {
+  describe('SSO Records Fetch', () => {
     const ssoRecordsApiUrl = `${getConfig().LMS_BASE_URL}/support/sso_records/${testUsername}`;
 
-    it('No SSO data', async () => {
+    it('No SSO data is Returned', async () => {
       mockAdapter.onGet(ssoRecordsApiUrl).reply(200, []);
       const response = await api.getSsoRecords(testUsername);
       expect(response).toEqual([]);
     });
 
-    it('Valid SSO data', async () => {
-      const expectedData = [{
-        provider: 'edX',
-        uid: 'uid',
-        modified: null,
-        extraData: '{}',
-      }];
-      mockAdapter.onGet(ssoRecordsApiUrl).reply(200, expectedData);
+    it('Valid SSO data is Returned', async () => {
+      const apiResponseData = [
+        {
+          provider: 'edX',
+          uid: 'uid',
+          modified: null,
+          extraData: '{}',
+        },
+        {
+          provider: 'Google',
+          uid: 'gid',
+          modified: null,
+          extraData: '{"auth": "sso"}',
+        }];
+      const expectedData = apiResponseData.map(item => ({
+        ...item,
+        extraData: JSON.parse(item.extraData),
+      }));
+      mockAdapter.onGet(ssoRecordsApiUrl).reply(200, apiResponseData);
       const response = await api.getSsoRecords(testUsername);
+      expect(response).toEqual(expectedData);
+    });
+  });
+
+  describe('Enrollments Fetch', () => {
+    it('Enrollments Response', async () => {
+      const enrollmentsApiUrl = `${getConfig().LMS_BASE_URL}/support/enrollment/${testUsername}`;
+      mockAdapter.onGet(enrollmentsApiUrl).reply(200, enrollmentsData);
+      const expectedData = { ...enrollmentsData };
+      delete expectedData.changeHandler;
+
+      const response = await api.getEnrollments(testUsername);
       expect(response).toEqual(expectedData);
     });
   });

--- a/src/users/data/api.test.js
+++ b/src/users/data/api.test.js
@@ -479,5 +479,46 @@ describe('API', () => {
         expect(response).toEqual(expectedData);
       });
     });
+
+    describe('Post Enrollment Change', () => {
+      const apiCallData = {
+        user: testUsername,
+        courseID: 'course-v1:testX',
+        oldMode: 'audit',
+        newMode: 'verified',
+        reason: 'test mode change',
+      };
+
+      const requestData = {
+        course_id: 'course-v1:testX',
+        new_mode: 'verified',
+        old_mode: 'audit',
+        reason: 'test mode change',
+      };
+
+      it('Unsuccessful enrollment change', async () => {
+        const expectedError = {
+          code: null,
+          dismissible: true,
+          text:
+            'There was an error submitting this enrollment. Check the JavaScript console for detailed errors.',
+          type: 'danger',
+          topic: 'enrollments',
+        };
+        mockAdapter.onPost(enrollmentsApiUrl, requestData).reply(() => throwError(400, ''));
+        const response = await api.postEnrollmentChange({ ...apiCallData });
+        expect(...response.errors).toEqual(expectedError);
+      });
+
+      it('Successful enrollment change', async () => {
+        const expectedSuccessResponse = {
+          topic: 'enrollments',
+          message: 'enrollment mode changed',
+        };
+        mockAdapter.onPost(enrollmentsApiUrl, requestData).reply(200, expectedSuccessResponse);
+        const response = await api.postEnrollmentChange({ ...apiCallData });
+        expect(response).toEqual(expectedSuccessResponse);
+      });
+    });
   });
 });

--- a/src/users/data/api.test.js
+++ b/src/users/data/api.test.js
@@ -6,8 +6,18 @@ import enrollmentsData from './test/enrollments';
 import * as api from './api';
 
 describe('API', () => {
+  const testEmail = 'email@example.com';
   const testUsername = 'username';
   let mockAdapter;
+
+  const throwError = (errorCode, dataString) => {
+    const error = new Error();
+    error.customAttributes = {
+      httpErrorStatus: errorCode,
+      httpErrorResponseData: JSON.stringify(dataString),
+    };
+    throw error;
+  };
 
   beforeEach(() => {
     mockAdapter = new MockAdapter(getAuthenticatedHttpClient());
@@ -59,6 +69,45 @@ describe('API', () => {
 
       const response = await api.getEnrollments(testUsername);
       expect(response).toEqual(expectedData);
+    });
+  });
+
+  describe('User Password Status Fetch', () => {
+    it('Password Status Data', async () => {
+      const apiUrl = `${getConfig().LMS_BASE_URL}/support/manage_user/${testUsername}`;
+      const expectedData = {
+        username: testUsername,
+        date_joined: Date().toLocaleString(),
+        is_active: true,
+        status: 'Usable',
+        password_toggle_history: [],
+        email: testEmail,
+      };
+      mockAdapter.onGet(apiUrl).reply(200, expectedData);
+
+      const response = await api.getUserPasswordStatus(testUsername);
+      expect(response).toEqual(expectedData);
+    });
+  });
+
+  describe('User Verification Details Fetch', () => {
+    const defaultResponse = {
+      sso_verification: [],
+      ss_photo_verification: [],
+      manual_verification: [],
+    };
+    const verificationApiUrl = `${getConfig().LMS_BASE_URL}/api/user/v1/accounts/${testUsername}/verifications/`;
+
+    it('default response is returned if error is raised', async () => {
+      mockAdapter.onGet(verificationApiUrl).reply(() => throwError(500, ''));
+      const response = await api.getUserVerificationDetail(testUsername);
+      expect(response).toEqual(defaultResponse);
+    });
+
+    it('default response is returned if 404 is raised', async () => {
+      mockAdapter.onGet(verificationApiUrl).reply(() => throwError(404, ''));
+      const response = await api.getUserVerificationDetail(testUsername);
+      expect(response).toEqual(defaultResponse);
     });
   });
 });

--- a/src/users/data/test/enrollments.js
+++ b/src/users/data/test/enrollments.js
@@ -1,0 +1,46 @@
+const enrollmentsData = {
+  data: [{
+    courseId: 'course-v1:testX+test123+2030',
+    courseStart: Date().toLocaleString(),
+    verifiedUpgradeDeadline: Date().toLocaleString(),
+    courseEnd: Date().toLocaleString(),
+    created: Date().toLocaleString(),
+    courseModes: [
+      {
+        slug: 'verified',
+      },
+    ],
+    isActive: true,
+    mode: 'audit',
+    manualEnrollment: {
+      reason: 'Test Enrollment',
+      enrolledBy: 'edX',
+      timestamp: Date().toLocaleString(),
+    },
+  },
+  {
+    courseId: 'course-v1:testX+test123+2040',
+    courseStart: Date().toLocaleString(),
+    verifiedUpgradeDeadline: Date().toLocaleString(),
+    courseEnd: Date().toLocaleString(),
+    created: Date().toLocaleString(),
+    isActive: false,
+    mode: 'audit',
+    courseModes: [
+      {
+        slug: 'verified',
+      },
+    ],
+    manualEnrollment: {
+      reason: 'Test Enrollment 2',
+      enrolledBy: 'edX',
+      timestamp: Date().toLocaleString(),
+    },
+  },
+  ],
+  user: 'edX',
+  changeHandler: jest.fn(() => {}),
+  expanded: true,
+};
+
+export default enrollmentsData;


### PR DESCRIPTION
### [PROD-2177](https://openedx.atlassian.net/browse/PROD-2177)

### Description
Adds the unit tests for API calls methods in support tools. A new dependency, [axios-mock-adapter](https://www.npmjs.com/package/axios-mock-adapter), has been added to mock the api calls and responses. To mock the auth user, [MockAuthService](https://github.com/edx/frontend-platform/blob/master/src/auth/MockAuthService.js) from edx/frontend-platform has been configured. This mock service allows to add an authenticated user and then mock the API calls made via the authenticated user.
