### PR TITLE
refactor: self-contain onboarding status component

### DIFF
--- a/src/users/OnboardingStatus.jsx
+++ b/src/users/OnboardingStatus.jsx
@@ -1,0 +1,68 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import { camelCaseObject, getConfig } from '@edx/frontend-platform';
+import PropTypes from 'prop-types';
+import Table from '../Table';
+import { formatDate, titleCase } from '../utils';
+import { getOnboardingStatus, getEnrollments } from './data/api';
+import PageLoading from '../components/common/PageLoading';
+
+export default function OnboardingStatus({
+  username,
+}) {
+  const [onboardingData, setOnboardingData] = useState(null);
+
+  useEffect(() => {
+    getEnrollments(username).then((enrollments) => {
+      getOnboardingStatus(enrollments, username).then((data) => {
+        const camelCaseData = camelCaseObject(data);
+        setOnboardingData(camelCaseData);
+      });
+    });
+  }, [username]);
+
+  const proctoringColumns = [
+    {
+      label: 'Onboarding Status',
+      key: 'status',
+    },
+    {
+      label: 'Expiration Date',
+      key: 'expirationDate',
+    },
+    {
+      label: 'Onboarding Link',
+      key: 'onboardingLink',
+    },
+  ];
+
+  const proctoringData = useMemo(() => {
+    if (onboardingData === null || onboardingData.length === 0) {
+      return [];
+    }
+    return [onboardingData].map(result => ({
+      status: result.onboardingStatus ? titleCase(result.onboardingStatus) : 'Not Started',
+      expirationDate: formatDate(result.expirationDate),
+      onboardingLink: result.onboardingLink ? {
+        displayValue: <a href={`${getConfig().LMS_BASE_URL}${result.onboardingLink}`} rel="noopener noreferrer" target="_blank" className="word_break">Link</a>,
+        value: result.onboardingLink,
+      } : 'N/A',
+    }));
+  }, [onboardingData]);
+
+  return (
+    <div className="flex-column p-4 m-3 card">
+      <h4>Proctoring Information</h4>
+      {onboardingData ? (
+        <Table
+          id="proctoring-data"
+          data={proctoringData}
+          columns={proctoringColumns}
+        />
+      ) : <PageLoading srMessage="Loading.." /> }
+    </div>
+  );
+}
+
+OnboardingStatus.propTypes = {
+  username: PropTypes.string.isRequired,
+};

