### PR TITLE
Add Reset Password Feature

### DIFF
--- a/src/users/UserSummary.jsx
+++ b/src/users/UserSummary.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Modal, Button, Input } from '@edx/paragon';
 
-import { postTogglePasswordStatus } from './data/api';
+import { postTogglePasswordStatus, postResetPassword } from './data/api';
 import Table from '../Table';
 import formatDate from '../dates/formatDate';
 
@@ -16,6 +16,7 @@ export default function UserSummary({
   const [idvModalIsOpen, setIdvModalIsOpen] = useState(false);
   const [disableUserModalIsOpen, setDisableUserModalIsOpen] = useState(false);
   const [disableHistoryModalIsOpen, setDisableHistoryModalIsOpen] = useState(false);
+  const [resetPasswordModalIsOpen, setResetPasswordModalIsOpen] = useState(false);
   const [comment, setComment] = useState('');
   const [userPasswordHistoryData, setUserPasswordHistoryData] = useState([]);
   const [extraSsoDataTitle, setSsoExtraDataTitle] = useState('');
@@ -32,6 +33,11 @@ export default function UserSummary({
 
   const togglePasswordStatus = () => {
     postTogglePasswordStatus(userData.username, comment);
+    changeHandler();
+  };
+
+  const resetPassword = () => {
+    postResetPassword(userData.email);
     changeHandler();
   };
 
@@ -248,19 +254,25 @@ export default function UserSummary({
             {userToggleVisible && (
               <div>
                 <Button
-                  className="toggle-password"
+                  id="toggle-password"
                   variant={`${userData.passwordStatus.status === PASSWORD_STATUS.USABLE ? 'danger' : 'primary'}`}
                   onClick={() => setDisableUserModalIsOpen(true)}
                 >
                   {userData.passwordStatus.status === PASSWORD_STATUS.USABLE ? 'Disable User' : 'Enable User'}
                 </Button>
+                <Button
+                  id="reset-password"
+                  variant="btn btn-danger ml-1"
+                  onClick={() => setResetPasswordModalIsOpen(true)}
+                >Reset Password
+                </Button>
                 {userData.passwordStatus.passwordToggleHistory.length > 0 && (
                   <Button
-                    variant="outline-primary"
-                    className="ml-1"
+                    id="toggle-password-history"
+                    variant="outline-primary ml-1"
                     onClick={() => openHistoryModel()}
                   >
-                    Show history
+                    Show History
                   </Button>
                 )}
               </div>
@@ -345,6 +357,29 @@ export default function UserSummary({
                 value={comment}
                 onChange={(event) => setComment(event.target.value)}
               />
+            </div>
+          )}
+        />
+        <Modal
+          open={resetPasswordModalIsOpen}
+          id="user-account-reset-password"
+          buttons={[
+            <Button
+              variant="danger"
+              onClick={resetPassword}
+            >
+              Confirm
+            </Button>,
+          ]}
+          onClose={() => setResetPasswordModalIsOpen(false)}
+          title="Reset Password"
+          body={(
+            <div>
+              { /* eslint-disable-next-line jsx-a11y/label-has-associated-control */ }
+              <label>
+                We will send a message with password recovery instructions to this email address {userData.email}.
+                Do you wish to proceed?
+              </label>
             </div>
           )}
         />

--- a/src/users/UserSummary.test.jsx
+++ b/src/users/UserSummary.test.jsx
@@ -51,14 +51,14 @@ describe('User Summary Component Tests', () => {
 
   describe('Disable User Button', () => {
     it('Disable User button for active user', () => {
-      const passwordActionButton = wrapper.find('.toggle-password').hostNodes();
+      const passwordActionButton = wrapper.find('#toggle-password').hostNodes();
       expect(passwordActionButton.text()).toEqual('Disable User');
       expect(passwordActionButton.disabled).toBeFalsy();
     });
 
     it('Disable User Modal', () => {
       const mockApiCall = jest.spyOn(api, 'postTogglePasswordStatus').mockImplementation(() => {});
-      const passwordActionButton = wrapper.find('.toggle-password').hostNodes();
+      const passwordActionButton = wrapper.find('#toggle-password').hostNodes();
       let disableDialogModal = wrapper.find('Modal#user-account-status-toggle');
 
       expect(disableDialogModal.prop('open')).toEqual(false);
@@ -89,14 +89,14 @@ describe('User Summary Component Tests', () => {
     });
 
     it('Enable User button for disabled user', () => {
-      const passwordActionButton = wrapper.find('.toggle-password').hostNodes();
+      const passwordActionButton = wrapper.find('#toggle-password').hostNodes();
       expect(passwordActionButton.text()).toEqual('Enable User');
       expect(passwordActionButton.disabled).toBeFalsy();
     });
 
     it('Enable User Modal', () => {
       const mockApiCall = jest.spyOn(api, 'postTogglePasswordStatus').mockImplementation(() => {});
-      const passwordActionButton = wrapper.find('.toggle-password').hostNodes();
+      const passwordActionButton = wrapper.find('#toggle-password').hostNodes();
       let enableUserModal = wrapper.find('Modal#user-account-status-toggle');
 
       expect(enableUserModal.prop('open')).toEqual(false);
@@ -112,6 +112,37 @@ describe('User Summary Component Tests', () => {
       enableUserModal.find('button.btn-danger').hostNodes().simulate('click');
 
       expect(UserSummaryData.changeHandler).toHaveBeenCalled();
+      mockApiCall.mockRestore();
+    });
+  });
+
+  describe('Reset Password Button', () => {
+    it('Reset Password button for a User', () => {
+      const passwordResetButton = wrapper.find('#reset-password').hostNodes();
+      expect(passwordResetButton.text()).toEqual('Reset Password');
+    });
+
+    it('Reset Password Modal', () => {
+      const mockApiCall = jest.spyOn(api, 'postResetPassword').mockImplementation(() => {});
+      const passwordResetButton = wrapper.find('#reset-password').hostNodes();
+      let resetPasswordModal = wrapper.find('Modal#user-account-reset-password');
+
+      expect(resetPasswordModal.prop('open')).toEqual(false);
+      expect(passwordResetButton.text()).toEqual('Reset Password');
+
+      passwordResetButton.simulate('click');
+      resetPasswordModal = wrapper.find('Modal#user-account-reset-password');
+
+      expect(resetPasswordModal.prop('open')).toEqual(true);
+      expect(resetPasswordModal.prop('title')).toEqual('Reset Password');
+      const confirmLabel = resetPasswordModal.find('label');
+      expect(confirmLabel.text()).toContain('Do you wish to proceed?');
+      resetPasswordModal.find('button.btn-danger').hostNodes().simulate('click');
+
+      expect(UserSummaryData.changeHandler).toHaveBeenCalled();
+      resetPasswordModal.find('button.btn-link').simulate('click');
+      resetPasswordModal = wrapper.find('Modal#user-account-reset-password');
+      expect(resetPasswordModal.prop('open')).toEqual(false);
       mockApiCall.mockRestore();
     });
   });
@@ -137,11 +168,11 @@ describe('User Summary Component Tests', () => {
       wrapper = mount(<UserSummary {...UserSummaryData} userData={userData} />);
     });
     it('Password History Modal', () => {
-      const passwordHistoryButton = wrapper.find('button.ml-1');
+      const passwordHistoryButton = wrapper.find('button#toggle-password-history');
       let historyModal = wrapper.find('Modal#password-history');
 
       expect(historyModal.prop('open')).toEqual(false);
-      expect(passwordHistoryButton.text()).toEqual('Show history');
+      expect(passwordHistoryButton.text()).toEqual('Show History');
       expect(passwordHistoryButton.disabled).toBeFalsy();
 
       passwordHistoryButton.simulate('click');

--- a/src/users/data/api.js
+++ b/src/users/data/api.js
@@ -332,3 +332,13 @@ export async function postTogglePasswordStatus(user, comment) {
   );
   return data;
 }
+
+export async function postResetPassword(email) {
+  const { data } = await getAuthenticatedHttpClient().post(
+    `${getConfig().LMS_BASE_URL}/account/password`,
+    {
+      email,
+    },
+  );
+  return data;
+}

--- a/src/users/data/api.test.js
+++ b/src/users/data/api.test.js
@@ -304,6 +304,17 @@ describe('API', () => {
     });
   });
 
+  describe('Reset Password', () => {
+    const resetPasswordApiUrl = `${getConfig().LMS_BASE_URL}/account/password`;
+
+    it('Reset Password Response', async () => {
+      const expectedResponse = { };
+      mockAdapter.onPost(resetPasswordApiUrl, { email: testEmail }).reply(200, expectedResponse);
+      const response = await api.postResetPassword(testEmail);
+      expect(response).toEqual(expectedResponse);
+    });
+  });
+
   describe('Get Course Data', () => {
     const courseUUID = 'uuid';
 


### PR DESCRIPTION
A new `Reset Password` button has been added in Account section:
![image](https://user-images.githubusercontent.com/52413434/113685962-3589dc00-96e0-11eb-86d8-3a726094296d.png)

Upon clicking the button, a confirmation modal will be shown. Clicking the `Confirm` button will then send an email to the respective user:
![image](https://user-images.githubusercontent.com/52413434/113686157-65d17a80-96e0-11eb-819a-ec4f547254f1.png)
