### PR TITLE
fix: alert message dismissal will not break page

### DIFF
--- a/src/userMessages/UserMessagesProvider.jsx
+++ b/src/userMessages/UserMessagesProvider.jsx
@@ -22,7 +22,7 @@ export default function UserMessagesProvider({ children }) {
   };
 
   const remove = id => {
-    setMessages(currentMessages => currentMessages.current.filter(message => message.id !== id));
+    setMessages(currentMessages => currentMessages.filter(message => message.id !== id));
   };
 
   const clear = (topic = null) => {


### PR DESCRIPTION
### [PROD-2349](https://openedx.atlassian.net/browse/PROD-2349)

### Description
Fix the issue with alert message dismissal where closing the alert would cause the page to break