### PR TITLE
Add Detail button to show Support Details for each Entitlement

### DIFF
--- a/src/users/data/test/entitlements.js
+++ b/src/users/data/test/entitlements.js
@@ -14,7 +14,15 @@ const entitlementsData = {
         supportDetails: [{
           supportUser: 'admin',
           action: 'CREATE',
+          actionCreated: Date().toLocaleString(),
           comments: 'creating entitlement',
+          unenrolledRun: null,
+        },
+        {
+          supportUser: 'admin',
+          action: 'EXPIRE',
+          actionCreated: Date().toLocaleString(),
+          comments: 'expiring entitlement',
           unenrolledRun: null,
         },
         ],

--- a/src/users/entitlements/Entitlements.test.jsx
+++ b/src/users/entitlements/Entitlements.test.jsx
@@ -48,6 +48,30 @@ describe('Entitlements Listing', () => {
     expect(collapsible.text()).toEqual('Entitlements (0)');
   });
 
+  it('Support Details data', () => {
+    wrapper = mount(<EntitlementsPageWrapper {...entitlementsData} />);
+    const tableRowsLengths = [2, 0];
+
+    const tableData = wrapper.find('table.table');
+    tableData.find('tbody tr').forEach((row, i) => {
+      const detailButton = row.find('button#details');
+      expect(detailButton.text()).toEqual('Details');
+      let supportDetailsModal = wrapper.find('Modal#support-details');
+      expect(supportDetailsModal.prop('open')).toEqual(false);
+      detailButton.simulate('click');
+
+      supportDetailsModal = wrapper.find('Modal#support-details');
+      expect(supportDetailsModal.prop('open')).toEqual(true);
+      expect(supportDetailsModal.prop('title')).toEqual('Entitlement Support Details');
+      expect(supportDetailsModal.find('table thead tr th')).toHaveLength(5);
+      expect(supportDetailsModal.find('table tbody tr')).toHaveLength(tableRowsLengths[i]);
+      supportDetailsModal.find('button.btn-link').simulate('click');
+
+      supportDetailsModal = wrapper.find('Modal#support-details');
+      expect(supportDetailsModal.prop('open')).toEqual(false);
+    });
+  });
+
   describe('Expire and Reissue entitlement buttons', () => {
     describe('Expire Entitlement button', () => {
       it('Disabled Expire entitlement button', () => {
@@ -98,7 +122,7 @@ describe('Entitlements Listing', () => {
         const tableData = wrapper.find('table.table');
 
         tableData.find('tbody tr').forEach(row => {
-          const reissueButton = row.find('button.btn-outline-primary').last();
+          const reissueButton = row.find('button#reissue').last();
           expect(reissueButton.text()).toEqual('Reissue');
           expect(reissueButton.prop('disabled')).toBeTruthy();
         });


### PR DESCRIPTION
[PROD-2277](https://openedx.atlassian.net/browse/PROD-2277)

A button `Detail` has been added in each row of Entitlement:
<img width="1401" alt="Screenshot 2021-03-31 at 7 36 41 PM" src="https://user-images.githubusercontent.com/52413434/113164993-0e07bf00-925b-11eb-9be7-0b016a5cd222.png">

Upon clicking the Detail Button, the following modal will be shown containing all the support details for the respective entitlement:
![image](https://user-images.githubusercontent.com/52413434/113165187-2bd52400-925b-11eb-94e2-38b73ad86e26.png)
Note: The modal is slidable so this screenshot may not be able to show all the fields.
