### PR TITLE
fix: clear errors before useEffect

### DIFF
--- a/src/users/IdentityVerificationStatus.jsx
+++ b/src/users/IdentityVerificationStatus.jsx
@@ -18,10 +18,10 @@ export default function IdentityVerificationStatus({
   const [detailIdvData, setDetailIdvData] = useState([]);
   const [isIdvModalOpen, setIsIdvModalOpen] = useState(false);
   useEffect(() => {
+    clear('idvStatus');
     getUserVerificationStatus(username).then((result) => {
       const camelCaseResult = camelCaseObject(result);
       if (camelCaseResult.errors) {
-        clear('idvStatus');
         camelCaseResult.errors.forEach(error => add(error));
         setVerificationData({});
       } else {

--- a/src/users/SingleSignOnRecords.jsx
+++ b/src/users/SingleSignOnRecords.jsx
@@ -18,10 +18,10 @@ export default function SingleSignOnRecords({
   const [ssoRecords, setSsoRecords] = useState(null);
   const { add, clear } = useContext(UserMessagesContext);
   useEffect(() => {
+    clear('ssoRecords');
     getSsoRecords(username).then((result) => {
       const camelCaseResult = camelCaseObject(result);
       if (camelCaseResult.errors) {
-        clear('ssoRecords');
         camelCaseResult.errors.forEach(error => add(error));
         setSsoRecords({});
       } else {

--- a/src/users/entitlements/Entitlements.jsx
+++ b/src/users/entitlements/Entitlements.jsx
@@ -36,6 +36,7 @@ export default function Entitlements({
   const summaryRef = useRef(null);
 
   useEffect(() => {
+    clear('entitlements');
     getEntitlements(user).then((result) => {
       const camelCaseResult = camelCaseObject(result);
       if (camelCaseResult.errors) {


### PR DESCRIPTION
A minor bug that can be seen when another user is fetched, the previous errors aren't removed.
This PR fixes the mentioned bug. (clears errors before fetching another component)