--- a/src/users/OnboardingStatus.test.jsx
+++ b/src/users/OnboardingStatus.test.jsx
@@ -1,0 +1,59 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { waitForComponentToPaint } from '../setupTest';
+import OnboardingStatus from './OnboardingStatus';
+import UserMessagesProvider from '../userMessages/UserMessagesProvider';
+import onboardingStatusData from './data/test/onboardingStatus';
+import enrollmentsData from './data/test/enrollments';
+import { titleCase, formatDate } from '../utils';
+
+import * as api from './data/api';
+
+const OnboardingStatusWrapper = (props) => (
+  <UserMessagesProvider>
+    <OnboardingStatus {...props} />
+  </UserMessagesProvider>
+);
+
+describe('Onboarding Status', () => {
+  let wrapper;
+  const props = {
+    username: 'edX',
+  };
+
+  beforeEach(async () => {
+    jest.spyOn(api, 'getEnrollments').mockImplementationOnce(() => Promise.resolve(enrollmentsData));
+    jest.spyOn(api, 'getOnboardingStatus').mockImplementationOnce(() => Promise.resolve(onboardingStatusData));
+    wrapper = mount(<OnboardingStatusWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+  });
+
+  it('Onboaridng props', () => {
+    const username = wrapper.prop('username');
+
+    expect(username).toEqual(props.username);
+  });
+  it('Onboarding Status', () => {
+    const dataTable = wrapper.find('Table#proctoring-data');
+    const dataBody = dataTable.find('tbody tr td');
+    expect(dataBody).toHaveLength(3);
+    expect(dataBody.at(0).text()).toEqual(titleCase(onboardingStatusData.onboardingStatus));
+    expect(dataBody.at(1).text()).toEqual(formatDate(onboardingStatusData.expirationDate));
+    expect(dataBody.at(2).text()).toEqual('Link');
+  });
+  it('No Onboarding Status Data', async () => {
+    const onboardingData = { ...onboardingStatusData, onboardingStatus: null, onboardingLink: null };
+
+    jest.spyOn(api, 'getEnrollments').mockImplementationOnce(() => Promise.resolve(enrollmentsData));
+    jest.spyOn(api, 'getOnboardingStatus').mockImplementationOnce(() => Promise.resolve(onboardingData));
+    wrapper = mount(<OnboardingStatusWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+
+    const dataTable = wrapper.find('Table#proctoring-data');
+    const dataBody = dataTable.find('tbody tr td');
+    expect(dataBody).toHaveLength(3);
+    expect(dataBody.at(0).text()).toEqual('Not Started');
+    expect(dataBody.at(1).text()).toEqual(formatDate(onboardingStatusData.expirationDate));
+    expect(dataBody.at(2).text()).toEqual('N/A');
+  });
+});

--- a/src/users/UserPage.jsx
+++ b/src/users/UserPage.jsx
@@ -161,7 +161,6 @@ export default function UserPage({ location }) {
         <>
           <UserSummary
             userData={data.user}
-            onboardingData={data.onboardingStatus}
             changeHandler={handleUserSummaryChange}
           />
           <Licenses

--- a/src/users/UserSummary.jsx
+++ b/src/users/UserSummary.jsx
@@ -1,17 +1,16 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Modal, Button, Input } from '@edx/paragon';
-import { getConfig } from '@edx/frontend-platform';
 import { postTogglePasswordStatus, postResetPassword } from './data/api';
 import Table from '../Table';
-import { formatDate, titleCase } from '../utils';
+import { formatDate } from '../utils';
 import { getAccountActivationUrl } from './data/urls';
 import IdentityVerificationStatus from './IdentityVerificationStatus';
+import OnboardingStatus from './OnboardingStatus';
 import SingleSignOnRecords from './SingleSignOnRecords';
 
 export default function UserSummary({
   userData,
-  onboardingData,
   changeHandler,
 }) {
   const [disableUserModalIsOpen, setDisableUserModalIsOpen] = useState(false);
@@ -117,30 +116,6 @@ export default function UserSummary({
     setDisableHistoryModalIsOpen(true);
   };
 
-  const proctoringColumns = [
-    {
-      label: 'Onboarding Status',
-      key: 'status',
-    },
-    {
-      label: 'Expiration Date',
-      key: 'expirationDate',
-    },
-    {
-      label: 'Onboarding Link',
-      key: 'onboardingLink',
-    },
-  ];
-
-  const proctoringData = [onboardingData].map(result => ({
-    status: result.onboardingStatus ? titleCase(result.onboardingStatus) : 'Not Started',
-    expirationDate: formatDate(result.expirationDate),
-    onboardingLink: result.onboardingLink ? {
-      displayValue: <a href={`${getConfig().LMS_BASE_URL}${result.onboardingLink}`} rel="noopener noreferrer" target="_blank" className="word_break">Link</a>,
-      value: result.onboardingLink,
-    } : 'N/A',
-  }));
-
   if (!userData.isActive) {
     let dataValue;
     if (userData.activationKey !== null) {
@@ -198,15 +173,8 @@ export default function UserSummary({
         </div>
         <div className="col-sm-6">
           <div className="flex-column">
-            <div className="flex-column p-4 m-3 card">
-              <h4>Proctoring Information</h4>
-              <Table
-                id="proctoring-data"
-                data={proctoringData}
-                columns={proctoringColumns}
-              />
-            </div>
             <IdentityVerificationStatus username={userData.username} />
+            <OnboardingStatus username={userData.username} />
             <SingleSignOnRecords username={userData.username} />
           </div>
         </div>
@@ -291,15 +259,9 @@ UserSummary.propTypes = {
       passwordToggleHistory: PropTypes.shape([]),
     }),
   }),
-  onboardingData: PropTypes.shape({
-    onboardingStatus: PropTypes.string,
-    expirationDate: PropTypes.string,
-    onboardingLink: PropTypes.string,
-  }),
   changeHandler: PropTypes.func.isRequired,
 };
 
 UserSummary.defaultProps = {
   userData: null,
-  onboardingData: null,
 };

--- a/src/users/UserSummary.test.jsx
+++ b/src/users/UserSummary.test.jsx
@@ -4,9 +4,10 @@ import React from 'react';
 import * as api from './data/api';
 import UserSummary from './UserSummary';
 import UserSummaryData from './data/test/userSummary';
-import { formatDate, titleCase } from '../utils';
 import UserMessagesProvider from '../userMessages/UserMessagesProvider';
 import idvStatusData from './data/test/idvStatus';
+import enrollmentsData from './data/test/enrollments';
+import onboardingStatusData from './data/test/onboardingStatus';
 import ssoRecordsData from './data/test/ssoRecords';
 
 const UserSummaryWrapper = (props) => (
@@ -20,6 +21,8 @@ describe('User Summary Component Tests', () => {
 
   const mountUserSummaryWrapper = (data) => {
     jest.spyOn(api, 'getUserVerificationStatus').mockImplementationOnce(() => Promise.resolve(idvStatusData));
+    jest.spyOn(api, 'getEnrollments').mockImplementationOnce(() => Promise.resolve(enrollmentsData));
+    jest.spyOn(api, 'getOnboardingStatus').mockImplementationOnce(() => Promise.resolve(onboardingStatusData));
     jest.spyOn(api, 'getSsoRecords').mockImplementationOnce(() => Promise.resolve(ssoRecordsData));
     wrapper = mount(<UserSummaryWrapper {...data} />);
   };
@@ -47,38 +50,6 @@ describe('User Summary Component Tests', () => {
       expect(ComponentUserData.dateJoined).toEqual(ExpectedUserData.dateJoined);
       expect(ComponentUserData.passwordStatus).toEqual(ExpectedUserData.passwordStatus);
       expect(ComponentUserData.activationKey).toEqual(ExpectedUserData.activationKey);
-    });
-    it('Onboarding Status Data Values', () => {
-      const ComponentOnboardingData = wrapper.prop('onboardingData');
-      const ExpectedOnboardingData = UserSummaryData.onboardingData;
-
-      expect(ComponentOnboardingData.onboardingStatus).toEqual(ExpectedOnboardingData.onboardingStatus);
-      expect(ComponentOnboardingData.expirationDate).toEqual(ExpectedOnboardingData.expirationDate);
-      expect(ComponentOnboardingData.onboardingReleaseDate).toEqual(ExpectedOnboardingData.onboardingReleaseDate);
-      expect(ComponentOnboardingData.onboardingLink).toEqual(ExpectedOnboardingData.onboardingLink);
-    });
-  });
-
-  describe('Onboarding Status Data', () => {
-    it('Onboarding Status', () => {
-      const dataTable = wrapper.find('Table#proctoring-data');
-      const dataBody = dataTable.find('tbody tr td');
-      expect(dataBody).toHaveLength(3);
-      expect(dataBody.at(0).text()).toEqual(titleCase(UserSummaryData.onboardingData.onboardingStatus));
-      expect(dataBody.at(1).text()).toEqual(formatDate(UserSummaryData.onboardingData.expirationDate));
-      expect(dataBody.at(2).text()).toEqual('Link');
-    });
-
-    it('No Onboarding Status Data', () => {
-      const onboardingData = { ...UserSummaryData.onboardingData, onboardingStatus: null, onboardingLink: null };
-      const userData = { ...UserSummaryData, onboardingData };
-      mountUserSummaryWrapper(userData);
-      const dataTable = wrapper.find('Table#proctoring-data');
-      const dataBody = dataTable.find('tbody tr td');
-      expect(dataBody).toHaveLength(3);
-      expect(dataBody.at(0).text()).toEqual('Not Started');
-      expect(dataBody.at(1).text()).toEqual(formatDate(UserSummaryData.onboardingData.expirationDate));
-      expect(dataBody.at(2).text()).toEqual('N/A');
     });
   });
 

--- a/src/users/data/api.js
+++ b/src/users/data/api.js
@@ -255,7 +255,6 @@ export async function getAllUserData(userIdentifier) {
   const errors = [];
   let user = null;
   let enrollments = [];
-  let onboardingStatus = {};
   try {
     user = await getUser(userIdentifier);
   } catch (error) {
@@ -268,14 +267,12 @@ export async function getAllUserData(userIdentifier) {
   if (user !== null) {
     enrollments = await getEnrollments(user.username);
     user.passwordStatus = await getUserPasswordStatus(user.username);
-    onboardingStatus = await getOnboardingStatus(enrollments, user.username);
   }
 
   return {
     errors,
     user,
     enrollments,
-    onboardingStatus,
   };
 }
 

--- a/src/users/data/test/onboardingStatus.js
+++ b/src/users/data/test/onboardingStatus.js
@@ -1,0 +1,10 @@
+const onboardingStatusData = {
+  onboardingStatus: 'verified',
+  expirationDate: null,
+  onboardingLink: '/course/course-uuid/some-route',
+  onboardingPastDue: false,
+  onboardingReleaseDate: new Date().toISOString(),
+  reviewRequirementsUrl: null,
+};
+
+export default onboardingStatusData;

--- a/src/users/data/test/userSummary.js
+++ b/src/users/data/test/userSummary.js
@@ -15,14 +15,6 @@ const UserSummaryData = {
     },
   },
   changeHandler: jest.fn(() => {}),
-  onboardingData: {
-    onboardingStatus: 'verified',
-    expirationDate: null,
-    onboardingLink: '/course/course-uuid/some-route',
-    onboardingPastDue: false,
-    onboardingReleaseDate: new Date().toISOString(),
-    reviewRequirementsUrl: null,
-  },
 };
 
 export default UserSummaryData;


### PR DESCRIPTION
### Description
This PR refactors onboarding status component towards self-containment, essentially moving its API calls into its own component. This change is a part of optimization for support tools [PROD-2363](https://openedx.atlassian.net/browse/PROD-2363). 

### Linked Ticket:
[PROD-2416](https://openedx.atlassian.net/browse/PROD-2416)

![image](https://user-images.githubusercontent.com/47540683/124744232-fa45b600-df37-11eb-9a9a-cbdcaf0a3eb7.png)
