### PR TITLE
fix: loading spinner for certificate

### DIFF
--- a/src/users/enrollments/Certificates.jsx
+++ b/src/users/enrollments/Certificates.jsx
@@ -27,6 +27,10 @@ export default function Certificates({
   const certificateRef = useRef(null);
 
   useEffect(() => {
+    setCertificateData(undefined);
+  }, [courseId]);
+
+  useEffect(() => {
     if ((certificate === undefined && !displayCertErrors) || (courseId !== oldCourseId)) {
       getCertificate(username, courseId).then((result) => {
         const camelCaseResult = camelCaseObject(result);


### PR DESCRIPTION
### Overview
This PR fixes issue with loading spinner in certificate component. When 'View Certificate' button is pressed second time, the loading spinner now appears again by resetting certificate data. 

### Linked Ticket
[PROD-2434](https://openedx.atlassian.net/browse/PROD-2434)

### Testing
This change needs to be tested locally and on stage to verify that it did not affect any other flow. 
