### PR TITLE
refactor: move api calls in entitlement component

### DIFF
--- a/src/users/UserPage.jsx
+++ b/src/users/UserPage.jsx
@@ -172,7 +172,6 @@ export default function UserPage({ location }) {
           />
           <Entitlements
             user={data.user.username}
-            data={data.entitlements}
             changeHandler={handleEntitlementsChange}
             expanded={showEntitlements}
           />

--- a/src/users/data/api.test.js
+++ b/src/users/data/api.test.js
@@ -348,7 +348,6 @@ describe('API', () => {
 
     it('Successful User Data Retrieval', async () => {
       mockAdapter.onGet(`${userAccountApiBaseUrl}/${testUsername}`).reply(200, successDictResponse);
-      mockAdapter.onGet(`${entitlementsApiBaseUrl}&page=1`).reply(200, { results: [], next: null });
       mockAdapter.onGet(enrollmentsApiUrl).reply(200, []);
       mockAdapter.onGet(ssoRecordsApiUrl).reply(200, []);
       mockAdapter.onGet(verificationDetailsApiUrl).reply(200, {});
@@ -363,7 +362,6 @@ describe('API', () => {
         ssoRecords: [],
         verificationStatus: { extraData: {} },
         enrollments: [],
-        entitlements: { results: [], next: null },
         onboardingStatus: { ...onboardingDefaultResponse, onboardingStatus: 'No Paid Enrollment' },
       });
     });
@@ -474,6 +472,11 @@ describe('API', () => {
         user: testUsername,
         uuid: 'uuid',
       };
+      it('Unsuccessful fetch', async () => {
+        mockAdapter.onGet(`${entitlementsApiBaseUrl}&page=1`).reply(() => throwError(400, 'There was an error fetching entitlements.'));
+        const response = await api.getEntitlements(testUsername);
+        expect(...response.errors).toEqual({ ...expectedError, text: 'There was an error fetching entitlements.' });
+      });
       it('Single page result', async () => {
         const expectedData = {
           count: 1,

--- a/src/users/data/test/entitlements.js
+++ b/src/users/data/test/entitlements.js
@@ -1,49 +1,54 @@
-const entitlementsData = {
-  data: {
-    results: [
-      {
-        user: 'edX',
-        uuid: 'entitlement-uuid',
-        courseUuid: 'course-uuid',
-        enrollmentCourseRun: 'course-v1:testX+test123+2030',
-        created: Date().toLocaleString(),
-        modified: Date().toLocaleString(),
-        expiredAt: Date().toLocaleString(),
-        mode: 'verified',
-        orderNumber: '123edX456',
-        supportDetails: [{
-          supportUser: 'admin',
-          action: 'CREATE',
-          actionCreated: Date().toLocaleString(),
-          comments: 'creating entitlement',
-          unenrolledRun: null,
-        },
-        {
-          supportUser: 'admin',
-          action: 'EXPIRE',
-          actionCreated: Date().toLocaleString(),
-          comments: 'expiring entitlement',
-          unenrolledRun: null,
-        },
-        ],
+export const entitlementsData = {
+  results: [
+    {
+      user: 'edX',
+      uuid: 'entitlement-uuid',
+      courseUuid: 'course-uuid',
+      enrollmentCourseRun: 'course-v1:testX+test123+2030',
+      created: Date().toLocaleString(),
+      modified: Date().toLocaleString(),
+      expiredAt: Date().toLocaleString(),
+      mode: 'verified',
+      orderNumber: '123edX456',
+      supportDetails: [{
+        supportUser: 'admin',
+        action: 'CREATE',
+        actionCreated: Date().toLocaleString(),
+        comments: 'creating entitlement',
+        unenrolledRun: null,
       },
       {
-        user: 'edX',
-        uuid: 'entitlement-1-uuid',
-        courseUuid: 'course-1-uuid',
-        enrollmentCourseRun: 'course-v1:testX+test123+2040',
-        created: Date().toLocaleString(),
-        modified: Date().toLocaleString(),
-        expiredAt: Date().toLocaleString(),
-        mode: 'professional',
-        orderNumber: '123edX456789',
-        supportDetails: [],
+        supportUser: 'admin',
+        action: 'EXPIRE',
+        actionCreated: Date().toLocaleString(),
+        comments: 'expiring entitlement',
+        unenrolledRun: null,
       },
-    ],
-  },
-  user: 'edX',
-  expanded: true,
-  changeHandler: jest.fn(() => {}),
+      ],
+    },
+    {
+      user: 'edX',
+      uuid: 'entitlement-1-uuid',
+      courseUuid: 'course-1-uuid',
+      enrollmentCourseRun: null,
+      created: Date().toLocaleString(),
+      modified: Date().toLocaleString(),
+      expiredAt: null,
+      mode: 'professional',
+      orderNumber: '123edX456789',
+      supportDetails: [],
+    },
+  ],
 };
 
-export default entitlementsData;
+export const entitlementsErrors = {
+  errors: [
+    {
+      code: null,
+      dismissible: true,
+      text: 'Test Error',
+      type: 'danger',
+      topic: 'entitlements',
+    },
+  ],
+};


### PR DESCRIPTION
[PROD-2395](https://openedx.atlassian.net/browse/PROD-2395)
Entitlement api calls have been moved from UserPage.jsx to Entitlements.jsx hence the component no longer depends on UserPage.jsx.

There are two visual changes in this PR:
1. I've also added a Page Loading while the entitlement is fetching data from api. Also the tests have been thoroughly changed according to the entitlement changes: (Edit: the loader has been moved inside the component)
![image](https://user-images.githubusercontent.com/52413434/124100165-ab030f80-da77-11eb-867a-f57c2edab184.png)

2. Also added error handling as shown below: 
<img width="1396" alt="Screenshot 2021-07-01 at 2 24 06 PM" src="https://user-images.githubusercontent.com/52413434/124100540-003f2100-da78-11eb-89ce-7fe4735f40e6.png">

