### PR TITLE
feat: add sso record component v2

### DIFF
--- a/src/overrides.scss
+++ b/src/overrides.scss
@@ -1,4 +1,3 @@
-
 // Reverting the container width to 1440px to keep the support tools styling consistent
 // See https://github.com/edx/paragon/pull/533 for paragon breaking change
 
@@ -18,6 +17,20 @@
     margin: 0;
     padding: 0.5rem;
     border-bottom: 1px solid silver;
+  }
+}
+
+.sso-table {
+  font-size: small;
+  width: auto;
+  th {
+    margin: 0;
+    padding: 0.5rem;
+    border-bottom: 1px solid black;
+  }
+  td {
+    margin: 0;
+    padding: 0.5rem;
   }
 }
 

--- a/src/users/SingleSignOnRecords.test.jsx
+++ b/src/users/SingleSignOnRecords.test.jsx
@@ -20,7 +20,8 @@ describe('Single Sign On Records', () => {
   };
 
   beforeEach(async () => {
-    jest.spyOn(api, 'getSsoRecords').mockImplementationOnce(() => Promise.resolve(ssoRecordsData));
+    const ssoData = { ...ssoRecordsData[0], extraData: [] };
+    jest.spyOn(api, 'getSsoRecords').mockImplementationOnce(() => Promise.resolve([ssoData]));
     wrapper = mount(<SingleSignOnRecordsWrapper {...props} />);
     await waitForComponentToPaint(wrapper);
   });
@@ -32,8 +33,8 @@ describe('Single Sign On Records', () => {
   });
 
   it('No extra sso data', () => {
-    const idvData = wrapper.find('Table#sso-data');
-    const extraDataButton = idvData.find('button.btn-link');
+    const ssoData = wrapper.find('Table#sso-data');
+    const extraDataButton = ssoData.find('button.btn-link');
     expect(extraDataButton).toHaveLength(0);
   });
 
@@ -69,9 +70,9 @@ describe('Single Sign On Records', () => {
     wrapper = mount(<SingleSignOnRecordsWrapper {...props} />);
     await waitForComponentToPaint(wrapper);
 
-    const ssoDataTable = wrapper.find('Table#sso-data');
-    const extraDataButton = ssoDataTable.find('button.btn-link');
-    let extraDataModal = wrapper.find('Modal#sso-extra-data');
+    const ssoDataTable = wrapper.find('Table#sso-data').at(0);
+    const extraDataButton = ssoDataTable.find('button.btn-link').at(0);
+    let extraDataModal = wrapper.find('Modal#sso-extra-data').at(0);
 
     expect(extraDataButton.text()).toEqual('Show');
     expect(extraDataModal.prop('open')).toEqual(false);

--- a/src/users/data/api.js
+++ b/src/users/data/api.js
@@ -60,10 +60,20 @@ export async function getSsoRecords(username) {
     );
     let parsedData = [];
     if (data.length > 0) {
-      parsedData = data.map((entry) => ({
-        ...entry,
-        extraData: JSON.parse(entry.extraData),
-      }));
+      parsedData = data.map((entry) => {
+        const extraData = JSON.parse(entry.extraData);
+
+        Object.keys(extraData).forEach((key) => {
+          extraData[key] = Array.isArray(extraData[key]) && extraData[key].length > 0
+            ? extraData[key][0]
+            : extraData[key];
+        });
+
+        return {
+          ...entry,
+          extraData,
+        };
+      });
     }
     return parsedData;
   } catch (error) {

--- a/src/users/data/test/ssoRecords.js
+++ b/src/users/data/test/ssoRecords.js
@@ -1,8 +1,41 @@
-const ssoRecordsData = [{
-  provider: 'edX',
-  uid: 'uid',
-  modified: null,
-  extraData: [],
-}];
+const ssoRecordsData = [
+  {
+    provider: 'edX',
+    uid: 'uid',
+    modified: null,
+    extraData: '{}',
+  },
+  {
+    provider: 'tpa-saml',
+    uid: 'edx-inc:test@edx.org',
+    created: '2020-06-19T12:38:40.456Z',
+    modified: '2020-07-08T15:11:34.340Z',
+    extraData: JSON.stringify({
+      userid: ['user@edx.org'],
+      'User ID': ['user@edx.org'],
+      Email: ['user@edx.org'],
+      mail: ['user@edx.org'],
+      session_index: '_540ed9fbf25f613a8177cab8bdabcc78',
+      surname: ['Test'],
+      auth_time: 1594221094,
+      name_id: 'user@edx.org',
+      givenName: ['Staff'],
+      'First Name': ['Staff'],
+      'Last Name': ['Test'],
+    }),
+  },
+  {
+    provider: 'google-oauth2',
+    uid: 'user@edx.org',
+    created: '2020-06-19T12:38:40.456Z',
+    modified: '2021-08-30T14:36:27.613Z',
+    extraData: JSON.stringify({
+      access_token: 'longlongtokenid-QWERTYUIOPasdfghjklZXCVBNM',
+      token_type: 'Bearer',
+      expires: 3599,
+      auth_time: 1630334187,
+    }),
+  },
+];
 
 export default ssoRecordsData;

--- a/src/users/v2/CopyShowHyperLinks.jsx
+++ b/src/users/v2/CopyShowHyperLinks.jsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Hyperlink } from '@edx/paragon';
+
+export default function CopyShowHyperlinks({ text }) {
+  const [copyText, setCopyText] = useState('Copy');
+
+  return (
+    <>
+      <Hyperlink
+        destination=""
+        target="_blank"
+        onClick={(e) => {
+          e.preventDefault();
+          navigator.clipboard.writeText(text);
+          // show temp check mark after copy
+          setCopyText('Copy\u2713');
+          setInterval(() => setCopyText('Copy'), 3000);
+        }}
+      >
+        {copyText}
+      </Hyperlink>
+      <Hyperlink
+        destination=""
+        target="_blank"
+        onClick={(e) => {
+          e.preventDefault();
+          // eslint-disable-next-line no-alert
+          alert(text);
+        }}
+      >
+        Show
+      </Hyperlink>
+    </>
+  );
+}
+
+CopyShowHyperlinks.propTypes = {
+  text: PropTypes.string.isRequired,
+};

--- a/src/users/v2/CopyShowHyperLinks.test.jsx
+++ b/src/users/v2/CopyShowHyperLinks.test.jsx
@@ -1,0 +1,46 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import CopyShowHyperlinks from './CopyShowHyperLinks';
+
+describe('Copy Show Hyperlinks', () => {
+  let props;
+  let wrapper;
+  const text = 'value1234567890';
+
+  beforeEach(() => {
+    props = {
+      text,
+    };
+    wrapper = mount(<CopyShowHyperlinks {...props} />);
+  });
+  it('Text Value', () => {
+    const copy = wrapper.find('a').at(0);
+    const show = wrapper.find('a').at(1);
+
+    expect(copy.text()).toEqual('Copy ');
+    expect(show.text()).toEqual('Show ');
+    expect(wrapper.text()).toEqual('Copy Show ');
+  });
+  it('Click Copy', () => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: () => {},
+      },
+    });
+    jest.spyOn(navigator.clipboard, 'writeText');
+    const copyLink = wrapper.find('a').at(0);
+    copyLink.simulate('click');
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(text);
+    expect(copyLink.text()).toEqual('Copy\u2713 ');
+    setInterval(() => expect(copyLink.text()).toEqual('Copy '), 3000);
+  });
+  it('Click Show', () => {
+    window.alert = jest.fn();
+    const showLink = wrapper.find('a').at(1);
+    showLink.simulate('click');
+
+    expect(window.alert).toHaveBeenCalledWith(text);
+    window.alert.mockClear();
+  });
+});

