### PR TITLE
fix: sort order for enrollments

### DIFF
--- a/src/users/UserSummary.jsx
+++ b/src/users/UserSummary.jsx
@@ -244,16 +244,6 @@ export default function UserSummary({
     },
   }));
 
-  const proctoringData = [onboardingData].map(result => ({
-    status: result.onboardingStatus ? titleCase(result.onboardingStatus) : 'Not Started',
-    expirationDate: formatDate(result.expirationDate),
-    onboardingReleaseDate: formatDate(result.onboardingReleaseDate),
-    onboardingLink: result.onboardingLink ? {
-      displayValue: <a href={`${getConfig().LMS_BASE_URL}${result.onboardingLink}`} rel="noopener noreferrer" target="_blank" className="word_break">Link</a>,
-      value: result.onboardingLink,
-    } : 'N/A',
-  }));
-
   const proctoringColumns = [
     {
       label: 'Onboarding Status',
@@ -264,14 +254,19 @@ export default function UserSummary({
       key: 'expirationDate',
     },
     {
-      label: 'Release Date',
-      key: 'onboardingReleaseDate',
-    },
-    {
       label: 'Onboarding Link',
       key: 'onboardingLink',
     },
   ];
+
+  const proctoringData = [onboardingData].map(result => ({
+    status: result.onboardingStatus ? titleCase(result.onboardingStatus) : 'Not Started',
+    expirationDate: formatDate(result.expirationDate),
+    onboardingLink: result.onboardingLink ? {
+      displayValue: <a href={`${getConfig().LMS_BASE_URL}${result.onboardingLink}`} rel="noopener noreferrer" target="_blank" className="word_break">Link</a>,
+      value: result.onboardingLink,
+    } : 'N/A',
+  }));
 
   if (!userData.isActive) {
     let dataValue;
@@ -472,7 +467,6 @@ UserSummary.propTypes = {
     onboardingStatus: PropTypes.string,
     expirationDate: PropTypes.string,
     onboardingLink: PropTypes.string,
-    onboardingReleaseDate: PropTypes.string,
   }),
   changeHandler: PropTypes.func.isRequired,
 };

--- a/src/users/UserSummary.test.jsx
+++ b/src/users/UserSummary.test.jsx
@@ -76,11 +76,10 @@ describe('User Summary Component Tests', () => {
     it('Onboarding Status', () => {
       const dataTable = wrapper.find('Table#proctoring-data');
       const dataBody = dataTable.find('tbody tr td');
-      expect(dataBody).toHaveLength(4);
+      expect(dataBody).toHaveLength(3);
       expect(dataBody.at(0).text()).toEqual(titleCase(UserSummaryData.onboardingData.onboardingStatus));
       expect(dataBody.at(1).text()).toEqual(formatDate(UserSummaryData.onboardingData.expirationDate));
-      expect(dataBody.at(2).text()).toEqual(formatDate(UserSummaryData.onboardingData.onboardingReleaseDate));
-      expect(dataBody.at(3).text()).toEqual('Link');
+      expect(dataBody.at(2).text()).toEqual('Link');
     });
 
     it('No Onboarding Status Data', () => {
@@ -89,11 +88,10 @@ describe('User Summary Component Tests', () => {
       wrapper = mount(<UserSummary {...userData} />);
       const dataTable = wrapper.find('Table#proctoring-data');
       const dataBody = dataTable.find('tbody tr td');
-      expect(dataBody).toHaveLength(4);
+      expect(dataBody).toHaveLength(3);
       expect(dataBody.at(0).text()).toEqual('Not Started');
       expect(dataBody.at(1).text()).toEqual(formatDate(UserSummaryData.onboardingData.expirationDate));
-      expect(dataBody.at(2).text()).toEqual(formatDate(UserSummaryData.onboardingData.onboardingReleaseDate));
-      expect(dataBody.at(3).text()).toEqual('N/A');
+      expect(dataBody.at(2).text()).toEqual('N/A');
     });
   });
 

--- a/src/users/data/api.js
+++ b/src/users/data/api.js
@@ -2,7 +2,7 @@ import { ensureConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import * as messages from '../../userMessages/messages';
 import * as AppUrls from './urls';
-import { isEmail } from '../../utils';
+import { isEmail, sortedCompareDates } from '../../utils';
 
 export async function getEntitlements(username, page = 1) {
   const baseURL = AppUrls.getEntitlementUrl();
@@ -187,7 +187,9 @@ export async function getOnboardingStatus(enrollments, username) {
 
   // get most recent paid enrollment
   const paidEnrollments = enrollments.filter((course) => course.mode === 'verified' || course.mode === 'professional');
-  paidEnrollments.sort((a, b) => (a.created < b.created));
+
+  // sort courses on enrollments created with most recent enrollment on top
+  paidEnrollments.sort((x, y) => sortedCompareDates(x.created, y.created, false));
 
   if (paidEnrollments.length === 0) {
     return {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -31,3 +31,10 @@ export function sort(firstElement, secondElement, key, direction) {
 export function titleCase(str) {
   return str.toLowerCase().replace(/_/g, ' ').replace(/\b(\w)/g, s => s.toUpperCase());
 }
+
+/**  Compare dates function for array.sort() */
+export function sortedCompareDates(x, y, asc) {
+  const a = new Date(x);
+  const b = new Date(y);
+  return asc ? a - b : b - a;
+}

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -1,5 +1,5 @@
 import {
-  isEmail, isValidUsername, formatDate, sort, titleCase,
+  isEmail, isValidUsername, formatDate, sort, titleCase, sortedCompareDates,
 } from './index';
 
 describe('Test Utils', () => {
@@ -88,6 +88,43 @@ describe('Test Utils', () => {
       expect(titleCase('hello_world')).toEqual('Hello World');
       expect(titleCase('title_case')).toEqual('Title Case');
       expect(titleCase('onboarding_exam_details')).toEqual('Onboarding Exam Details');
+    });
+  });
+
+  describe('sortedCompareDates', () => {
+    const dates = [
+      '2022-04-06T20:49:53.428771Z',
+      '2022-04-06T20:49:53.428771Z',
+      '2021-04-06T20:49:53.428771Z',
+      '2020-04-06T20:49:53.428771Z',
+      '2021-04-06T10:49:53.428771Z',
+    ];
+
+    const ascSortedDates = [
+      '2020-04-06T20:49:53.428771Z',
+      '2021-04-06T10:49:53.428771Z',
+      '2021-04-06T20:49:53.428771Z',
+      '2022-04-06T20:49:53.428771Z',
+      '2022-04-06T20:49:53.428771Z',
+    ];
+
+    const dscSortedDates = [
+      '2022-04-06T20:49:53.428771Z',
+      '2022-04-06T20:49:53.428771Z',
+      '2021-04-06T20:49:53.428771Z',
+      '2021-04-06T10:49:53.428771Z',
+      '2020-04-06T20:49:53.428771Z',
+    ];
+
+    it('dates in asc order', () => {
+      expect(dates.sort(
+        (a, b) => sortedCompareDates(a, b, true),
+      )).toEqual(ascSortedDates);
+    });
+    it('dates in dsc order', () => {
+      expect(dates.sort(
+        (a, b) => sortedCompareDates(a, b, false),
+      )).toEqual(dscSortedDates);
     });
   });
 });


### PR DESCRIPTION
Updates on PR #126

- Fix sort order for enrollments ([see](https://www.javascripttutorial.net/javascript-array-sort/) how array.sort() works, dates example in particular)
- Remove release date field