### PR TITLE
feat: show onboarding status for user

### DIFF
--- a/src/users/UserPage.jsx
+++ b/src/users/UserPage.jsx
@@ -163,6 +163,7 @@ export default function UserPage({ location }) {
             userData={data.user}
             verificationData={data.verificationStatus}
             ssoRecords={data.ssoRecords}
+            onboardingData={data.onboardingStatus}
             changeHandler={handleUserSummaryChange}
           />
           <Licenses

--- a/src/users/UserSummary.jsx
+++ b/src/users/UserSummary.jsx
@@ -1,15 +1,17 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Modal, Button, Input } from '@edx/paragon';
+import { getConfig } from '@edx/frontend-platform';
 import { postTogglePasswordStatus, postResetPassword } from './data/api';
 import Table from '../Table';
-import { formatDate } from '../utils';
+import { formatDate, titleCase } from '../utils';
 import { getAccountActivationUrl } from './data/urls';
 
 export default function UserSummary({
   userData,
   verificationData,
   ssoRecords,
+  onboardingData,
   changeHandler,
 }) {
   const [ssoModalIsOpen, setSsoModalIsOpen] = useState(false);
@@ -151,6 +153,7 @@ export default function UserSummary({
       key: 'extra',
     },
   ];
+
   const userPasswordHistoryColumns = [
     {
       label: 'Date',
@@ -241,6 +244,35 @@ export default function UserSummary({
     },
   }));
 
+  const proctoringData = [onboardingData].map(result => ({
+    status: result.onboardingStatus ? titleCase(result.onboardingStatus) : 'Not Started',
+    expirationDate: formatDate(result.expirationDate),
+    onboardingReleaseDate: formatDate(result.onboardingReleaseDate),
+    onboardingLink: result.onboardingLink ? {
+      displayValue: <a href={`${getConfig().LMS_BASE_URL}${result.onboardingLink}`} rel="noopener noreferrer" target="_blank" className="word_break">Link</a>,
+      value: result.onboardingLink,
+    } : 'N/A',
+  }));
+
+  const proctoringColumns = [
+    {
+      label: 'Onboarding Status',
+      key: 'status',
+    },
+    {
+      label: 'Expiration Date',
+      key: 'expirationDate',
+    },
+    {
+      label: 'Release Date',
+      key: 'onboardingReleaseDate',
+    },
+    {
+      label: 'Onboarding Link',
+      key: 'onboardingLink',
+    },
+  ];
+
   if (!userData.isActive) {
     let dataValue;
     if (userData.activationKey !== null) {
@@ -304,6 +336,14 @@ export default function UserSummary({
                 id="idv-data"
                 data={IdvData}
                 columns={idvColumns}
+              />
+            </div>
+            <div className="flex-column p-4 m-3 card">
+              <h4>Proctoring Information</h4>
+              <Table
+                id="proctoring-data"
+                data={proctoringData}
+                columns={proctoringColumns}
               />
             </div>
             <div className="flex-column p-4 m-3 card">
@@ -428,6 +468,12 @@ UserSummary.propTypes = {
     extraData: PropTypes.shape([]),
   }),
   ssoRecords: PropTypes.shape([]),
+  onboardingData: PropTypes.shape({
+    onboardingStatus: PropTypes.string,
+    expirationDate: PropTypes.string,
+    onboardingLink: PropTypes.string,
+    onboardingReleaseDate: PropTypes.string,
+  }),
   changeHandler: PropTypes.func.isRequired,
 };
 
@@ -435,4 +481,5 @@ UserSummary.defaultProps = {
   userData: null,
   verificationData: null,
   ssoRecords: [],
+  onboardingData: null,
 };

--- a/src/users/UserSummary.test.jsx
+++ b/src/users/UserSummary.test.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import * as api from './data/api';
 import UserSummary from './UserSummary';
 import UserSummaryData from './data/test/userSummary';
+import { formatDate, titleCase } from '../utils';
 
 const getActivationKeyRow = (data) => {
   const wrapper = mount(<UserSummary {...data} />);
@@ -59,6 +60,40 @@ describe('User Summary Component Tests', () => {
       expect(ComponentSsoData.provider).toEqual(ExpectedSsoData.provider);
       expect(ComponentSsoData.modified).toEqual(ExpectedSsoData.modified);
       expect(ComponentSsoData.extraData).toEqual(ExpectedSsoData.extraData);
+    });
+    it('Onboarding Status Data Values', () => {
+      const ComponentOnboardingData = wrapper.prop('onboardingData');
+      const ExpectedOnboardingData = UserSummaryData.onboardingData;
+
+      expect(ComponentOnboardingData.onboardingStatus).toEqual(ExpectedOnboardingData.onboardingStatus);
+      expect(ComponentOnboardingData.expirationDate).toEqual(ExpectedOnboardingData.expirationDate);
+      expect(ComponentOnboardingData.onboardingReleaseDate).toEqual(ExpectedOnboardingData.onboardingReleaseDate);
+      expect(ComponentOnboardingData.onboardingLink).toEqual(ExpectedOnboardingData.onboardingLink);
+    });
+  });
+
+  describe('Onboarding Status Data', () => {
+    it('Onboarding Status', () => {
+      const dataTable = wrapper.find('Table#proctoring-data');
+      const dataBody = dataTable.find('tbody tr td');
+      expect(dataBody).toHaveLength(4);
+      expect(dataBody.at(0).text()).toEqual(titleCase(UserSummaryData.onboardingData.onboardingStatus));
+      expect(dataBody.at(1).text()).toEqual(formatDate(UserSummaryData.onboardingData.expirationDate));
+      expect(dataBody.at(2).text()).toEqual(formatDate(UserSummaryData.onboardingData.onboardingReleaseDate));
+      expect(dataBody.at(3).text()).toEqual('Link');
+    });
+
+    it('No Onboarding Status Data', () => {
+      const onboardingData = { ...UserSummaryData.onboardingData, onboardingStatus: null, onboardingLink: null };
+      const userData = { ...UserSummaryData, onboardingData };
+      wrapper = mount(<UserSummary {...userData} />);
+      const dataTable = wrapper.find('Table#proctoring-data');
+      const dataBody = dataTable.find('tbody tr td');
+      expect(dataBody).toHaveLength(4);
+      expect(dataBody.at(0).text()).toEqual('Not Started');
+      expect(dataBody.at(1).text()).toEqual(formatDate(UserSummaryData.onboardingData.expirationDate));
+      expect(dataBody.at(2).text()).toEqual(formatDate(UserSummaryData.onboardingData.onboardingReleaseDate));
+      expect(dataBody.at(3).text()).toEqual('N/A');
     });
   });
 

--- a/src/users/data/test/userSummary.js
+++ b/src/users/data/test/userSummary.js
@@ -27,6 +27,14 @@ const UserSummaryData = {
     isVerified: true,
     extraData: [],
   },
+  onboardingData: {
+    onboardingStatus: 'verified',
+    expirationDate: null,
+    onboardingLink: '/course/course-uuid/some-route',
+    onboardingPastDue: false,
+    onboardingReleaseDate: new Date().toISOString(),
+    reviewRequirementsUrl: null,
+  },
 };
 
 export default UserSummaryData;

--- a/src/users/data/urls.js
+++ b/src/users/data/urls.js
@@ -65,3 +65,7 @@ export const getResetPasswordUrl = () => `${
 export const getAccountActivationUrl = (activationKey) => `${
   LMS_BASE_URL
 }/activate/${activationKey}`;
+
+export const getOnboardingStatusUrl = (courseId, username) => `${
+  LMS_BASE_URL
+}/api/edx_proctoring/v1/user_onboarding/status?course_id=${encodeURIComponent(courseId)}&username=${encodeURIComponent(username)}`;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -26,3 +26,8 @@ export function sort(firstElement, secondElement, key, direction) {
   }
   return 0;
 }
+
+/** Convert a string containing space and/or underscore (snake_case) into titleCase. e.g. hello_world -> Hello World */
+export function titleCase(str) {
+  return str.toLowerCase().replace(/_/g, ' ').replace(/\b(\w)/g, s => s.toUpperCase());
+}

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -1,5 +1,5 @@
 import {
-  isEmail, isValidUsername, formatDate, sort,
+  isEmail, isValidUsername, formatDate, sort, titleCase,
 } from './index';
 
 describe('Test Utils', () => {
@@ -68,6 +68,26 @@ describe('Test Utils', () => {
     it('when the values are equal', () => {
       expect(sort(sortDict1, sortDict1, 'id', 'asc')).toEqual(0);
       expect(sort(sortDict1, sortDict1, 'id', 'asc')).toEqual(0);
+    });
+  });
+
+  describe('titleCase', () => {
+    it('empty string', () => {
+      expect(titleCase('')).toEqual('');
+      expect(titleCase(' ')).toEqual(' ');
+    });
+    it('one word string', () => {
+      expect(titleCase('hello')).toEqual('Hello');
+      expect(titleCase('title')).toEqual('Title');
+    });
+    it('string with spaces', () => {
+      expect(titleCase('hello world')).toEqual('Hello World');
+      expect(titleCase('title case')).toEqual('Title Case');
+    });
+    it('string with underscore', () => {
+      expect(titleCase('hello_world')).toEqual('Hello World');
+      expect(titleCase('title_case')).toEqual('Title Case');
+      expect(titleCase('onboarding_exam_details')).toEqual('Onboarding Exam Details');
     });
   });
 });


### PR DESCRIPTION
## Description
This PR adds `Proctoring Information` table which fetch user onboarding data against this [endpoint](https://github.com/edx/edx-proctoring/blob/master/edx_proctoring/views.py#L444) which is a wrapper of `Verificient` service. 

## Linked Issue Ticket
[PROD-2358](https://openedx.atlassian.net/browse/PROD-2358) contains detailed discussion and decisions. 

## Local Dependency
[edx/mockprock](https://github.com/edx/edx-proctoring/blob/master/docs/developing.rst#using-mockprock-as-a-backend) should be setup and running in devstack.

## Testing
- Edge cases needs to be tested on stage
- Feedback from support is must 

## Rebase and Commit Squash
May need to rebase with master and commits will be squashed into one with `feat: show onboarding status for user` message before merge. 

## Screenshot
![image](https://user-images.githubusercontent.com/47540683/121411549-30b20480-c97d-11eb-83aa-f4401c671981.png)
![image](https://user-images.githubusercontent.com/47540683/121414263-e41bf880-c97f-11eb-9ec6-2f94898a7924.png)
