### PR TITLE
feat: add entitlementV2 component

### DIFF
--- a/src/components/Table.jsx
+++ b/src/components/Table.jsx
@@ -85,7 +85,7 @@ export default function Table({
 
 Table.propTypes = {
   columns: PropTypes.arrayOf(PropTypes.shape({
-    header: PropTypes.string.isRequired,
+    Header: PropTypes.string.isRequired,
     accessor: PropTypes.string.isRequired,
     sortable: PropTypes.bool,
   })).isRequired,

--- a/src/users/entitlements/v2/Entitlements.jsx
+++ b/src/users/entitlements/v2/Entitlements.jsx
@@ -1,0 +1,302 @@
+import React, {
+  useMemo, useState, useCallback, useRef, useLayoutEffect, useContext, useEffect,
+} from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  Button, TransitionReplace, Dropdown, Hyperlink,
+} from '@edx/paragon';
+import { camelCaseObject, getConfig } from '@edx/frontend-platform';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faMinus, faPlus } from '@fortawesome/free-solid-svg-icons';
+import EntitlementForm from '../EntitlementForm';
+import { CREATE, REISSUE, EXPIRE } from '../EntitlementActions';
+import PageLoading from '../../../components/common/PageLoading';
+import CourseSummary from '../../courseSummary/CourseSummary';
+import TableV2 from '../../../components/Table';
+import { getEntitlements } from '../../data/api';
+import UserMessagesContext from '../../../userMessages/UserMessagesContext';
+import { formatDate } from '../../../utils';
+import AlertList from '../../../userMessages/AlertList';
+
+export default function Entitlements({
+  changeHandler, user,
+}) {
+  const { add, clear } = useContext(UserMessagesContext);
+  const [formType, setFormType] = useState(null);
+  const [userEntitlement, setUserEntitlement] = useState(undefined);
+  const [courseSummaryUUID, setCourseSummaryUUID] = useState(null);
+  const [entitlementData, setEntitlementData] = useState(null);
+  const formRef = useRef(null);
+  const summaryRef = useRef(null);
+
+  useEffect(() => {
+    clear('entitlements');
+    getEntitlements(user).then((result) => {
+      const camelCaseResult = camelCaseObject(result);
+      if (camelCaseResult.errors) {
+        camelCaseResult.errors.forEach(error => add(error));
+        setEntitlementData({ results: [] });
+      } else {
+        setEntitlementData(camelCaseResult);
+      }
+    });
+  }, [user]);
+
+  const tableData = useMemo(() => {
+    if (entitlementData === null) {
+      return [];
+    }
+    return entitlementData.results.map(entitlement => ({
+      expander: entitlement.supportDetails.map(supportDetail => ({
+        action: supportDetail.action,
+        comments: supportDetail.comments,
+        actionCreated: formatDate(supportDetail.created),
+        supportUser: supportDetail.supportUser,
+        unenrolledRun: supportDetail.unenrolledRun,
+      })),
+      courseUuid: entitlement.courseUuid,
+      courseSummary: (
+        <Hyperlink
+          destination=""
+          target="_blank"
+          onClick={(event) => {
+            event.preventDefault();
+            setFormType(null);
+            setUserEntitlement(undefined);
+            setCourseSummaryUUID(entitlement.courseUuid);
+          }}
+        >
+          See Details
+        </Hyperlink>
+      ),
+      enrollmentCourseRun: (entitlement.enrollmentCourseRun ? (
+        <a
+          href={`${getConfig().LMS_BASE_URL}/courses/${entitlement.enrollmentCourseRun}`}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          {entitlement.enrollmentCourseRun}
+        </a>
+      ) : 'Course Run Not Selected'),
+      expiredAt: formatDate(entitlement.expiredAt),
+      created: formatDate(entitlement.created),
+      modified: formatDate(entitlement.modified),
+      orderNumber: (
+        <a
+          href={`${getConfig().ECOMMERCE_BASE_URL}/dashboard/orders/${entitlement.orderNumber}/`}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          {entitlement.orderNumber}
+        </a>
+      ),
+      mode: entitlement.mode,
+      actions: (
+        <Dropdown>
+          <Dropdown.Toggle variant="sm">
+            Actions
+          </Dropdown.Toggle>
+          <Dropdown.Menu>
+            <Dropdown.Item
+              onClick={() => {
+                setCourseSummaryUUID(null);
+                setUserEntitlement(entitlement);
+                setFormType(REISSUE);
+              }}
+              disabled={Boolean(!entitlement.enrollmentCourseRun)}
+              className="small"
+            >
+              Reissue
+            </Dropdown.Item>
+            <Dropdown.Item
+              onClick={() => {
+                setCourseSummaryUUID(null);
+                setUserEntitlement(entitlement);
+                setFormType(EXPIRE);
+              }}
+              disabled={Boolean(entitlement.expiredAt)}
+              className="small"
+            >
+              Expire
+            </Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>
+
+      ),
+    }));
+  }, [entitlementData]);
+
+  useLayoutEffect(() => {
+    if (formType != null) {
+      formRef.current.focus();
+    }
+  });
+
+  const expandAllRowsHandler = ({ getToggleAllRowsExpandedProps }) => (
+    <a {...getToggleAllRowsExpandedProps()} className="link-primary">
+      Expand All
+    </a>
+  );
+  expandAllRowsHandler.propTypes = {
+    getToggleAllRowsExpandedProps: PropTypes.func.isRequired,
+  };
+
+  const rowExpandHandler = ({ row }) => (
+    // We can use the getToggleRowExpandedProps prop-getter
+    // to build the expander.
+    <div className="text-center">
+      <span {...row.getToggleRowExpandedProps()}>
+        {row.isExpanded ? (
+          <FontAwesomeIcon icon={faMinus} />
+        ) : <FontAwesomeIcon icon={faPlus} />}
+      </span>
+    </div>
+  );
+
+  rowExpandHandler.propTypes = {
+    row: PropTypes.shape({
+      isExpanded: PropTypes.bool,
+      getToggleRowExpandedProps: PropTypes.func,
+    }).isRequired,
+  };
+
+  const columns = React.useMemo(
+    () => [
+      {
+        // Make an expander column
+        Header: expandAllRowsHandler,
+        id: 'expander',
+        Cell: rowExpandHandler, // Use Cell to render an expander for each row.
+      },
+      {
+        Header: 'Course UUID', accessor: 'courseUuid', sortable: true,
+      },
+      {
+        Header: 'Course Run ID', accessor: 'enrollmentCourseRun', sortable: true,
+      },
+      {
+        Header: 'Course Summary', accessor: 'courseSummary',
+      },
+      {
+        Header: 'Expiration Date', accessor: 'expiredAt', sortable: true,
+      },
+      {
+        Header: 'Date Created', accessor: 'created', sortable: true,
+      },
+      {
+        Header: 'Date Modified', accessor: 'modified', sortable: true,
+      },
+      {
+        Header: 'Order', accessor: 'orderNumber', sortable: true,
+      },
+      {
+        Header: 'Mode', accessor: 'mode', sortable: true,
+      },
+      {
+        Header: 'Actions', accessor: 'actions',
+      },
+    ],
+    [],
+  );
+
+  const supportDetailsColumn = React.useMemo(
+    () => [
+      {
+        Header: 'Action', accessor: 'action', sortable: true,
+      },
+      {
+        Header: 'Comments', accessor: 'comments', sortable: true,
+      },
+      {
+        Header: 'Action Creation Timestamp', accessor: 'actionCreated', sortable: true,
+      },
+      {
+        Header: 'Support User', accessor: 'supportUser', sortable: true,
+      },
+      {
+        Header: 'Unenrolled Run', accessor: 'unenrolledRun', sortable: true,
+      },
+    ],
+    [],
+  );
+
+  const renderRowSubComponent = useCallback(
+    ({ row }) => (
+      <TableV2
+        // eslint-disable-next-line react/prop-types
+        data={row.original.expander}
+        columns={supportDetailsColumn}
+        styleName="custom-expander-table"
+      />
+    ),
+    [],
+  );
+
+  return (
+    <section className="mb-3">
+      {!formType && (
+        <div className="row">
+          <h3 className="ml-4 mr-auto">Entitlements ({tableData.length})</h3>
+          <Button
+            id="create-enrollment-button"
+            type="button"
+            variant="outline-primary mr-4"
+            size="sm"
+            onClick={() => {
+              setCourseSummaryUUID(null);
+              setUserEntitlement(undefined);
+              setFormType(CREATE);
+            }}
+          >
+            Create New Entitlement
+          </Button>
+        </div>
+      )}
+
+      {!entitlementData
+        ? <PageLoading srMessage="Loading" />
+        : (
+          <TableV2
+            columns={columns}
+            data={tableData}
+            renderRowSubComponent={renderRowSubComponent}
+            styleName="custom-table"
+          />
+        )}
+
+      <AlertList topic="entitlements" className="mb-3" />
+      <TransitionReplace>
+        {formType !== null ? (
+          <EntitlementForm
+            key="entitlement-form"
+            user={user}
+            entitlement={userEntitlement}
+            formType={formType}
+            changeHandler={changeHandler}
+            submitHandler={() => { }}
+            closeHandler={() => setFormType(null)}
+            forwardedRef={formRef}
+          />
+        ) : (<React.Fragment key="nothing" />)}
+      </TransitionReplace>
+      <TransitionReplace>
+        {courseSummaryUUID !== null ? (
+          <CourseSummary
+            key="course-summary"
+            courseUUID={courseSummaryUUID}
+            clearHandler={() => {
+              setCourseSummaryUUID(null);
+            }}
+            forwardedRef={summaryRef}
+          />
+        ) : (<React.Fragment key="nothing" />)}
+      </TransitionReplace>
+    </section>
+  );
+}
+
+Entitlements.propTypes = {
+  changeHandler: PropTypes.func.isRequired,
+  user: PropTypes.string.isRequired,
+};

--- a/src/users/entitlements/v2/Entitlements.test.jsx
+++ b/src/users/entitlements/v2/Entitlements.test.jsx
@@ -1,0 +1,187 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { waitForComponentToPaint } from '../../../setupTest';
+import EntitlementsV2 from './Entitlements';
+import { entitlementsData, entitlementsErrors } from '../../data/test/entitlements';
+import CourseSummaryData from '../../data/test/courseSummary';
+import UserMessagesProvider from '../../../userMessages/UserMessagesProvider';
+import * as api from '../../data/api';
+
+const EntitlementsPageWrapper = (props) => (
+  <UserMessagesProvider>
+    <EntitlementsV2 {...props} />
+  </UserMessagesProvider>
+);
+
+describe('Entitlements V2 Listing', () => {
+  let wrapper;
+  const props = {
+    user: 'edX',
+    changeHandler: jest.fn(() => {}),
+  };
+
+  beforeEach(async () => {
+    jest.spyOn(api, 'getEntitlements').mockImplementationOnce(() => Promise.resolve(entitlementsData));
+    wrapper = mount(<EntitlementsPageWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('Create New Entitlement button rendered by default', () => {
+    const entitlementButton = wrapper.find('button.btn-outline-primary').first();
+    expect(entitlementButton.text()).toEqual('Create New Entitlement');
+    expect(entitlementButton.prop('disabled')).toBeFalsy();
+    entitlementButton.simulate('click');
+
+    const createEntitlementForm = wrapper.find('CreateEntitlementForm');
+    expect(createEntitlementForm.html()).toEqual(expect.stringContaining('Create Entitlement'));
+    createEntitlementForm.find('button.btn-outline-secondary').simulate('click');
+    expect(wrapper.find('CreateEntitlementForm')).toEqual({});
+  });
+
+  it('entitlements data', () => {
+    const componentHeader = wrapper.find('h3');
+    expect(componentHeader.text()).toEqual('Entitlements (2)');
+  });
+
+  it('No entitlements data', async () => {
+    jest.spyOn(api, 'getEntitlements').mockImplementationOnce(() => Promise.resolve({ results: [] }));
+    wrapper = mount(<EntitlementsPageWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+    const componentHeader = wrapper.find('h3');
+    expect(componentHeader.text()).toEqual('Entitlements (0)');
+  });
+
+  it('Error fetching entitlements', async () => {
+    jest.spyOn(api, 'getEntitlements').mockImplementationOnce(() => Promise.resolve(entitlementsErrors));
+    wrapper = mount(<EntitlementsPageWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+
+    const alert = wrapper.find('div.alert');
+    expect(alert.text()).toEqual(entitlementsErrors.errors[0].text);
+  });
+
+  it('Support Details data', () => {
+    let expandable = wrapper.find('table tbody tr').at(0).find('td div span').at(0);
+    expect(expandable.html()).toContain('fa-plus');
+    expandable.simulate('click');
+
+    expandable = wrapper.find('table tbody tr').at(0).find('td div span').at(0);
+    expect(expandable.html()).toContain('fa-minus');
+
+    const extraTable = wrapper.find('table tbody tr').at(1).find('table');
+    expect(extraTable.find('thead tr th').length).toEqual(5);
+    expect(extraTable.find('tbody tr').length).toEqual(2);
+
+    expandable.simulate('click');
+
+    expandable = wrapper.find('table tbody tr').at(0).find('td div span').at(0);
+    expect(expandable.html()).toContain('fa-plus');
+  });
+
+  describe('Reissue entitlement button', () => {
+    it('Enabled Reissue entitlement button', () => {
+      // We're only checking row 0 of the table since the Reissue button is not disabled
+      let dataRow = wrapper.find('table tbody tr').at(0);
+      dataRow.find('.dropdown button').simulate('click');
+      dataRow = wrapper.find('table tbody tr').at(0);
+      const expireOption = dataRow.find('.dropdown-menu.show a').at(0);
+      expect(expireOption.text()).toEqual('Reissue');
+      expect(expireOption.html()).not.toEqual(expect.stringContaining('disabled'));
+      expireOption.simulate('click');
+
+      const expireEntitlementForm = wrapper.find('ReissueEntitlementForm');
+      expect(expireEntitlementForm.html()).toEqual(expect.stringContaining('Reissue Entitlement'));
+      expireEntitlementForm.find('button.btn-outline-secondary').simulate('click');
+      expect(wrapper.find('ExpireEntitlementForm')).toEqual({});
+    });
+
+    it('Disabled Reissue entitlement button', () => {
+      // We're only checking row 1 of the table since it has the button Reissue Button disabled
+      let dataRow = wrapper.find('table tbody tr').at(1);
+      dataRow.find('.dropdown button').simulate('click');
+      dataRow = wrapper.find('table tbody tr').at(1);
+      const expireOption = dataRow.find('.dropdown-menu.show a').at(0);
+      expect(expireOption.text()).toEqual('Reissue');
+      expect(expireOption.html()).toEqual(expect.stringContaining('disabled'));
+    });
+  });
+
+  describe('Expire Entitlement button', () => {
+    it('Disabled Expire entitlement button', () => {
+      // We're only checking row 0 of the table since it has the button Expire Button disabled
+      let dataRow = wrapper.find('table tbody tr').at(0);
+      dataRow.find('.dropdown button').simulate('click');
+      dataRow = wrapper.find('table tbody tr').at(0);
+      const expireOption = dataRow.find('.dropdown-menu.show a').at(1);
+      expect(expireOption.text()).toEqual('Expire');
+      expect(expireOption.html()).toEqual(expect.stringContaining('disabled'));
+    });
+
+    it('Enabled Expire entitlement button', () => {
+      // We're only checking row 1 of the table since the expire button is not disabled
+      let dataRow = wrapper.find('table tbody tr').at(1);
+      dataRow.find('.dropdown button').simulate('click');
+      dataRow = wrapper.find('table tbody tr').at(1);
+      const expireOption = dataRow.find('.dropdown-menu.show a').at(1);
+      expect(expireOption.text()).toEqual('Expire');
+      expect(expireOption.html()).not.toEqual(expect.stringContaining('disabled'));
+      expireOption.simulate('click');
+
+      const expireEntitlementForm = wrapper.find('ExpireEntitlementForm');
+      expect(expireEntitlementForm.html()).toEqual(expect.stringContaining('Expire Entitlement'));
+      expireEntitlementForm.find('button.btn-outline-secondary').simulate('click');
+      expect(wrapper.find('ExpireEntitlementForm')).toEqual({});
+    });
+  });
+
+  describe('Course Summary button', () => {
+    it('Successful course summary fetch', async () => {
+      const apiMock = jest.spyOn(api, 'getCourseData').mockImplementationOnce(() => Promise.resolve(CourseSummaryData.courseData));
+
+      const dataRow = wrapper.find('table tbody tr').at(0);
+      const courseUuidButton = dataRow.find('td').at(3).find('a');
+      courseUuidButton.simulate('click');
+
+      expect(apiMock).toHaveBeenCalledTimes(1);
+      await waitForComponentToPaint(wrapper);
+
+      let courseSummary = wrapper.find('CourseSummary');
+      expect(courseSummary).not.toBeUndefined();
+      expect(courseSummary.html()).toEqual(expect.stringContaining(CourseSummaryData.courseData.uuid));
+      courseSummary.find('button.btn-outline-secondary').simulate('click');
+      courseSummary = wrapper.find('CourseSummary');
+      expect(courseSummary).toEqual({});
+      apiMock.mockReset();
+    });
+
+    it('Unsuccessful course summary fetch', async () => {
+      const apiMock = jest.spyOn(api, 'getCourseData').mockImplementationOnce(() => Promise.resolve({
+        errors: [
+          {
+            code: null,
+            dismissible: true,
+            text: "We couldn't find summary data for this Course.",
+            type: 'error',
+            topic: 'course-summary',
+          },
+        ],
+      }));
+
+      const dataRow = wrapper.find('table tbody tr').at(0);
+      const courseUuidButton = dataRow.find('td').at(3).find('a');
+      courseUuidButton.simulate('click');
+
+      expect(apiMock).toHaveBeenCalledTimes(1);
+      await waitForComponentToPaint(wrapper);
+
+      const alert = wrapper.find('CourseSummary').find('.alert');
+      expect(alert.text()).toEqual("We couldn't find summary data for this Course.");
+      apiMock.mockReset();
+    });
+  });
+});

--- a/src/users/v2/UserPage.jsx
+++ b/src/users/v2/UserPage.jsx
@@ -11,7 +11,7 @@ import UserMessagesContext from '../../userMessages/UserMessagesContext';
 import { isEmail, isValidUsername } from '../../utils/index';
 import { getAllUserData } from '../data/api';
 import Licenses from '../licenses/Licenses';
-import Entitlements from '../entitlements/Entitlements';
+import EntitlementsV2 from '../entitlements/v2/Entitlements';
 import UserSearch from '../UserSearch';
 import UserSummary from '../UserSummary';
 import EnrollmentsV2 from '../enrollments/v2/Enrollments';
@@ -163,7 +163,7 @@ export default function UserPage({ location }) {
             userEmail={data.user.email}
             expanded={showLicenses}
           />
-          <Entitlements
+          <EntitlementsV2
             user={data.user.username}
             changeHandler={handleEntitlementsChange}
             expanded={showEntitlements}


### PR DESCRIPTION
[PROD-2463](https://openedx.atlassian.net/browse/PROD-2463)

This PR adds a new design for Entitlement Component while keeping the older components. This v2 component uses the same Table component that we used in Enrollment v2 component.

Entitlement with Expanded Row:
<img width="1626" alt="Screenshot 2021-09-09 at 11 32 36 PM" src="https://user-images.githubusercontent.com/52413434/132742993-0af16a5a-cbb9-4f93-8c7f-0bd445c92c5a.png">

Entitlement with Disabled Reissue and Enabled Expire actions:
<img width="1646" alt="Screenshot 2021-09-09 at 11 33 06 PM" src="https://user-images.githubusercontent.com/52413434/132743081-32aa0f2a-f545-47a9-a1eb-5ea007e50323.png">
