### PR TITLE
fix: filter active enrollments

### DIFF
--- a/src/users/data/api.js
+++ b/src/users/data/api.js
@@ -185,8 +185,8 @@ export async function getOnboardingStatus(enrollments, username) {
     reviewRequirementsUrl: null,
   };
 
-  // get most recent paid enrollment
-  const paidEnrollments = enrollments.filter((course) => course.mode === 'verified' || course.mode === 'professional');
+  // get most recent paid active enrollment
+  const paidEnrollments = enrollments.filter((enrollment) => enrollment.is_active && (enrollment.mode === 'verified' || enrollment.mode === 'professional'));
 
   // sort courses on enrollments created with most recent enrollment on top
   paidEnrollments.sort((x, y) => sortedCompareDates(x.created, y.created, false));

--- a/src/users/data/api.test.js
+++ b/src/users/data/api.test.js
@@ -57,7 +57,18 @@ describe('API', () => {
     const { data } = enrollmentsData;
     data[1].mode = 'verified';
     data[1].course_id = data[1].courseId;
-    const url = `${onboardingStatusApiUrl}?course_id=${encodeURIComponent(data[1].courseId)}&username=${encodeURIComponent(testUsername)}`;
+    data[1].is_active = data[1].isActive; // false
+    let url = `${onboardingStatusApiUrl}?course_id=${encodeURIComponent(data[1].course_id)}&username=${encodeURIComponent(testUsername)}`;
+
+    it('No Active Paid Enrollment ', async () => {
+      mockAdapter.onGet(url).reply(() => throwError(404, ''));
+
+      const response = await api.getOnboardingStatus(data, testUsername);
+      expect(response).toEqual({ ...expectedSuccessResponse, onboardingStatus: 'No Record Found' });
+    });
+
+    data[1].is_active = true;
+    url = `${onboardingStatusApiUrl}?course_id=${encodeURIComponent(data[1].course_id)}&username=${encodeURIComponent(testUsername)}`;
 
     it('Successful Fetch ', async () => {
       mockAdapter.onGet(url).reply(200, expectedSuccessResponse);


### PR DESCRIPTION
### Description
This PR adds active enrollment filter for getting onboarding status data. It primarily covers the use case in which a user has most recent paid enrollment inactive. 

### Linked Issues:
[PROD-2410](https://openedx.atlassian.net/browse/PROD-2410)

