### PR TITLE
feat: add enrollment form v2

### DIFF
--- a/src/components/Table.jsx
+++ b/src/components/Table.jsx
@@ -49,7 +49,7 @@ export default function Table({
           {rows.map((row) => {
             prepareRow(row);
             return (
-              <React.Fragment {...row.getRowProps()}>
+              <React.Fragment {...row.key}>
                 <tr>
                   {row.cells.map(cell => (
                     <td {...cell.getCellProps()}>{cell.render('Cell')}</td>

--- a/src/users/data/test/enrollments.js
+++ b/src/users/data/test/enrollments.js
@@ -25,6 +25,7 @@ export const changeEnrollmentFormData = {
 
 export const createEnrollmentFormData = {
   user: 'edX',
+  changeHandler: jest.fn(() => {}),
   closeHandler: jest.fn(() => {}),
 };
 

--- a/src/users/enrollments/constants.js
+++ b/src/users/enrollments/constants.js
@@ -2,7 +2,7 @@ export const CHANGE = 'change';
 export const CREATE = 'create';
 
 export const modes = [
-  { label: '--', value: '' },
+  { label: 'Mode', value: '', disabled: true },
   { label: 'Honor', value: 'honor' },
   { label: 'Professional', value: 'professional' },
   { label: 'Verified', value: 'verified' },
@@ -14,7 +14,7 @@ export const modes = [
 ];
 
 export const reasons = [
-  { label: '--', value: '' },
+  { label: 'Reason', value: '', disabled: true },
   { label: 'Financial Assistance', value: 'Financial Assistance' },
   { label: 'Upset Learner', value: 'Upset Learner' },
   { label: 'Teaching Assistant', value: 'Teaching Assistant' },

--- a/src/users/enrollments/v2/ChangeEnrollmentForm.jsx
+++ b/src/users/enrollments/v2/ChangeEnrollmentForm.jsx
@@ -1,0 +1,184 @@
+import React, { useCallback, useState, useContext } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button, Input, InputSelect, Modal,
+} from '@edx/paragon';
+import AlertList from '../../../userMessages/AlertList';
+import { patchEnrollment } from '../../data/api';
+import UserMessagesContext from '../../../userMessages/UserMessagesContext';
+import { reasons } from '../constants';
+
+export default function ChangeEnrollmentForm({
+  user,
+  enrollment,
+  closeHandler,
+  forwardedRef,
+  changeHandler,
+}) {
+  const [mode, setMode] = useState(enrollment.mode);
+  const [reason, setReason] = useState('');
+  const [comments, setComments] = useState('');
+  const [hideOnSubmit, setHideOnSubmit] = useState(false);
+  const [modalIsOpen, setModalIsOpen] = useState(true);
+  const { add, clear } = useContext(UserMessagesContext);
+
+  reasons[0] = { label: 'Reason for Change', value: '', disabled: true };
+
+  const getModes = () => {
+    const modeList = [];
+    modeList.push({ label: 'New Mode', value: '', disabled: true });
+    enrollment.courseModes.map(enrollmentMode => (
+      modeList.push(enrollmentMode.slug)
+    ));
+    if (!modeList.some(enrollmentMode => enrollmentMode === enrollment.mode)) {
+      modeList.push(enrollment.mode);
+    }
+    return modeList;
+  };
+
+  const submit = useCallback(() => {
+    clear('changeEnrollments');
+    const sendReason = (reason === 'other') ? comments : reason;
+    patchEnrollment({
+      user,
+      courseID: enrollment.courseId,
+      oldMode: enrollment.mode,
+      newMode: mode,
+      reason: sendReason,
+    }).then((result) => {
+      if (result.errors !== undefined) {
+        result.errors.forEach(error => add(error));
+      } else {
+        const successMessage = {
+          code: null,
+          dismissible: true,
+          text: 'Enrollment successfully changed.',
+          type: 'success',
+          topic: 'changeEnrollments',
+        };
+        setHideOnSubmit(true);
+        add(successMessage);
+        changeHandler();
+      }
+    });
+  });
+
+  const changeEnrollmentForm = (
+    <form>
+      <AlertList topic="changeEnrollments" className="mb-3" />
+      <div className="form-group">
+
+        <div className="row small">
+          <div className="col-sm-6">
+            Course Run ID
+          </div>
+          <div className="col-sm-6">
+            {enrollment.courseId}
+          </div>
+        </div>
+        <hr />
+
+        <div className="row small">
+          <div className="col-sm-6">
+            Mode
+          </div>
+          <div className="col-sm-6">
+            {enrollment.mode}
+          </div>
+        </div>
+        <hr />
+
+        <div className="row small">
+          <div className="col-sm-6">
+            Active
+          </div>
+          <div className="col-sm-6">
+            {enrollment.isActive.toString()}
+          </div>
+        </div>
+        <hr />
+
+        <InputSelect
+          className="mb-n3"
+          type="select"
+          options={getModes()}
+          value=""
+          id="mode"
+          name="mode"
+          onChange={(event) => setMode(event)}
+          disabled={hideOnSubmit}
+        />
+        <InputSelect
+          className="mb-4"
+          type="select"
+          options={reasons}
+          id="reason"
+          name="reason"
+          value=""
+          onChange={(event) => setReason(event)}
+          disabled={hideOnSubmit}
+        />
+        <Input
+          placeholder="Explanation"
+          type="textarea"
+          id="comments"
+          name="comments"
+          defaultValue=""
+          onChange={(event) => setComments(event.target.value)}
+          disabled={hideOnSubmit}
+          ref={forwardedRef}
+        />
+      </div>
+    </form>
+  );
+
+  return (
+    <Modal
+      open={modalIsOpen}
+      onClose={() => {
+        setModalIsOpen(false);
+        closeHandler(false);
+        clear('changeEnrollments');
+      }}
+      title="Change Enrollment"
+      id="change-enrollment"
+      dialogClassName="modal-lg"
+      body={(
+        changeEnrollmentForm
+      )}
+      buttons={[
+        <Button
+          variant="primary"
+          disabled={!(mode && reason)}
+          className="mr-3"
+          onClick={submit}
+          hidden={hideOnSubmit}
+        >
+          Submit
+        </Button>,
+      ]}
+    />
+  );
+}
+
+ChangeEnrollmentForm.propTypes = {
+  enrollment: PropTypes.shape({
+    courseId: PropTypes.string.isRequired,
+    mode: PropTypes.string.isRequired,
+    isActive: PropTypes.bool.isRequired,
+    courseModes: PropTypes.array,
+  }),
+  user: PropTypes.string.isRequired,
+  closeHandler: PropTypes.func.isRequired,
+  changeHandler: PropTypes.func.isRequired,
+  forwardedRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+};
+
+ChangeEnrollmentForm.defaultProps = {
+  enrollment: {
+    courseId: '',
+    mode: '',
+    isActive: false,
+  },
+  forwardedRef: null,
+};

--- a/src/users/enrollments/v2/ChangeEnrollmentForm.test.jsx
+++ b/src/users/enrollments/v2/ChangeEnrollmentForm.test.jsx
@@ -1,0 +1,87 @@
+import { mount } from 'enzyme';
+import { waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { waitForComponentToPaint } from '../../../setupTest';
+import ChangeEnrollmentForm from './ChangeEnrollmentForm';
+import { changeEnrollmentFormData } from '../../data/test/enrollments';
+import UserMessagesProvider from '../../../userMessages/UserMessagesProvider';
+import * as api from '../../data/api';
+
+const EnrollmentFormWrapper = (props) => (
+  <UserMessagesProvider>
+    <ChangeEnrollmentForm {...props} />
+  </UserMessagesProvider>
+);
+
+describe('Enrollment Change form', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(<EnrollmentFormWrapper {...changeEnrollmentFormData} />);
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('Default form rendering', () => {
+    let changeFormModal = wrapper.find('Modal#change-enrollment');
+    expect(changeFormModal.prop('open')).toEqual(true);
+    const modeSelectionDropdown = wrapper.find('select#mode');
+    const modeChangeReasonDropdown = wrapper.find('select#reason');
+    const commentsTextarea = wrapper.find('textarea#comments');
+    expect(modeSelectionDropdown.find('option')).toHaveLength(3);
+    expect(modeChangeReasonDropdown.find('option')).toHaveLength(5);
+    expect(commentsTextarea.text()).toEqual('');
+
+    wrapper.find('button.btn-link').simulate('click');
+    changeFormModal = wrapper.find('Modal#change-enrollment');
+    expect(changeFormModal.prop('open')).toEqual(false);
+  });
+
+  describe('Form submission', () => {
+    it('Successful form submission', async () => {
+      const apiMock = jest.spyOn(api, 'patchEnrollment').mockImplementationOnce(() => Promise.resolve({}));
+      expect(apiMock).toHaveBeenCalledTimes(0);
+
+      wrapper.find('select#reason').simulate('change', { target: { value: 'Other' } });
+      wrapper.find('select#mode').simulate('change', { target: { value: 'verified' } });
+      wrapper.find('textarea#comments').simulate('change', { target: { value: 'test mode change' } });
+      wrapper.find('button.btn-primary').simulate('click');
+      expect(apiMock).toHaveBeenCalledTimes(1);
+
+      // The mock call count does not update on time for expect call, therefore, waitFor is used to give enough time
+      // for the call count to update. However, it is possible this might turn out to be flaky.
+      await waitFor(() => expect(changeEnrollmentFormData.changeHandler).toHaveBeenCalledTimes(1));
+      apiMock.mockReset();
+      const submitButton = wrapper.find('button.btn-primary');
+      expect(submitButton).toEqual({});
+    });
+
+    it('Unsuccessful form submission', async () => {
+      const apiMock = jest.spyOn(api, 'patchEnrollment').mockImplementationOnce(() => Promise.resolve({
+        errors: [
+          {
+            code: null,
+            dismissible: true,
+            text: 'Error changing enrollment',
+            type: 'danger',
+            topic: 'changeEnrollments',
+          },
+        ],
+      }));
+      expect(apiMock).toHaveBeenCalledTimes(0);
+
+      wrapper.find('select#reason').simulate('change', { target: { value: 'Other' } });
+
+      wrapper.find('select#mode').simulate('change', { target: { value: 'verified' } });
+      wrapper.find('textarea#comments').simulate('change', { target: { value: 'test mode change' } });
+      wrapper.find('button.btn-primary').simulate('click');
+      await waitForComponentToPaint(wrapper);
+
+      expect(apiMock).toHaveBeenCalledTimes(1);
+      expect(wrapper.find('.alert').text()).toEqual('Error changing enrollment');
+    });
+  });
+});

--- a/src/users/enrollments/v2/CreateEnrollmentForm.jsx
+++ b/src/users/enrollments/v2/CreateEnrollmentForm.jsx
@@ -1,0 +1,129 @@
+import React, { useCallback, useState, useContext } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button, Input, InputSelect, Modal,
+} from '@edx/paragon';
+
+import AlertList from '../../../userMessages/AlertList';
+import { postEnrollment } from '../../data/api';
+import UserMessagesContext from '../../../userMessages/UserMessagesContext';
+import { reasons, modes } from '../constants';
+
+export default function CreateEnrollmentForm({
+  user,
+  closeHandler,
+  forwardedRef,
+  changeHandler,
+}) {
+  const [courseID, setCourseID] = useState('');
+  const [mode, setMode] = useState('');
+  const [reason, setReason] = useState('');
+  const [comments, setComments] = useState('');
+  const [modalIsOpen, setModalIsOpen] = useState(true);
+  const { add, clear } = useContext(UserMessagesContext);
+
+  const submit = useCallback(() => {
+    clear('createEnrollments');
+    const sendReason = (reason === 'other') ? comments : reason;
+    postEnrollment({
+      user,
+      courseID,
+      mode,
+      reason: sendReason,
+    }).then((result) => {
+      if (result.errors !== undefined) {
+        result.errors.forEach(error => add(error));
+      } else {
+        const successMessage = {
+          code: null,
+          dismissible: true,
+          text: 'New Enrollment successfully created.',
+          type: 'success',
+          topic: 'createEnrollments',
+        };
+        add(successMessage);
+        changeHandler();
+      }
+    });
+  });
+
+  const createEnrollmentForm = (
+    <form>
+      <AlertList topic="createEnrollments" className="mb-3" />
+      <div className="form-group">
+        <Input
+          type="text"
+          id="courseID"
+          name="courseID"
+          placeholder="Course Run ID"
+          onChange={(event) => setCourseID(event.target.value)}
+          ref={forwardedRef}
+        />
+        <InputSelect
+          className="mb-n3 small"
+          type="select"
+          options={modes}
+          id="mode"
+          name="mode"
+          value=""
+          onChange={(event) => setMode(event)}
+        />
+        <InputSelect
+          className="mb-4 small"
+          type="select"
+          options={reasons}
+          id="reason"
+          name="reason"
+          value=""
+          onChange={(event) => setReason(event)}
+        />
+        <Input
+          placeholder="Explanation"
+          type="textarea"
+          id="comments"
+          name="comments"
+          defaultValue=""
+          onChange={(event) => setComments(event.target.value)}
+        />
+      </div>
+    </form>
+  );
+
+  return (
+    <Modal
+      open={modalIsOpen}
+      onClose={() => {
+        closeHandler(false);
+        setModalIsOpen(false);
+        clear('createEnrollments');
+      }}
+      title="Create New Enrollment"
+      id="create-enrollment"
+      dialogClassName="modal-lg"
+      body={(
+        createEnrollmentForm
+      )}
+      buttons={[
+        <Button
+          variant="primary"
+          disabled={!(courseID && reason)}
+          className="mr-3"
+          onClick={submit}
+        >
+          Submit
+        </Button>,
+      ]}
+    />
+  );
+}
+
+CreateEnrollmentForm.propTypes = {
+  user: PropTypes.string.isRequired,
+  closeHandler: PropTypes.func.isRequired,
+  changeHandler: PropTypes.func.isRequired,
+  forwardedRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+};
+
+CreateEnrollmentForm.defaultProps = {
+  forwardedRef: null,
+};

--- a/src/users/enrollments/v2/CreateEnrollmentForm.test.jsx
+++ b/src/users/enrollments/v2/CreateEnrollmentForm.test.jsx
@@ -1,0 +1,84 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import { waitForComponentToPaint } from '../../../setupTest';
+import CreateEnrollmentForm from './CreateEnrollmentForm';
+import { createEnrollmentFormData } from '../../data/test/enrollments';
+import UserMessagesProvider from '../../../userMessages/UserMessagesProvider';
+import * as api from '../../data/api';
+
+const EnrollmentFormWrapper = (props) => (
+  <UserMessagesProvider>
+    <CreateEnrollmentForm {...props} />
+  </UserMessagesProvider>
+);
+
+describe('Enrollment Create form', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(<EnrollmentFormWrapper {...createEnrollmentFormData} />);
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('Default form rendering', () => {
+    let createFormModal = wrapper.find('Modal#create-enrollment');
+    expect(createFormModal.prop('open')).toEqual(true);
+    const modeSelectionDropdown = wrapper.find('select#mode');
+    const modeChangeReasonDropdown = wrapper.find('select#reason');
+    const commentsTextarea = wrapper.find('textarea#comments');
+    expect(modeSelectionDropdown.find('option')).toHaveLength(9);
+    expect(modeChangeReasonDropdown.find('option')).toHaveLength(5);
+    expect(commentsTextarea.text()).toEqual('');
+
+    wrapper.find('button.btn-link').simulate('click');
+    createFormModal = wrapper.find('Modal#create-enrollment');
+    expect(createFormModal.prop('open')).toEqual(false);
+  });
+
+  describe('Form submission', () => {
+    it('Successful form submission', async () => {
+      const apiMock = jest.spyOn(api, 'postEnrollment').mockImplementationOnce(() => Promise.resolve({}));
+      expect(apiMock).toHaveBeenCalledTimes(0);
+
+      wrapper.find('input#courseID').simulate('change', { target: { value: 'course-v1:testX+test123+2030' } });
+      wrapper.find('select#reason').simulate('change', { target: { value: 'Other' } });
+      wrapper.find('select#mode').simulate('change', { target: { value: 'verified' } });
+      wrapper.find('textarea#comments').simulate('change', { target: { value: 'test create enrollment' } });
+      wrapper.find('button.btn-primary').simulate('click');
+      expect(apiMock).toHaveBeenCalledTimes(1);
+
+      await waitForComponentToPaint(wrapper);
+      expect(wrapper.find('.alert').text()).toEqual('New Enrollment successfully created.');
+      apiMock.mockReset();
+    });
+
+    it('Unsuccessful form submission', async () => {
+      const apiMock = jest.spyOn(api, 'postEnrollment').mockImplementationOnce(() => Promise.resolve({
+        errors: [
+          {
+            code: null,
+            dismissible: true,
+            text: 'Error creating enrollment',
+            type: 'danger',
+            topic: 'createEnrollments',
+          },
+        ],
+      }));
+      expect(apiMock).toHaveBeenCalledTimes(0);
+      wrapper.find('input#courseID').simulate('change', { target: { value: 'course-v1:testX+test123+2030' } });
+
+      wrapper.find('select#reason').simulate('change', { target: { value: 'Other' } });
+      wrapper.find('select#mode').simulate('change', { target: { value: 'verified' } });
+      wrapper.find('textarea#comments').simulate('change', { target: { value: 'test create enrollment' } });
+      wrapper.find('button.btn-primary').simulate('click');
+      await waitForComponentToPaint(wrapper);
+
+      expect(apiMock).toHaveBeenCalledTimes(1);
+      expect(wrapper.find('.alert').text()).toEqual('Error creating enrollment');
+    });
+  });
+});

--- a/src/users/enrollments/v2/EnrollmentForm.jsx
+++ b/src/users/enrollments/v2/EnrollmentForm.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { CREATE, CHANGE } from '../constants';
+import CreateEnrollmentForm from './CreateEnrollmentForm';
+import ChangeEnrollmentForm from './ChangeEnrollmentForm';
+
+export default function EnrollmentForm({
+  formType,
+  enrollment,
+  changeHandler,
+  closeHandler,
+  user,
+  forwardedRef,
+}) {
+  if (formType === CHANGE) {
+    return (
+      <ChangeEnrollmentForm
+        enrollment={enrollment}
+        user={user}
+        changeHandler={changeHandler}
+        closeHandler={closeHandler}
+        forwardedRef={forwardedRef}
+      />
+    );
+  } if (formType === CREATE) {
+    return (
+      <CreateEnrollmentForm
+        enrollment={enrollment}
+        user={user}
+        changeHandler={changeHandler}
+        closeHandler={closeHandler}
+        forwardedRef={forwardedRef}
+      />
+    );
+  }
+}
+
+EnrollmentForm.propTypes = {
+  formType: PropTypes.string.isRequired,
+  enrollment: PropTypes.shape({
+    courseId: PropTypes.string.isRequired,
+    mode: PropTypes.string.isRequired,
+    isActive: PropTypes.bool.isRequired,
+  }),
+  user: PropTypes.string.isRequired,
+  changeHandler: PropTypes.func.isRequired,
+  closeHandler: PropTypes.func.isRequired,
+  forwardedRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+};
+
+EnrollmentForm.defaultProps = {
+  enrollment: {
+    courseId: '',
+    mode: '',
+    isActive: false,
+  },
+  forwardedRef: null,
+};

--- a/src/users/enrollments/v2/Enrollments.jsx
+++ b/src/users/enrollments/v2/Enrollments.jsx
@@ -16,7 +16,7 @@ import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faMinus, faPlus } from '@fortawesome/free-solid-svg-icons';
 import Certificates from '../Certificates';
-import EnrollmentForm from '../EnrollmentForm';
+import EnrollmentForm from './EnrollmentForm';
 import { CREATE, CHANGE } from '../constants';
 import PageLoading from '../../../components/common/PageLoading';
 import UserMessagesContext from '../../../userMessages/UserMessagesContext';
@@ -26,7 +26,7 @@ import { getEnrollments } from '../../data/api';
 import AlertList from '../../../userMessages/AlertList';
 
 export default function Enrollments({
-  changeHandler, user,
+  user,
 }) {
   const { add, clear } = useContext(UserMessagesContext);
   const [formType, setFormType] = useState(null);
@@ -35,18 +35,22 @@ export default function Enrollments({
   const [selectedCourseId, setSelectedCourseId] = useState(undefined);
   const formRef = useRef(null);
 
+  const changeHandler = () => setEnrollmentData(null);
+
   useEffect(() => {
-    clear('enrollments');
-    getEnrollments(user).then((result) => {
-      const camelCaseResult = camelCaseObject(result);
-      if (camelCaseResult.errors) {
-        camelCaseResult.errors.forEach(error => add(error));
-        setEnrollmentData([]);
-      } else {
-        setEnrollmentData(camelCaseResult);
-      }
-    });
-  }, [user]);
+    if (enrollmentData === null) {
+      clear('enrollments');
+      getEnrollments(user).then((result) => {
+        const camelCaseResult = camelCaseObject(result);
+        if (camelCaseResult.errors) {
+          camelCaseResult.errors.forEach(error => add(error));
+          setEnrollmentData([]);
+        } else {
+          setEnrollmentData(camelCaseResult);
+        }
+      });
+    }
+  }, [user, enrollmentData]);
 
   const tableData = useMemo(() => {
     if (enrollmentData === null || enrollmentData.length === 0) {
@@ -201,7 +205,6 @@ export default function Enrollments({
 
   return (
     <section className="mb-3">
-      {!formType && (
       <div className="row">
         <h3 className="ml-4 mr-auto">Enrollments ({tableData.length})</h3>
         <Button
@@ -217,7 +220,6 @@ export default function Enrollments({
           Create New Enrollment
         </Button>
       </div>
-      )}
       {enrollmentData
         ? (
           <TableV2
@@ -259,6 +261,5 @@ export default function Enrollments({
 }
 
 Enrollments.propTypes = {
-  changeHandler: PropTypes.func.isRequired,
   user: PropTypes.string.isRequired,
 };

--- a/src/users/enrollments/v2/Enrollments.test.jsx
+++ b/src/users/enrollments/v2/Enrollments.test.jsx
@@ -65,9 +65,11 @@ describe('Course Enrollments V2 Listing', () => {
   it('Enrollment create form is rendered', () => {
     const createEnrollmentButton = wrapper.find('button#create-enrollment-button');
     createEnrollmentButton.simulate('click');
-    const createEnrollmentForm = wrapper.find('CreateEnrollmentForm');
-    expect(createEnrollmentForm.find('h4').text()).toEqual(expect.stringContaining('Create New Enrollment'));
-    createEnrollmentForm.find('button.btn-outline-secondary').simulate('click');
+    const createFormModal = wrapper.find('Modal#create-enrollment');
+    expect(createFormModal.html()).toEqual(expect.stringContaining('Create New Enrollment'));
+    expect(createFormModal.prop('open')).toEqual(true);
+
+    createFormModal.find('button.btn-link').simulate('click');
     expect(wrapper.find('CreateEnrollmentForm')).toEqual({});
   });
 
@@ -78,9 +80,11 @@ describe('Course Enrollments V2 Listing', () => {
     dataRow = wrapper.find('table tbody tr').at(0);
     dataRow.find('.dropdown-menu.show a').at(0).simulate('click');
 
-    const changeEnrollmentForm = wrapper.find('ChangeEnrollmentForm');
-    expect(changeEnrollmentForm.html()).toEqual(expect.stringContaining(courseId));
-    changeEnrollmentForm.find('button.btn-outline-secondary').simulate('click');
+    const changeFormModal = wrapper.find('Modal#change-enrollment');
+    expect(changeFormModal.html()).toEqual(expect.stringContaining(courseId));
+    expect(changeFormModal.prop('open')).toEqual(true);
+
+    changeFormModal.find('button.btn-link').simulate('click');
     expect(wrapper.find('changeEnrollmentForm')).toEqual({});
   });
 

--- a/src/users/v2/UserPage.jsx
+++ b/src/users/v2/UserPage.jsx
@@ -120,12 +120,6 @@ export default function UserPage({ location }) {
     handleFetchSearchResults(userIdentifier);
   });
 
-  const handleEnrollmentsChange = useCallback(() => {
-    setShowEntitlements(false);
-    setShowLicenses(false);
-    handleFetchSearchResults(userIdentifier);
-  });
-
   useEffect(() => {
     if (!searching) {
       handleFetchSearchResults(userIdentifier);
@@ -174,7 +168,6 @@ export default function UserPage({ location }) {
           />
           <EnrollmentsV2
             user={data.user.username}
-            changeHandler={handleEnrollmentsChange}
           />
 
         </>


### PR DESCRIPTION
[PROD-2492](https://openedx.atlassian.net/browse/PROD-2492)
Adding new design for creating a new enrollment and changing an existing enrollment forms. Aside from the design-based changes, this PR will change the following:

1. Enrollment component reloads every time a new enrollment is created or an existing enrollment is changed.
2. Create form stays the same with an addition of success message when a new enrollment is created but the submit button hides upon changing an enrollment in change enrollment form
3. Fixes warnings in TableV2 component

Some screenshots exhibiting the behavior of these forms:
<img width="780" alt="Screenshot 2021-09-15 at 4 15 21 PM" src="https://user-images.githubusercontent.com/52413434/133435325-9eb19dcb-b2d9-4f44-bbe6-3ab0e96f6f93.png">
<img width="788" alt="Screenshot 2021-09-15 at 4 15 09 PM" src="https://user-images.githubusercontent.com/52413434/133435318-4596c583-c693-4dd1-9d88-d8d2ec18b6ad.png">
<img width="781" alt="Screenshot 2021-09-15 at 4 15 47 PM" src="https://user-images.githubusercontent.com/52413434/133435330-32c5c198-4461-4835-bbad-bf91e0a874a7.png">
<img width="788" alt="Screenshot 2021-09-15 at 1 18 05 PM" src="https://user-images.githubusercontent.com/52413434/133435307-2204e927-cfde-4742-be11-4798ea8785e4.png">
