### PR TITLE
feat: add view certificate button

### DIFF
--- a/src/users/data/api.js
+++ b/src/users/data/api.js
@@ -443,3 +443,74 @@ export async function postResetPassword(email) {
   );
   return data;
 }
+
+export async function getCertificate(username, courseKey) {
+  try {
+    const { data } = await getAuthenticatedHttpClient().get(
+      AppUrls.getCertificateUrl(username, courseKey),
+    );
+    return Array.isArray(data) && data.length > 0 ? data[0] : data;
+  } catch (error) {
+    return {
+      errors: [
+        {
+          code: null,
+          dismissible: true,
+          text: error.message,
+          type: 'danger',
+          topic: 'certificates',
+        },
+      ],
+    };
+  }
+}
+
+export async function generateCertificate(username, courseKey) {
+  const formData = new FormData();
+  formData.append('username', username);
+  formData.append('course_key', courseKey);
+  try {
+    const { data } = await getAuthenticatedHttpClient().post(
+      AppUrls.generateCertificateUrl(),
+      formData,
+    );
+    return data;
+  } catch (error) {
+    return {
+      errors: [
+        {
+          code: null,
+          dismissible: true,
+          text: error.message,
+          type: 'danger',
+          topic: 'certificates',
+        },
+      ],
+    };
+  }
+}
+
+export async function regenerateCertificate(username, courseKey) {
+  const formData = new FormData();
+  formData.append('username', username);
+  formData.append('course_key', courseKey);
+  try {
+    const { data } = await getAuthenticatedHttpClient().post(
+      AppUrls.regenerateCertificateUrl(),
+      formData,
+    );
+    return data;
+  } catch (error) {
+    return {
+      errors: [
+        {
+          code: null,
+          dismissible: true,
+          text: error.message,
+          type: 'danger',
+          topic: 'certificates',
+        },
+      ],
+    };
+  }
+}

--- a/src/users/data/api.test.js
+++ b/src/users/data/api.test.js
@@ -5,6 +5,7 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { enrollmentsData } from './test/enrollments';
 import { downloadableCertificate } from './test/certificates';
 import * as api from './api';
