### PR TITLE
Fix Reset Password button

### DIFF
--- a/src/users/data/api.js
+++ b/src/users/data/api.js
@@ -335,10 +335,7 @@ export async function postTogglePasswordStatus(user, comment) {
 
 export async function postResetPassword(email) {
   const { data } = await getAuthenticatedHttpClient().post(
-    `${getConfig().LMS_BASE_URL}/account/password`,
-    {
-      email,
-    },
+    `${getConfig().LMS_BASE_URL}/account/password`, `email_from_support_tools=${email}`,
   );
   return data;
 }

--- a/src/users/data/api.test.js
+++ b/src/users/data/api.test.js
@@ -309,7 +309,7 @@ describe('API', () => {
 
     it('Reset Password Response', async () => {
       const expectedResponse = { };
-      mockAdapter.onPost(resetPasswordApiUrl, { email: testEmail }).reply(200, expectedResponse);
+      mockAdapter.onPost(resetPasswordApiUrl, `email_from_support_tools=${testEmail}`).reply(200, expectedResponse);
       const response = await api.postResetPassword(testEmail);
       expect(response).toEqual(expectedResponse);
     });


### PR DESCRIPTION
[PROD-2337](https://openedx.atlassian.net/browse/PROD-2337)
Changed the api call to match the form data on the backend. The reset password view uses request.POST to extract data from the body which must be sent in a different way.