--- a/src/users/v2/SingleSignOnRecordCard.jsx
+++ b/src/users/v2/SingleSignOnRecordCard.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Card, Row, Col,
+} from '@edx/paragon';
+import TableV2 from '../../components/Table';
+import { formatDate } from '../../utils';
+import CopyShowHyperlinks from './CopyShowHyperLinks';
+
+export default function SingleSignOnRecordCard({ ssoRecord }) {
+  let data;
+  let columns;
+
+  if (ssoRecord != null) {
+    data = { ...ssoRecord.extraData };
+    columns = React.useMemo(
+      () => Object.keys(data)
+        .sort((a, b) => a > b)
+        .map((key) => ({
+          Header: key,
+          accessor: key,
+        })),
+    );
+
+    Object.keys(data).forEach((key) => {
+      const value = data[key].toString();
+      if (value.length > 14) {
+        data[key] = <CopyShowHyperlinks text={value} />;
+      }
+    });
+    data = React.useMemo(
+      () => data,
+    );
+  }
+
+  return (
+    ssoRecord ? (
+      <Card className="pt-2 px-3 mb-1 w-100">
+        <Card.Body className="p-0">
+          <Card.Title as="h3" className="btn-header mt-4">
+            {ssoRecord.provider}
+          </Card.Title>
+          <Row>
+            <Col>
+              <Card.Subtitle align="left" as="h4">
+                {ssoRecord.uid}
+              </Card.Subtitle>
+            </Col>
+            <Col>
+              <Card.Subtitle align="right" as="h4">
+                Last Modified: {formatDate(ssoRecord.modified)}
+              </Card.Subtitle>
+            </Col>
+          </Row>
+
+          <Card.Title as="h5" className="btn-header mt-4">
+            Additional Data
+          </Card.Title>
+
+          <TableV2
+            styleName="sso-table"
+            id="sso-data-new"
+            data={[data]}
+            columns={columns}
+          />
+        </Card.Body>
+      </Card>
+    ) : (
+      <></>
+    )
+  );
+}
+
+SingleSignOnRecordCard.propTypes = {
+  ssoRecord: PropTypes.shape({
+    provider: PropTypes.string,
+    uid: PropTypes.string,
+    modified: PropTypes.string,
+    extraData: PropTypes.object,
+  }).isRequired,
+};

