### PR TITLE
feat: course enrollment listing updates

### DIFF
--- a/src/users/data/test/enrollments.js
+++ b/src/users/data/test/enrollments.js
@@ -2,6 +2,8 @@ const enrollmentsData = {
   data: [{
     courseId: 'course-v1:testX+test123+2030',
     courseStart: Date().toLocaleString(),
+    courseName: 'Test Course 1',
+    pacingType: 'Self Paced',
     verifiedUpgradeDeadline: Date().toLocaleString(),
     courseEnd: Date().toLocaleString(),
     created: Date().toLocaleString(),
@@ -21,6 +23,8 @@ const enrollmentsData = {
   {
     courseId: 'course-v1:testX+test123+2040',
     courseStart: Date().toLocaleString(),
+    courseName: 'Test Course 2',
+    pacingType: 'Instructor Paced',
     verifiedUpgradeDeadline: Date().toLocaleString(),
     courseEnd: Date().toLocaleString(),
     created: Date().toLocaleString(),

--- a/src/users/enrollments/EnrollmentExtra.jsx
+++ b/src/users/enrollments/EnrollmentExtra.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-indent */
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -7,40 +6,40 @@ export default function EnrollmentExtra({
 }) {
   return (
     <section className="card mb-3">
-        <div className="m-3">
-          <h4>Course Title: {enrollmentExtraData.courseName}</h4>
-      <table className="table">
-        <tbody>
+      <div className="m-3">
+        <h4>Course Title: {enrollmentExtraData.courseName}</h4>
+        <table className="table">
+          <tbody>
 
-          <tr>
-            <td>Last Modified</td>
-            <td>{enrollmentExtraData.lastModified}</td>
-          </tr>
+            <tr>
+              <td>Last Modified</td>
+              <td>{enrollmentExtraData.lastModified}</td>
+            </tr>
 
-          <tr>
-            <td>Last Modified By</td>
-            <td>{enrollmentExtraData.lastModifiedBy}</td>
-          </tr>
+            <tr>
+              <td>Last Modified By</td>
+              <td>{enrollmentExtraData.lastModifiedBy}</td>
+            </tr>
 
-          <tr>
-            <td>Reason</td>
-            <td>{enrollmentExtraData.reason}</td>
-          </tr>
-        </tbody>
+            <tr>
+              <td>Reason</td>
+              <td>{enrollmentExtraData.reason}</td>
+            </tr>
+          </tbody>
 
-      </table>
+        </table>
 
-      <div className="d-flex flex-row justify-content-end mb-2">
-        <button
-          onClick={closeHandler}
-          className="btn btn-outline-secondary"
-          type="button"
-          ref={forwardedRef}
-        >
+        <div className="d-flex flex-row justify-content-end mb-2">
+          <button
+            onClick={closeHandler}
+            className="btn btn-outline-secondary"
+            type="button"
+            ref={forwardedRef}
+          >
             Hide
-        </button>
-      </div>
+          </button>
         </div>
+      </div>
     </section>
   );
 }

--- a/src/users/enrollments/EnrollmentExtra.jsx
+++ b/src/users/enrollments/EnrollmentExtra.jsx
@@ -1,0 +1,63 @@
+/* eslint-disable react/jsx-indent */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function EnrollmentExtra({
+  enrollmentExtraData, closeHandler, forwardedRef,
+}) {
+  return (
+    <section className="card mb-3">
+        <div className="m-3">
+          <h4>Course Title: {enrollmentExtraData.courseName}</h4>
+      <table className="table">
+        <tbody>
+
+          <tr>
+            <td>Last Modified</td>
+            <td>{enrollmentExtraData.lastModified}</td>
+          </tr>
+
+          <tr>
+            <td>Last Modified By</td>
+            <td>{enrollmentExtraData.lastModifiedBy}</td>
+          </tr>
+
+          <tr>
+            <td>Reason</td>
+            <td>{enrollmentExtraData.reason}</td>
+          </tr>
+        </tbody>
+
+      </table>
+
+      <div className="d-flex flex-row justify-content-end mb-2">
+        <button
+          onClick={closeHandler}
+          className="btn btn-outline-secondary"
+          type="button"
+          ref={forwardedRef}
+        >
+            Hide
+        </button>
+      </div>
+        </div>
+    </section>
+  );
+}
+
+EnrollmentExtra.propTypes = {
+  enrollmentExtraData: PropTypes.shape({
+    courseName: PropTypes.string,
+    lastModified: PropTypes.string,
+    lastModifiedBy: PropTypes.string,
+    reason: PropTypes.string,
+  }),
+  closeHandler: PropTypes.func,
+  forwardedRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+};
+
+EnrollmentExtra.defaultProps = {
+  enrollmentExtraData: null,
+  closeHandler: null,
+  forwardedRef: null,
+};

--- a/src/users/enrollments/EnrollmentExtra.test.jsx
+++ b/src/users/enrollments/EnrollmentExtra.test.jsx
@@ -1,0 +1,47 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import EnrollmentExtra from './EnrollmentExtra';
+
+const props = {
+  enrollmentExtraData: {
+    lastModified: new Date(2021, 0, 1, 0, 0, 0, 0).toLocaleString(),
+    lastModifiedBy: 'edX',
+    reason: 'Test',
+    courseName: 'Test Course',
+  },
+  closeHandler: jest.fn(() => {}),
+};
+
+describe('Enrollment Extra Data', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(<EnrollmentExtra {...props} />);
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('Default Data Render', () => {
+    const dataRows = wrapper.find('table.table').find('tr');
+    expect(dataRows).toHaveLength(3);
+
+    const lastModified = dataRows.at(0);
+    const lastModifiedBy = dataRows.at(1);
+    const reason = dataRows.at(2);
+    expect(lastModified.text()).toEqual(expect.stringContaining('1/1/2021, 12:00:00 AM'));
+    expect(lastModifiedBy.text()).toEqual(expect.stringContaining('edX'));
+    expect(reason.text()).toEqual(expect.stringContaining('Test'));
+
+    expect(wrapper.find('h4').text()).toEqual('Course Title: Test Course');
+  });
+
+  it('Hide Button Render', () => {
+    const hideButton = wrapper.find('button.btn-outline-secondary');
+    expect(hideButton.text()).toEqual('Hide');
+    hideButton.simulate('click');
+    expect(props.closeHandler).toHaveBeenCalled();
+  });
+});

--- a/src/users/enrollments/Enrollments.jsx
+++ b/src/users/enrollments/Enrollments.jsx
@@ -69,7 +69,7 @@ export default function Enrollments({
         displayValue: formatDate(result.created),
         value: result.created,
       },
-      pacing: {
+      pacingType: {
         value: result.pacingType,
       },
       active: {
@@ -144,7 +144,7 @@ export default function Enrollments({
       label: 'Enrollment Date', key: 'created', columnSortable: true, onSort: () => setSort('created'), width: 'col-3',
     },
     {
-      label: 'Pacing Type', key: 'pacing', columnSortable: true, onSort: () => setSort('pacing'), width: 'col-3',
+      label: 'Pacing Type', key: 'pacingType', columnSortable: true, onSort: () => setSort('pacing'), width: 'col-3',
     },
     {
       label: 'Mode', key: 'mode', columnSortable: true, onSort: () => setSort('mode'), width: 'col-3',

--- a/src/users/enrollments/Enrollments.test.jsx
+++ b/src/users/enrollments/Enrollments.test.jsx
@@ -34,7 +34,7 @@ describe('Course Enrollments Listing', () => {
     const dataTable = wrapper.find('table.table');
     dataTable.find('tbody tr').forEach(row => {
       const courseId = row.find('a').text();
-      row.find('button.btn-outline-primary').simulate('click');
+      row.find('button#enrollment-change').simulate('click');
       const enrollmentForm = wrapper.find('EnrollmentForm');
       expect(enrollmentForm.html()).toEqual(expect.stringContaining(courseId));
       enrollmentForm.find('button.btn-outline-secondary').simulate('click');

--- a/src/users/enrollments/Enrollments.test.jsx
+++ b/src/users/enrollments/Enrollments.test.jsx
@@ -42,6 +42,18 @@ describe('Course Enrollments Listing', () => {
     });
   });
 
+  it('Enrollment extra data is rendered for individual enrollment', () => {
+    const dataTable = wrapper.find('table.table');
+    dataTable.find('tbody tr').forEach(row => {
+      const courseName = row.find('td').at(1).text();
+      row.find('button#extra-data').simulate('click');
+      const enrollmentExtra = wrapper.find('EnrollmentExtra');
+      expect(enrollmentExtra.html()).toEqual(expect.stringContaining(courseName));
+      enrollmentExtra.find('button.btn-outline-secondary').simulate('click');
+      expect(wrapper.find('EnrollmentExtra')).toEqual({});
+    });
+  });
+
   it('Sorting Columns Button Enabled by default', () => {
     const dataTable = wrapper.find('table.table');
     const tableHeaders = dataTable.find('thead tr th');

--- a/src/users/index.scss
+++ b/src/users/index.scss
@@ -2,10 +2,10 @@ button.toggle-password {
   max-width: 150px;
 }
 
-button.neg-margin-top{
+button.neg-margin-top {
   margin-top: -7px;
 }
 
 a.word_break {
-  word-break:break-word;
+  word-break: break-word;
 }


### PR DESCRIPTION
### [PROD-2334](https://openedx.atlassian.net/browse/PROD-2334)

### Description
Adds the course title and pacing information on the enrollment listing. Three existing fields, Modified, Modified By, and Reason have been moved, A new button, Show Extra, has been added under actions. Clicking the button opens a new section that has the above-mentioned 3 fields. This relocation has been done in order to avoid getting the table bulky and hard to read.

<img width="1534" alt="Screenshot 2021-05-04 at 4 14 38 PM" src="https://user-images.githubusercontent.com/40599381/116997631-7c2a2080-acf6-11eb-963d-141543dd92f3.png">

------------------

<img width="1534" alt="Screenshot 2021-05-04 at 4 14 54 PM" src="https://user-images.githubusercontent.com/40599381/116997644-80563e00-acf6-11eb-8b04-f78913006435.png">



---------------------

<img width="1534" alt="Screenshot 2021-05-04 at 4 38 27 PM" src="https://user-images.githubusercontent.com/40599381/116998135-33269c00-acf7-11eb-88de-da01b497efec.png">