+import * as urls from './urls';
 
 describe('API', () => {
   const testUsername = 'username';
@@ -19,9 +20,9 @@ describe('API', () => {
   const verificationStatusApiUrl = `${getConfig().LMS_BASE_URL}/api/user/v1/accounts/${testUsername}/verification_status/`;
   const licensesApiUrl = `${getConfig().LICENSE_MANAGER_URL}/api/v1/staff_lookup_licenses/`;
   const onboardingStatusApiUrl = `${getConfig().LMS_BASE_URL}/api/edx_proctoring/v1/user_onboarding/status`;
-  const certificatesUrl = `${getConfig().LMS_BASE_URL}/certificates/search?user=${testUsername}&course_id=${testCourseId}`;
-  const generateCertificateUrl = `${getConfig().LMS_BASE_URL}/certificates/generate`;
-  const regenerateCertificateUrl = `${getConfig().LMS_BASE_URL}/certificates/regenerate`;
+  const certificatesUrl = urls.getCertificateUrl(testUsername, testCourseId);
+  const generateCertificateUrl = urls.generateCertificateUrl();
+  const regenerateCertificateUrl = urls.regenerateCertificateUrl();
 
   let mockAdapter;
 

--- a/src/users/data/api.test.js
+++ b/src/users/data/api.test.js
@@ -3,11 +3,13 @@ import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 import { enrollmentsData } from './test/enrollments';
+import { downloadableCertificate } from './test/certificates';
 import * as api from './api';
 
 describe('API', () => {
   const testUsername = 'username';
   const testEmail = 'email@example.com';
+  const testCourseId = 'course-v1:testX+test123+2030';
   const userAccountApiBaseUrl = `${getConfig().LMS_BASE_URL}/api/user/v1/accounts`;
   const ssoRecordsApiUrl = `${getConfig().LMS_BASE_URL}/support/sso_records/${testUsername}`;
   const enrollmentsApiUrl = `${getConfig().LMS_BASE_URL}/support/enrollment/${testUsername}`;
@@ -17,6 +19,9 @@ describe('API', () => {
   const verificationStatusApiUrl = `${getConfig().LMS_BASE_URL}/api/user/v1/accounts/${testUsername}/verification_status/`;
   const licensesApiUrl = `${getConfig().LICENSE_MANAGER_URL}/api/v1/staff_lookup_licenses/`;
   const onboardingStatusApiUrl = `${getConfig().LMS_BASE_URL}/api/edx_proctoring/v1/user_onboarding/status`;
+  const certificatesUrl = `${getConfig().LMS_BASE_URL}/certificates/search?user=${testUsername}&course_id=${testCourseId}`;
+  const generateCertificateUrl = `${getConfig().LMS_BASE_URL}/certificates/generate`;
+  const regenerateCertificateUrl = `${getConfig().LMS_BASE_URL}/certificates/regenerate`;
 
   let mockAdapter;
 
@@ -30,7 +35,7 @@ describe('API', () => {
   };
 
   beforeEach(() => {
-    mockAdapter = new MockAdapter(getAuthenticatedHttpClient());
+    mockAdapter = new MockAdapter(getAuthenticatedHttpClient(), { onNoMatch: 'throwException' });
   });
 
   afterEach(() => {
@@ -680,6 +685,74 @@ describe('API', () => {
         const response = await api.getLicense(testEmail);
         expect(response).toEqual({ results: [], status: 'Unable to connect to the service' });
       });
+    });
+  });
+
+  describe('Certificate Operations', () => {
+    const successDictResponse = downloadableCertificate;
+    const successListResponse = [successDictResponse];
+    const expectedError = {
+      code: null,
+      dismissible: true,
+      text: '',
+      type: 'danger',
+      topic: 'certificates',
+    };
+
+    test.each([successDictResponse, successListResponse])('Successful Certificate Fetch', async (successResponse) => {
+      mockAdapter.onGet(certificatesUrl).reply(200, successResponse);
+      const response = await api.getCertificate(testUsername, testCourseId);
+      expect(response).toEqual(Array.isArray(successResponse) ? successResponse[0] : successResponse);
+    });
+
+    it('Unsuccessful Certificates fetch', async () => {
+      mockAdapter.onGet(certificatesUrl).reply(() => throwError(400, ''));
+      const response = await api.getCertificate(testUsername, testCourseId);
+      expect(...response.errors).toEqual(expectedError);
+    });
+
+    it('Successful generate Certificate', async () => {
+      /**
+       * No data is added in the post request check because axios-mock-adapter fails
+       * with formData in post request.
+       * See: https://github.com/ctimmerm/axios-mock-adapter/issues/253
+       */
+      mockAdapter.onPost(generateCertificateUrl).reply(200, successDictResponse);
+      const response = await api.generateCertificate(testUsername, testCourseId);
+      expect(response).toEqual(successDictResponse);
+    });
+
+    it('Unsuccessful generate Certificate', async () => {
+      /**
+       * No data is added in the post request check because axios-mock-adapter fails
+       * with formData in post request.
+       * See: https://github.com/ctimmerm/axios-mock-adapter/issues/253
+       */
+      mockAdapter.onPost(generateCertificateUrl).reply(() => throwError(400, ''));
+      const response = await api.generateCertificate(testUsername, testCourseId);
+      expect(...response.errors).toEqual(expectedError);
+    });
+
+    it('Successful regenerate Certificate', async () => {
+      /**
+       * No data is added in the post request check because axios-mock-adapter fails
+       * with formData in post request.
+       * See: https://github.com/ctimmerm/axios-mock-adapter/issues/253
+       */
+      mockAdapter.onPost(regenerateCertificateUrl).reply(200, successDictResponse);
+      const response = await api.regenerateCertificate(testUsername, testCourseId);
+      expect(response).toEqual(successDictResponse);
+    });
+
+    it('Unsuccessful regenerate Certificate', async () => {
+      /**
+       * No data is added in the post request check because axios-mock-adapter fails
+       * with formData in post request.
+       * See: https://github.com/ctimmerm/axios-mock-adapter/issues/253
+       */
+      mockAdapter.onPost(regenerateCertificateUrl).reply(() => throwError(400, ''));
+      const response = await api.regenerateCertificate(testUsername, testCourseId);
+      expect(...response.errors).toEqual(expectedError);
     });
   });
 });

--- a/src/users/data/test/certificates.js
+++ b/src/users/data/test/certificates.js
@@ -1,0 +1,19 @@
+export const downloadableCertificate = {
+  courseKey: 'course-v1:testX+test123+2030',
+  type: 'verified',
+  status: 'passing',
+  grade: '60',
+  modified: new Date('2020/01/01').toLocaleString(),
+  downloadUrl: '/certificates/1234-abcd',
+  regenerate: false,
+};
+
+export const regeneratableCertificate = {
+  courseKey: 'course-v1:testX+test123+2030',
+  type: 'verified',
+  status: 'passing',
+  grade: '60',
+  modified: new Date('2020/01/01').toLocaleString(),
+  downloadUrl: null,
+  regenerate: true,
+};

--- a/src/users/data/urls.js
+++ b/src/users/data/urls.js
@@ -69,3 +69,15 @@ export const getAccountActivationUrl = (activationKey) => `${
 export const getOnboardingStatusUrl = (courseId, username) => `${
   LMS_BASE_URL
 }/api/edx_proctoring/v1/user_onboarding/status?course_id=${encodeURIComponent(courseId)}&username=${encodeURIComponent(username)}`;
+
+export const getCertificateUrl = (username, courseKey) => `${
+  LMS_BASE_URL
+}/certificates/search?user=${username}&course_id=${courseKey}`;
+
+export const generateCertificateUrl = () => `${
+  LMS_BASE_URL
+}/certificates/generate`;
+
+export const regenerateCertificateUrl = () => `${
+  LMS_BASE_URL
+}/certificates/regenerate`;

--- a/src/users/enrollments/Certificates.jsx
+++ b/src/users/enrollments/Certificates.jsx
@@ -1,0 +1,198 @@
+import React, {
+  useContext,
+  useEffect,
+  useState,
+  useRef,
+  useLayoutEffect,
+} from 'react';
+import { camelCaseObject, getConfig } from '@edx/frontend-platform';
+import PropTypes from 'prop-types';
+import { Button } from '@edx/paragon';
+import PageLoading from '../../components/common/PageLoading';
+import { formatDate } from '../../utils';
+import { getCertificate, generateCertificate, regenerateCertificate } from '../data/api';
+import UserMessagesContext from '../../userMessages/UserMessagesContext';
+import AlertList from '../../userMessages/AlertList';
+
+export default function Certificates({
+  username, courseId, closeHandler,
+}) {
+  const { add, clear } = useContext(UserMessagesContext);
+  const [displayCertErrors, setDisplayCertificateErrors] = useState(false);
+  const [certificate, setCertificateData] = useState(undefined);
+  const [status, setStatus] = useState(undefined);
+  const [buttonDisabled, setButtonDisabled] = useState(false);
+  // eslint-disable-next-line no-use-before-define
+  const oldCourseId = usePrevious(courseId);
+  const certificateRef = useRef(null);
+
+  useEffect(() => {
+    if ((certificate === undefined && !displayCertErrors) || (courseId !== oldCourseId)) {
+      getCertificate(username, courseId).then((result) => {
+        const camelCaseResult = camelCaseObject(result);
+        if (camelCaseResult.errors) {
+          clear('certificates');
+          camelCaseResult.errors.forEach(error => add(error));
+          setDisplayCertificateErrors(true);
+        } else {
+          setDisplayCertificateErrors(false);
+          setCertificateData(camelCaseResult);
+        }
+      });
+    }
+  }, [certificate, courseId]);
+
+  useLayoutEffect(() => {
+    if (certificateRef != null) {
+      certificateRef.current.focus();
+    }
+  });
+
+  function usePrevious(value) {
+    const ref = useRef();
+    useEffect(() => {
+      ref.current = value;
+    }, [value]);
+    return ref.current;
+  }
+
+  function renderHideButton() {
+    return (
+      <div className="d-flex flex-row justify-content-end m-2">
+        <Button
+          onClick={closeHandler}
+          ref={certificateRef}
+          variant="outline-secondary"
+          type="button"
+        >
+          Hide
+        </Button>
+      </div>
+    );
+  }
+
+  function postGenerateCertificate() {
+    setButtonDisabled(true);
+    setStatus('Generating New Certificate');
+    generateCertificate(username, certificate.courseKey).then((result) => {
+      if (result.errors) {
+        clear('certificates');
+        result.errors.forEach(error => add(error));
+        setDisplayCertificateErrors(true);
+      } else {
+        setDisplayCertificateErrors(false);
+        setCertificateData(undefined);
+      }
+      setButtonDisabled(false);
+      setStatus(undefined);
+    });
+  }
+
+  function postRegenerateCertificate() {
+    setButtonDisabled(true);
+    setStatus('Regenerating Certificate');
+    regenerateCertificate(username, certificate.courseKey).then((result) => {
+      if (result.errors) {
+        clear('certificates');
+        result.errors.forEach(error => add(error));
+        setDisplayCertificateErrors(true);
+      } else {
+        setDisplayCertificateErrors(false);
+        setCertificateData(undefined);
+      }
+      setButtonDisabled(false);
+      setStatus(undefined);
+    });
+  }
+
+  return (
+    <section className="card mb-3">
+      <>
+        {renderHideButton()}
+      </>
+
+      {!certificate && !displayCertErrors && <PageLoading srMessage="Loading" /> }
+      {displayCertErrors && <AlertList topic="certificates" />}
+
+      {certificate && !displayCertErrors && (
+
+      <div className="m-3">
+        <h2>Course ID: {certificate.courseKey}</h2>
+        {status && (<h3>Status: {status} </h3>)}
+        <table className="table">
+          <tbody>
+
+            <tr>
+              <td><strong>Certificate Type</strong></td>
+              <td>{certificate.type ? certificate.type : 'Not Available'}</td>
+            </tr>
+
+            <tr>
+              <td><strong>Status</strong></td>
+              <td>{certificate.status ? certificate.status : 'Not Available'}</td>
+            </tr>
+
+            <tr>
+              <td><strong>Grade</strong></td>
+              <td>{certificate.grade ? certificate.grade : 'Not Available'}</td>
+            </tr>
+
+            <tr>
+              <td><strong>Last Updated</strong></td>
+              <td>{formatDate(certificate.modified)}</td>
+            </tr>
+
+            <tr>
+              <td><strong>Download URL</strong></td>
+              <td>{certificate.downloadUrl ? <a href={`${getConfig().LMS_BASE_URL}${certificate.downloadUrl}`}>Download</a> : 'Not Available'}</td>
+            </tr>
+
+            <tr>
+              <td><strong>Actions</strong></td>
+              <td>
+                {
+                    certificate.regenerate
+                      ? (
+                        <Button
+                          onClick={postRegenerateCertificate}
+                          id="regenerate-certificate"
+                          variant="danger"
+                          disabled={buttonDisabled}
+                        >
+                          Regenerate
+                        </Button>
+                      )
+                      : (
+                        <Button
+                          onClick={postGenerateCertificate}
+                          variant="danger"
+                          id="generate-certificate"
+                          disabled={buttonDisabled}
+                        >
+                          Generate
+                        </Button>
+                      )
+                }
+
+              </td>
+            </tr>
+          </tbody>
+
+        </table>
+      </div>
+      )}
+    </section>
+  );
+}
+
+Certificates.propTypes = {
+  username: PropTypes.string,
+  courseId: PropTypes.string,
+  closeHandler: PropTypes.func,
+};
+
+Certificates.defaultProps = {
+  username: null,
+  courseId: null,
+  closeHandler: null,
+};

--- a/src/users/enrollments/Certificates.test.jsx
+++ b/src/users/enrollments/Certificates.test.jsx
@@ -1,0 +1,237 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import { waitForComponentToPaint } from '../../setupTest';
+import Certificates from './Certificates';
+import { downloadableCertificate, regeneratableCertificate } from '../data/test/certificates';
+import UserMessagesProvider from '../../userMessages/UserMessagesProvider';
+import * as api from '../data/api';
+
+const CertificateWrapper = (props) => (
+  <UserMessagesProvider>
+    <Certificates {...props} />;
+  </UserMessagesProvider>
+);
+
+describe('Certificate component', () => {
+  let apiMock; let wrapper;
+  const testUser = 'testUser';
+  const testCourseId = 'course-v1:testX+test123+2030';
+
+  const props = {
+    username: testUser,
+    courseId: testCourseId,
+    closeHandler: jest.fn(() => {}),
+  };
+
+  afterEach(() => {
+    apiMock.mockRestore();
+  });
+
+  it('Downloadable Certificate', async () => {
+    apiMock = jest.spyOn(api, 'getCertificate').mockImplementationOnce(() => Promise.resolve(downloadableCertificate));
+    wrapper = mount(<CertificateWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+
+    expect(wrapper.find('h2').html()).toEqual(expect.stringContaining(downloadableCertificate.courseKey));
+    const dataRows = wrapper.find('table.table tbody tr');
+    expect(dataRows.length).toEqual(6);
+
+    // Explictly check each row and verify individual piece of data
+    const certType = dataRows.at(0).find('td');
+    expect(certType.at(0).text()).toEqual('Certificate Type');
+    expect(certType.at(1).text()).toEqual('verified');
+
+    const status = dataRows.at(1).find('td');
+    expect(status.at(0).text()).toEqual('Status');
+    expect(status.at(1).text()).toEqual('passing');
+
+    const grade = dataRows.at(2).find('td');
+    expect(grade.at(0).text()).toEqual('Grade');
+    expect(grade.at(1).text()).toEqual('60');
+
+    const lastUpdated = dataRows.at(3).find('td');
+    expect(lastUpdated.at(0).text()).toEqual('Last Updated');
+    expect(lastUpdated.at(1).text()).toEqual('Jan 1, 2020 12:00 AM');
+
+    const downloadUrl = dataRows.at(4).find('td');
+    expect(downloadUrl.at(0).text()).toEqual('Download URL');
+    expect(downloadUrl.at(1).text()).toEqual('Download');
+    expect(downloadUrl.at(1).find('a').prop('href')).toEqual('http://localhost:18000/certificates/1234-abcd');
+
+    const action = dataRows.at(5).find('td');
+    expect(action.at(0).text()).toEqual('Actions');
+    expect(action.find('button#generate-certificate').length).toEqual(1);
+  });
+
+  it('Regeneratable Certificate', async () => {
+    apiMock = jest.spyOn(api, 'getCertificate').mockImplementationOnce(() => Promise.resolve(regeneratableCertificate));
+    wrapper = mount(<CertificateWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+
+    expect(wrapper.find('h2').html()).toEqual(expect.stringContaining(regeneratableCertificate.courseKey));
+    const dataRows = wrapper.find('table.table tbody tr');
+    expect(dataRows.length).toEqual(6);
+
+    const action = dataRows.at(5).find('td');
+    const actionButton = action.find('button#regenerate-certificate');
+    expect(action.at(0).text()).toEqual('Actions');
+    expect(actionButton.text()).toEqual('Regenerate');
+  });
+
+  it('Missing Certificate Data', async () => {
+    apiMock = jest.spyOn(api, 'getCertificate').mockImplementationOnce(() => Promise.resolve({ courseKey: testCourseId }));
+    wrapper = mount(<CertificateWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+
+    expect(wrapper.find('h2').html()).toEqual(expect.stringContaining(testCourseId));
+    const dataRows = wrapper.find('table.table tbody tr');
+    expect(dataRows.length).toEqual(6);
+
+    expect(dataRows.at(0).find('td').at(1).text()).toEqual('Not Available');
+    expect(dataRows.at(1).find('td').at(1).text()).toEqual('Not Available');
+    expect(dataRows.at(2).find('td').at(1).text()).toEqual('Not Available');
+    expect(dataRows.at(3).find('td').at(1).text()).toEqual('N/A');
+    expect(dataRows.at(4).find('td').at(1).text()).toEqual('Not Available');
+  });
+
+  it('Certificate Fetch Errors', async () => {
+    apiMock = jest.spyOn(api, 'getCertificate').mockImplementationOnce(() => Promise.resolve({
+      errors: [
+        {
+          code: null,
+          dismissible: true,
+          text: 'No certificate found',
+          type: 'danger',
+          topic: 'certificates',
+        },
+      ],
+    }));
+    wrapper = mount(<CertificateWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+    const alert = wrapper.find('.alert');
+    expect(alert.text()).toEqual('No certificate found');
+  });
+
+  describe('Generate Certificates flow', () => {
+    let generateApiMock;
+
+    afterEach(() => {
+      generateApiMock.mockRestore();
+    });
+
+    it('Successful certificate generation flow', async () => {
+      generateApiMock = jest.spyOn(api, 'generateCertificate').mockImplementationOnce(() => Promise.resolve({}));
+      apiMock = jest.spyOn(api, 'getCertificate').mockImplementation(() => Promise.resolve(downloadableCertificate));
+
+      wrapper = mount(<CertificateWrapper {...props} />);
+      await waitForComponentToPaint(wrapper);
+
+      let generateButton = wrapper.find('button#generate-certificate');
+      expect(generateButton.text()).toEqual('Generate');
+      expect(generateButton.prop('disabled')).toBeFalsy();
+
+      generateButton.simulate('click');
+      generateButton = wrapper.find('button#generate-certificate');
+
+      expect(generateButton.prop('disabled')).toBeTruthy();
+      expect(generateApiMock).toHaveBeenCalledTimes(1);
+      expect(wrapper.find('h3').text()).toEqual('Status: Generating New Certificate ');
+
+      // Once the generation api call is successful, the status text and button will revert.
+      await waitForComponentToPaint(wrapper);
+      generateButton = wrapper.find('button#generate-certificate');
+      expect(wrapper.find('h3').length).toEqual(0);
+      expect(generateButton.prop('disabled')).toBeFalsy();
+    });
+
+    it('Unsuccessful certificate generation flow', async () => {
+      generateApiMock = jest.spyOn(api, 'generateCertificate').mockImplementationOnce(() => Promise.resolve({
+        errors: [
+          {
+            code: null,
+            dismissible: true,
+            text: 'Error generating certificate',
+            type: 'danger',
+            topic: 'certificates',
+          },
+        ],
+      }));
+      apiMock = jest.spyOn(api, 'getCertificate').mockImplementation(() => Promise.resolve(downloadableCertificate));
+
+      wrapper = mount(<CertificateWrapper {...props} />);
+      await waitForComponentToPaint(wrapper);
+
+      const generateButton = wrapper.find('button#generate-certificate');
+      expect(generateButton.text()).toEqual('Generate');
+      expect(generateButton.prop('disabled')).toBeFalsy();
+      generateButton.simulate('click');
+      expect(generateApiMock).toHaveBeenCalledTimes(1);
+
+      await waitForComponentToPaint(wrapper);
+      const alert = wrapper.find('.alert');
+      expect(alert.text()).toEqual('Error generating certificate');
+    });
+  });
+
+  describe('Regenerate Certificates flow', () => {
+    let regenerateApiMock;
+
+    afterEach(() => {
+      regenerateApiMock.mockRestore();
+    });
+
+    it('Successful certificate regeneration flow', async () => {
+      regenerateApiMock = jest.spyOn(api, 'regenerateCertificate').mockImplementationOnce(() => Promise.resolve({}));
+      apiMock = jest.spyOn(api, 'getCertificate').mockImplementation(() => Promise.resolve(regeneratableCertificate));
+
+      wrapper = mount(<CertificateWrapper {...props} />);
+      await waitForComponentToPaint(wrapper);
+
+      let regenerateButton = wrapper.find('button#regenerate-certificate');
+      expect(regenerateButton.text()).toEqual('Regenerate');
+      expect(regenerateButton.prop('disabled')).toBeFalsy();
+
+      regenerateButton.simulate('click');
+      regenerateButton = wrapper.find('button#regenerate-certificate');
+
+      expect(regenerateButton.prop('disabled')).toBeTruthy();
+      expect(regenerateApiMock).toHaveBeenCalledTimes(1);
+      expect(wrapper.find('h3').text()).toEqual('Status: Regenerating Certificate ');
+
+      await waitForComponentToPaint(wrapper);
+      regenerateButton = wrapper.find('button#regenerate-certificate');
+      expect(wrapper.find('h3').length).toEqual(0);
+      expect(regenerateButton.prop('disabled')).toBeFalsy();
+    });
+
+    it('Unsuccessful certificate regeneration flow', async () => {
+      regenerateApiMock = jest.spyOn(api, 'regenerateCertificate').mockImplementationOnce(() => Promise.resolve({
+        errors: [
+          {
+            code: null,
+            dismissible: true,
+            text: 'Error regenerating certificate',
+            type: 'danger',
+            topic: 'certificates',
+          },
+        ],
+      }));
+      apiMock = jest.spyOn(api, 'getCertificate').mockImplementation(() => Promise.resolve(regeneratableCertificate));
+
+      wrapper = mount(<CertificateWrapper {...props} />);
+      await waitForComponentToPaint(wrapper);
+
+      const regenerateButton = wrapper.find('button#regenerate-certificate');
+      expect(regenerateButton.text()).toEqual('Regenerate');
+      expect(regenerateButton.prop('disabled')).toBeFalsy();
+
+      regenerateButton.simulate('click');
+      expect(regenerateApiMock).toHaveBeenCalledTimes(1);
+
+      await waitForComponentToPaint(wrapper);
+      const alert = wrapper.find('.alert');
+      expect(alert.text()).toEqual('Error regenerating certificate');
+    });
+  });
+});

--- a/src/users/enrollments/Certificates.test.jsx
+++ b/src/users/enrollments/Certificates.test.jsx
@@ -122,7 +122,9 @@ describe('Certificate component', () => {
 
     it('Successful certificate generation flow', async () => {
       generateApiMock = jest.spyOn(api, 'generateCertificate').mockImplementationOnce(() => Promise.resolve({}));
-      apiMock = jest.spyOn(api, 'getCertificate').mockImplementation(() => Promise.resolve(downloadableCertificate));
+      apiMock = jest.spyOn(api, 'getCertificate').mockImplementationOnce(() => Promise.resolve(downloadableCertificate));
+      // 2nd call to get certificate after generaion would yield regenerate certificate data.
+      jest.spyOn(api, 'getCertificate').mockImplementationOnce(() => Promise.resolve(regeneratableCertificate));
 
       wrapper = mount(<CertificateWrapper {...props} />);
       await waitForComponentToPaint(wrapper);
@@ -138,11 +140,14 @@ describe('Certificate component', () => {
       expect(generateApiMock).toHaveBeenCalledTimes(1);
       expect(wrapper.find('h3').text()).toEqual('Status: Generating New Certificate ');
 
-      // Once the generation api call is successful, the status text and button will revert.
+      // Once the generation api call is successful, the status text will revert
+      // and button will change into regenerate button.
       await waitForComponentToPaint(wrapper);
-      generateButton = wrapper.find('button#generate-certificate');
+      const regenerateButton = wrapper.find('button#regenerate-certificate');
       expect(wrapper.find('h3').length).toEqual(0);
-      expect(generateButton.prop('disabled')).toBeFalsy();
+      expect(regenerateButton.text()).toEqual('Regenerate');
+      expect(regenerateButton.prop('disabled')).toBeFalsy();
+      expect(apiMock).toHaveBeenCalledTimes(2);
     });
 
     it('Unsuccessful certificate generation flow', async () => {

--- a/src/users/enrollments/Enrollments.jsx
+++ b/src/users/enrollments/Enrollments.jsx
@@ -9,6 +9,7 @@ import React, {
 import { Button, TransitionReplace, Collapsible } from '@edx/paragon';
 import { getConfig } from '@edx/frontend-platform';
 import PropTypes from 'prop-types';
+import Certificates from './Certificates';
 import EnrollmentForm from './EnrollmentForm';
 import EnrollmentExtra from './EnrollmentExtra';
 import { CREATE, CHANGE } from './constants';
@@ -23,6 +24,7 @@ export default function Enrollments({
   const [formType, setFormType] = useState(null);
   const [enrollmentToChange, setEnrollmentToChange] = useState(undefined);
   const [enrollmentExtraData, setEnrollmentExtraData] = useState(undefined);
+  const [selectedCourseId, setSelectedCourseId] = useState(undefined);
   const formRef = useRef(null);
   const extraRef = useRef(null);
 
@@ -33,11 +35,12 @@ export default function Enrollments({
       lastModifiedBy: enrollment.manualEnrollment && enrollment.manualEnrollment.enrolledBy ? enrollment.manualEnrollment.enrolledBy : 'N/A',
       reason: enrollment.manualEnrollment && enrollment.manualEnrollment.reason ? enrollment.manualEnrollment.reason : 'N/A',
     };
+    setSelectedCourseId(undefined);
     setEnrollmentExtraData(extraData);
   }
 
   useLayoutEffect(() => {
-    if (enrollmentExtraData !== undefined) {
+    if (enrollmentExtraData !== undefined && selectedCourseId === undefined) {
       extraRef.current.focus();
     }
   });
@@ -102,6 +105,16 @@ export default function Enrollments({
               }}
             >
               Show Extra
+            </Button>
+            <Button
+              type="button"
+              id="certificate"
+              variant="outline-primary mt-2 mr-2"
+              onClick={() => {
+                setSelectedCourseId(result.courseId);
+              }}
+            >
+              View Certificate
             </Button>
           </div>
         ),
@@ -196,6 +209,16 @@ export default function Enrollments({
             closeHandler={() => setEnrollmentExtraData(undefined)}
             enrollmentExtraData={enrollmentExtraData}
             forwardedRef={extraRef}
+          />
+        ) : (<React.Fragment key="nothing" />) }
+      </TransitionReplace>
+      <TransitionReplace>
+        {selectedCourseId !== undefined ? (
+          <Certificates
+            key="certificates-data"
+            closeHandler={() => setSelectedCourseId(undefined)}
+            courseId={selectedCourseId}
+            username={user}
           />
         ) : (<React.Fragment key="nothing" />) }
       </TransitionReplace>


### PR DESCRIPTION
### [PROD-2357](https://openedx.atlassian.net/browse/PROD-2357)

### Description

Add certificate tool with the following features:

- Get certificate details
- Generate certificate
- Regenerate certificate

The backend APIs are the same as old support tools, located at https://github.com/edx/edx-platform/blob/master/lms/djangoapps/certificates/views/support.py. The view cert button is added to the enrollment listing, as requested in the ticket.


![image](https://user-images.githubusercontent.com/40599381/123141693-17778080-d472-11eb-846b-889d5ca5332d.png)
![image](https://user-images.githubusercontent.com/40599381/123141718-1ba39e00-d472-11eb-920c-d2eb540934ac.png)
![image](https://user-images.githubusercontent.com/40599381/123141735-21997f00-d472-11eb-9d60-f90346263539.png)
![image](https://user-images.githubusercontent.com/40599381/123141767-2bbb7d80-d472-11eb-849a-ebb92f787e82.png)
![image](https://user-images.githubusercontent.com/40599381/123409298-7569ac80-d5c7-11eb-8f0b-8758f6d0a8a1.png)