--- a/src/users/v2/SingleSignOnRecordCard.test.jsx
+++ b/src/users/v2/SingleSignOnRecordCard.test.jsx
@@ -1,0 +1,72 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { camelCaseObject } from '@edx/frontend-platform';
+import { waitForComponentToPaint } from '../../setupTest';
+import ssoRecordsData from '../data/test/ssoRecords';
+import SingleSignOnRecordCard from './SingleSignOnRecordCard';
+import { formatDate } from '../../utils';
+
+describe.each(ssoRecordsData)('Single Sign On Record Card', (ssoRecordData) => {
+  // prepare data
+  const ssoRecordProp = camelCaseObject({
+    ...ssoRecordData,
+    extraData: JSON.parse(ssoRecordData.extraData),
+  });
+
+  let wrapper;
+  let props;
+
+  beforeEach(async () => {
+    props = {
+      ssoRecord: ssoRecordProp,
+    };
+    wrapper = mount(<SingleSignOnRecordCard {...props} />);
+    await waitForComponentToPaint(wrapper);
+  });
+
+  it('SSO props', () => {
+    const ssoRecord = wrapper.prop('ssoRecord');
+    expect(ssoRecord).toEqual(props.ssoRecord);
+  });
+
+  it('No SSO Data', async () => {
+    props = {
+      ssoRecord: null,
+    };
+    wrapper = mount(<SingleSignOnRecordCard {...props} />);
+    await waitForComponentToPaint(wrapper);
+
+    expect(wrapper.isEmptyRender()).toBeTruthy();
+  });
+
+  it('SSO Record', () => {
+    const provider = wrapper.find('h3.card-title');
+    const uid = wrapper.find('h4.card-subtitle').at(0);
+    const modified = wrapper.find('h4.card-subtitle').at(1);
+
+    expect(provider.text()).toEqual(ssoRecordProp.provider);
+    expect(uid.text()).toEqual(ssoRecordProp.uid);
+    expect(modified.text()).toEqual(`Last Modified: ${formatDate(ssoRecordProp.modified)}`);
+  });
+
+  it('SSO Record Additional Data', () => {
+    const dataTable = wrapper.find('Table#sso-data-new');
+    const dataHeader = dataTable.find('thead tr th');
+    const dataBody = dataTable.find('tbody tr td');
+
+    const { extraData } = ssoRecordProp;
+
+    expect(dataHeader).toHaveLength(Object.keys(extraData).length);
+    expect(dataBody).toHaveLength(Object.keys(extraData).length);
+
+    for (let i = 0; i < dataHeader.length; i++) {
+      const accesor = dataHeader.at(i).text();
+      const text = dataBody.at(i).text();
+
+      expect(accesor in extraData).toBeTruthy();
+      expect(text).toEqual(
+        extraData[accesor].toString().length > 14 ? 'Copy Show ' : extraData[accesor].toString(),
+      );
+    }
+  });
+});

--- a/src/users/v2/SingleSignOnRecords.jsx
+++ b/src/users/v2/SingleSignOnRecords.jsx
@@ -1,0 +1,54 @@
+import React, { useState, useEffect, useContext } from 'react';
+import { camelCaseObject } from '@edx/frontend-platform';
+import PropTypes from 'prop-types';
+import UserMessagesContext from '../../userMessages/UserMessagesContext';
+import { getSsoRecords } from '../data/api';
+import PageLoading from '../../components/common/PageLoading';
+import AlertList from '../../userMessages/AlertList';
+import SingleSignOnRecordCard from './SingleSignOnRecordCard';
+
+export default function SingleSignOnRecords({ username }) {
+  const [ssoRecords, setSsoRecords] = useState(null);
+  const { add, clear } = useContext(UserMessagesContext);
+  useEffect(() => {
+    clear('ssoRecords');
+    getSsoRecords(username).then((result) => {
+      const camelCaseResult = camelCaseObject(result);
+      if (camelCaseResult.errors) {
+        camelCaseResult.errors.forEach((error) => add(error));
+        setSsoRecords({});
+      } else {
+        setSsoRecords(camelCaseResult);
+      }
+    });
+  }, [username]);
+
+  return (
+    <section className="mb-3">
+      <AlertList topic="ssoRecords" className="mb-3" />
+      <h3 id="sso-title-header" className="ml-4">SSO Records</h3>
+      {/* eslint-disable-next-line no-nested-ternary */}
+      {ssoRecords ? (
+        ssoRecords.length ? (
+          <div id="sso-records-list" className="ml-3">
+            {ssoRecords.map(record => (
+              <>
+                <div className="row">
+                  <SingleSignOnRecordCard ssoRecord={record} />
+                </div>
+              </>
+            ))}
+          </div>
+        ) : (
+          <p className="ml-4">No SSO Records were Found.</p>
+        ))
+        : (
+          <PageLoading srMessage="Loading" />
+        )}
+    </section>
+  );
+}
+
+SingleSignOnRecords.propTypes = {
+  username: PropTypes.string.isRequired,
+};

--- a/src/users/v2/SingleSignOnRecords.test.jsx
+++ b/src/users/v2/SingleSignOnRecords.test.jsx
@@ -1,0 +1,77 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { waitForComponentToPaint } from '../../setupTest';
+import SingleSignOnRecords from './SingleSignOnRecords';
+import UserMessagesProvider from '../../userMessages/UserMessagesProvider';
+import ssoRecordsData from '../data/test/ssoRecords';
+
+import * as api from '../data/api';
+
+const SingleSignOnRecordsWrapper = (props) => (
+  <UserMessagesProvider>
+    <SingleSignOnRecords {...props} />
+  </UserMessagesProvider>
+);
+
+describe('Single Sign On Records', () => {
+  // prepare data
+  const ssoRecords = ssoRecordsData.map((entry) => ({
+    ...entry,
+    extraData: JSON.parse(entry.extraData),
+  }));
+
+  let wrapper;
+  const props = {
+    username: 'edX',
+  };
+
+  beforeEach(async () => {
+    jest.spyOn(api, 'getSsoRecords').mockImplementationOnce(() => Promise.resolve(ssoRecords));
+    wrapper = mount(<SingleSignOnRecordsWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+  });
+
+  it('SSO props', () => {
+    const username = wrapper.prop('username');
+    expect(username).toEqual(props.username);
+  });
+
+  it('SSO Data', () => {
+    const cardList = wrapper.find('Card');
+    expect(cardList).toHaveLength(ssoRecords.length);
+    expect(wrapper.find('h3#sso-title-header').text()).toEqual('SSO Records');
+  });
+
+  it('No SSO Data', async () => {
+    jest.spyOn(api, 'getSsoRecords').mockImplementationOnce(() => Promise.resolve([]));
+    wrapper = mount(<SingleSignOnRecordsWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+
+    expect(wrapper.find('h3#sso-title-header').text()).toEqual('SSO Records');
+    const cardList = wrapper.find('Card');
+    expect(cardList).toHaveLength(0);
+
+    const noRecordMessage = wrapper.find('p');
+    expect(noRecordMessage.text()).toEqual('No SSO Records were Found.');
+  });
+
+  it('Error fetching sso data', async () => {
+    const ssoErrors = {
+      errors: [
+        {
+          code: null,
+          dismissible: true,
+          text: 'Test Error',
+          type: 'danger',
+          topic: 'ssoRecords',
+        },
+      ],
+    };
+    jest.spyOn(api, 'getSsoRecords').mockImplementationOnce(() => Promise.resolve(ssoErrors));
+    wrapper = mount(<SingleSignOnRecordsWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+
+    const alert = wrapper.find('div.alert');
+    expect(alert.text()).toEqual(ssoErrors.errors[0].text);
+  });
+});

--- a/src/users/v2/UserPage.jsx
+++ b/src/users/v2/UserPage.jsx
@@ -15,6 +15,7 @@ import EntitlementsV2 from '../entitlements/v2/Entitlements';
 import UserSearch from '../UserSearch';
 import UserSummary from '../UserSummary';
 import EnrollmentsV2 from '../enrollments/v2/Enrollments';
+import SingleSignOnRecords from './SingleSignOnRecords';
 
 // Supports urls such as /users/?username={username} and /users/?email={email}
 export default function UserPage({ location }) {
@@ -158,6 +159,9 @@ export default function UserPage({ location }) {
           <UserSummary
             userData={data.user}
             changeHandler={handleUserSummaryChange}
+          />
+          <SingleSignOnRecords
+            username={data.user.username}
           />
           <Licenses
             userEmail={data.user.email}


### PR DESCRIPTION
## Description
This PR adds Card and List component for SSO Records as part of Support Tool Redesign.

- Uses new Table variant for rendering data Table
- width set to 100% per card as per design
- table width set to auto to avoid table consuming the entire card
- Single card per row

## Linked Ticket
[PROD-2459](https://openedx.atlassian.net/browse/PROD-2459)
[PROD-2460](https://openedx.atlassian.net/browse/PROD-2460)

## Screenshots
<img width="1217" alt="Screenshot 2021-09-14 at 9 48 45 PM" src="https://user-images.githubusercontent.com/40599381/133300052-a9616542-3b9e-4421-9eed-1f6955b1249b.png">

<img width="1664" alt="Screenshot 2021-09-14 at 10 16 31 PM" src="https://user-images.githubusercontent.com/40599381/133303720-e12191e4-beca-4f7a-993c-00e28c10c36a.png">




## How to test locally:
1. Add List Component 
```js
      <SingleSignOnRecordsList
        username={data.user.username}
      />
```
2. Add dummy data here: `/admin/social_django/usersocialauth/`
3. Populate extra data (you may add response from test data file) 

## TODO
- [x] add instructions to test components locally 
- [x] get initial review
- [x] write component test
