### PR TITLE
feat: add entitlement form v2

### DIFF
--- a/src/users/entitlements/v2/CreateEntitlementForm.jsx
+++ b/src/users/entitlements/v2/CreateEntitlementForm.jsx
@@ -1,0 +1,140 @@
+import React, { useCallback, useState, useContext } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button, Input, Modal,
+} from '@edx/paragon';
+import classNames from 'classnames';
+
+import UserMessagesContext from '../../../userMessages/UserMessagesContext';
+import AlertList from '../../../userMessages/AlertList';
+import { postEntitlement } from '../../data/api';
+import { CREATE } from '../EntitlementActions';
+import { EntitlementPropTypes, EntitlementDefaultProps } from '../PropTypes';
+
+export default function CreateEntitlementForm({
+  entitlement,
+  changeHandler,
+  closeHandler,
+  user,
+  forwardedRef,
+}) {
+  const [courseUuid, setCourseUuid] = useState(entitlement.courseUuid);
+  const [mode, setMode] = useState(entitlement.mode);
+  const [comments, setComments] = useState('');
+  const [modalIsOpen, setModalIsOpen] = useState(true);
+  const [disableSubmit, setDisableSubmit] = useState(false);
+  const { add, clear } = useContext(UserMessagesContext);
+
+  const submit = useCallback(() => {
+    clear('createEntitlement');
+    setDisableSubmit(true);
+    postEntitlement({
+      requestData: {
+        course_uuid: courseUuid,
+        user,
+        mode,
+        refund_locked: true,
+        support_details: [{
+          action: CREATE,
+          comments,
+        }],
+      },
+    }).then((result) => {
+      setDisableSubmit(false);
+      if (result.errors !== undefined) {
+        result.errors.forEach(error => add(error));
+      } else {
+        const successMessage = {
+          code: null,
+          dismissible: true,
+          text: 'New Entitlement successfully created.',
+          type: 'success',
+          topic: 'createEntitlement',
+        };
+        add(successMessage);
+        changeHandler();
+      }
+    });
+  });
+
+  const createEntitlementForm = (
+    <form>
+      <AlertList topic="createEntitlement" className="mb-3" />
+      <Input
+        className="mb-4"
+        type="text"
+        id="courseUuid"
+        name="courseUuid"
+        placeholder="Course UUID"
+        value={courseUuid}
+        onChange={(event) => setCourseUuid(event.target.value)}
+        ref={forwardedRef}
+      />
+      <Input
+        className="mb-4"
+        type="select"
+        id="mode"
+        name="mode"
+        defaultValue=""
+        options={[
+          { label: 'Mode', value: '', disabled: true },
+          { label: 'Verified', value: 'verified' },
+          { label: 'Professional', value: 'professional' },
+          { label: 'No ID Professional', value: 'no-id-professional' },
+        ]}
+        onChange={(event) => setMode(event.target.value)}
+      />
+      <Input
+        placeholder="Explanation"
+        type="textarea"
+        id="comments"
+        name="comments"
+        defaultValue=""
+        onChange={(event) => setComments(event.target.value)}
+      />
+    </form>
+  );
+
+  return (
+    <Modal
+      open={modalIsOpen}
+      onClose={() => {
+        closeHandler(false);
+        setModalIsOpen(false);
+        clear('createEntitlement');
+      }}
+      title="Create New Entitlement"
+      id="create-entitlement"
+      dialogClassName="modal-lg"
+      body={(
+        createEntitlementForm
+      )}
+      buttons={[
+        <Button
+          variant="primary"
+          disabled={!(courseUuid && mode && comments) || (disableSubmit)}
+          className={classNames(
+            'mr-3',
+            { disabled: !(courseUuid && mode && comments) || (disableSubmit) },
+          )}
+          onClick={submit}
+        >
+          Submit
+        </Button>,
+      ]}
+    />
+  );
+}
+
+CreateEntitlementForm.propTypes = {
+  entitlement: EntitlementPropTypes,
+  user: PropTypes.string.isRequired,
+  changeHandler: PropTypes.func.isRequired,
+  closeHandler: PropTypes.func.isRequired,
+  forwardedRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+};
+
+CreateEntitlementForm.defaultProps = {
+  entitlement: EntitlementDefaultProps,
+  forwardedRef: null,
+};

--- a/src/users/entitlements/v2/CreateEntitlementForm.test.jsx
+++ b/src/users/entitlements/v2/CreateEntitlementForm.test.jsx
@@ -1,0 +1,88 @@
+import { mount } from 'enzyme';
+import { waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { waitForComponentToPaint } from '../../../setupTest';
+import CreateEntitlementForm from './CreateEntitlementForm';
+import entitlementFormData from '../../data/test/entitlementForm';
+import UserMessagesProvider from '../../../userMessages/UserMessagesProvider';
+import * as api from '../../data/api';
+
+const CreateEntitlementFormWrapper = (props) => (
+  <UserMessagesProvider>
+    <CreateEntitlementForm {...props} />
+  </UserMessagesProvider>
+);
+
+describe('Create Entitlement Form', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(<CreateEntitlementFormWrapper {...entitlementFormData} />);
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('Default form render', () => {
+    let createFormModal = wrapper.find('Modal#create-entitlement');
+    expect(createFormModal.prop('open')).toEqual(true);
+    const courseUuidInput = wrapper.find('input#courseUuid');
+    const modeSelectDropdown = wrapper.find('select#mode');
+    const commentsTextArea = wrapper.find('textarea#comments');
+    expect(courseUuidInput.prop('value')).toEqual(entitlementFormData.entitlement.courseUuid);
+    expect(modeSelectDropdown.find('option')).toHaveLength(4);
+    expect(commentsTextArea.text()).toEqual('');
+
+    wrapper.find('button.btn-link').simulate('click');
+    createFormModal = wrapper.find('Modal#create-entitlement');
+    expect(createFormModal.prop('open')).toEqual(false);
+  });
+
+  describe('Form Submission', () => {
+    it('Submit button disabled by default', () => {
+      expect(wrapper.find('button.btn-primary').prop('disabled')).toBeTruthy();
+    });
+
+    it('Successful form submission', async () => {
+      const apiMock = jest.spyOn(api, 'postEntitlement').mockImplementationOnce(() => Promise.resolve({}));
+      expect(apiMock).toHaveBeenCalledTimes(0);
+
+      wrapper.find('input#courseUuid').simulate('change', { target: { value: 'b4f19c72-784d-4110-a3ba-318666a7db1a' } });
+      wrapper.find('select#mode').simulate('change', { target: { value: 'professional' } });
+      wrapper.find('textarea#comments').simulate('change', { target: { value: 'creating new entitlement' } });
+      const submitButton = wrapper.find('button.btn-primary');
+      expect(submitButton.prop('disabled')).toBeFalsy();
+      submitButton.simulate('click');
+
+      expect(apiMock).toHaveBeenCalledTimes(1);
+      // The mock call count does not update on time for expect call, therefore, waitFor is used to give enough time
+      // for the call count to update. However, it is possible this might turn out to be flaky.
+      await waitFor(() => expect(entitlementFormData.changeHandler).toHaveBeenCalledTimes(1));
+      apiMock.mockReset();
+    });
+
+    it('Unsuccessful form submission', async () => {
+      const apiMock = jest.spyOn(api, 'postEntitlement').mockImplementationOnce(() => Promise.resolve({
+        errors: [
+          {
+            code: null,
+            dismissible: true,
+            text: 'Error creating entitlement',
+            type: 'danger',
+            topic: 'createEntitlement',
+          },
+        ],
+      }));
+      expect(apiMock).toHaveBeenCalledTimes(0);
+
+      wrapper.find('textarea#comments').simulate('change', { target: { value: 'creating new entitlement' } });
+      wrapper.find('button.btn-primary').simulate('click');
+      await waitForComponentToPaint(wrapper);
+
+      expect(apiMock).toHaveBeenCalledTimes(1);
+      expect(wrapper.find('.alert').text()).toEqual('Error creating entitlement');
+    });
+  });
+});

--- a/src/users/entitlements/v2/EntitlementForm.jsx
+++ b/src/users/entitlements/v2/EntitlementForm.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { CREATE, REISSUE, EXPIRE } from '../EntitlementActions';
+import CreateEntitlementForm from './CreateEntitlementForm';
+import ReissueEntitlementForm from './ReissueEntitlementForm';
+import ExpireEntitlementForm from './ExpireEntitlementForm';
+import { EntitlementPropTypes, EntitlementDefaultProps } from '../PropTypes';
+
+export default function EntitlementForm({
+  formType,
+  entitlement,
+  changeHandler,
+  closeHandler,
+  user,
+  forwardedRef,
+}) {
+  if (formType === CREATE) {
+    return (
+      <CreateEntitlementForm
+        user={user}
+        entitlement={entitlement}
+        changeHandler={changeHandler}
+        closeHandler={closeHandler}
+        forwardedRef={forwardedRef}
+      />
+    );
+  } if (formType === EXPIRE) {
+    return (
+      <ExpireEntitlementForm
+        user={user}
+        entitlement={entitlement}
+        changeHandler={changeHandler}
+        closeHandler={closeHandler}
+        forwardedRef={forwardedRef}
+      />
+    );
+  } if (formType === REISSUE) {
+    return (
+      <ReissueEntitlementForm
+        key="entitlement-reissue-form"
+        user={user}
+        entitlement={entitlement}
+        changeHandler={changeHandler}
+        closeHandler={closeHandler}
+        forwardedRef={forwardedRef}
+      />
+    );
+  }
+}
+
+EntitlementForm.propTypes = {
+  formType: PropTypes.string.isRequired,
+  entitlement: EntitlementPropTypes,
+  user: PropTypes.string.isRequired,
+  changeHandler: PropTypes.func.isRequired,
+  closeHandler: PropTypes.func.isRequired,
+  forwardedRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+};
+
+EntitlementForm.defaultProps = {
+  entitlement: EntitlementDefaultProps,
+  forwardedRef: null,
+};

--- a/src/users/entitlements/v2/EntitlementForm.test.jsx
+++ b/src/users/entitlements/v2/EntitlementForm.test.jsx
@@ -1,0 +1,38 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import EntitlementForm from './EntitlementForm';
+import entitlementFormData from '../../data/test/entitlementForm';
+import UserMessagesProvider from '../../../userMessages/UserMessagesProvider';
+import { CREATE, REISSUE, EXPIRE } from '../EntitlementActions';
+
+const EntitlementFormWrapper = (props) => (
+  <UserMessagesProvider>
+    <EntitlementForm {...props} />
+  </UserMessagesProvider>
+);
+
+describe('Entitlement forms', () => {
+  let wrapper;
+
+  it('Create Entitlement form render', () => {
+    wrapper = mount(<EntitlementFormWrapper {...entitlementFormData} formType={CREATE} />);
+    expect(wrapper.find('CreateEntitlementForm').length).toEqual(1);
+    expect(wrapper.find('ReissueEntitlementForm').length).toEqual(0);
+    expect(wrapper.find('ExpireEntitlementForm').length).toEqual(0);
+  });
+
+  it('Reissue Entitlement form render', () => {
+    wrapper = mount(<EntitlementFormWrapper {...entitlementFormData} formType={REISSUE} />);
+    expect(wrapper.find('ReissueEntitlementForm').length).toEqual(1);
+    expect(wrapper.find('CreateEntitlementForm').length).toEqual(0);
+    expect(wrapper.find('ExpireEntitlementForm').length).toEqual(0);
+  });
+
+  it('Expire Entitlement form render', () => {
+    wrapper = mount(<EntitlementFormWrapper {...entitlementFormData} formType={EXPIRE} />);
+    expect(wrapper.find('ExpireEntitlementForm').length).toEqual(1);
+    expect(wrapper.find('CreateEntitlementForm').length).toEqual(0);
+    expect(wrapper.find('ReissueEntitlementForm').length).toEqual(0);
+  });
+});

--- a/src/users/entitlements/v2/Entitlements.test.jsx
+++ b/src/users/entitlements/v2/Entitlements.test.jsx
@@ -37,10 +37,12 @@ describe('Entitlements V2 Listing', () => {
     expect(entitlementButton.prop('disabled')).toBeFalsy();
     entitlementButton.simulate('click');
 
-    const createEntitlementForm = wrapper.find('CreateEntitlementForm');
-    expect(createEntitlementForm.html()).toEqual(expect.stringContaining('Create Entitlement'));
-    createEntitlementForm.find('button.btn-outline-secondary').simulate('click');
-    expect(wrapper.find('CreateEntitlementForm')).toEqual({});
+    let createFormModal = wrapper.find('Modal#create-entitlement');
+    expect(createFormModal.prop('open')).toEqual(true);
+    expect(createFormModal.html()).toEqual(expect.stringContaining('Create New Entitlement'));
+    wrapper.find('button.btn-link').simulate('click');
+    createFormModal = wrapper.find('Modal#create-entitlement');
+    expect(createFormModal.prop('open')).toEqual(false);
   });
 
   it('entitlements data', () => {
@@ -84,7 +86,12 @@ describe('Entitlements V2 Listing', () => {
   });
 
   describe('Reissue entitlement button', () => {
-    it('Enabled Reissue entitlement button', () => {
+    it('Enabled Reissue entitlement button', async () => {
+      entitlementsData.results[0] = { ...entitlementsData.results[0], enrollmentCourseRun: null };
+      jest.spyOn(api, 'getEntitlements').mockImplementationOnce(() => Promise.resolve(entitlementsData));
+      wrapper = mount(<EntitlementsPageWrapper {...props} />);
+      await waitForComponentToPaint(wrapper);
+
       // We're only checking row 0 of the table since the Reissue button is not disabled
       let dataRow = wrapper.find('table tbody tr').at(0);
       dataRow.find('.dropdown button').simulate('click');
@@ -94,10 +101,12 @@ describe('Entitlements V2 Listing', () => {
       expect(expireOption.html()).not.toEqual(expect.stringContaining('disabled'));
       expireOption.simulate('click');
 
-      const expireEntitlementForm = wrapper.find('ReissueEntitlementForm');
-      expect(expireEntitlementForm.html()).toEqual(expect.stringContaining('Reissue Entitlement'));
-      expireEntitlementForm.find('button.btn-outline-secondary').simulate('click');
-      expect(wrapper.find('ExpireEntitlementForm')).toEqual({});
+      let reissueFormModal = wrapper.find('Modal#reissue-entitlement');
+      expect(reissueFormModal.prop('open')).toEqual(true);
+      expect(reissueFormModal.html()).toEqual(expect.stringContaining('Reissue Entitlement'));
+      wrapper.find('button.btn-link').simulate('click');
+      reissueFormModal = wrapper.find('Modal#reissue-entitlement');
+      expect(reissueFormModal.prop('open')).toEqual(false);
     });
 
     it('Disabled Reissue entitlement button', () => {
@@ -132,10 +141,12 @@ describe('Entitlements V2 Listing', () => {
       expect(expireOption.html()).not.toEqual(expect.stringContaining('disabled'));
       expireOption.simulate('click');
 
-      const expireEntitlementForm = wrapper.find('ExpireEntitlementForm');
-      expect(expireEntitlementForm.html()).toEqual(expect.stringContaining('Expire Entitlement'));
-      expireEntitlementForm.find('button.btn-outline-secondary').simulate('click');
-      expect(wrapper.find('ExpireEntitlementForm')).toEqual({});
+      let expireFormModal = wrapper.find('Modal#expire-entitlement');
+      expect(expireFormModal.prop('open')).toEqual(true);
+      expect(expireFormModal.html()).toEqual(expect.stringContaining('Expire Entitlement'));
+      wrapper.find('button.btn-link').simulate('click');
+      expireFormModal = wrapper.find('Modal#expire-entitlement');
+      expect(expireFormModal.prop('open')).toEqual(false);
     });
   });
 

--- a/src/users/entitlements/v2/ExpireEntitlementForm.jsx
+++ b/src/users/entitlements/v2/ExpireEntitlementForm.jsx
@@ -1,0 +1,132 @@
+import React, { useCallback, useState, useContext } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button, Input, Modal,
+} from '@edx/paragon';
+import classNames from 'classnames';
+
+import UserMessagesContext from '../../../userMessages/UserMessagesContext';
+import AlertList from '../../../userMessages/AlertList';
+import { patchEntitlement } from '../../data/api';
+import { EXPIRE } from '../EntitlementActions';
+import { EntitlementPropTypes, EntitlementDefaultProps } from '../PropTypes';
+import makeRequestData from '../utils';
+
+export default function ExpireEntitlementForm({
+  entitlement,
+  changeHandler,
+  closeHandler,
+  forwardedRef,
+}) {
+  const [comments, setComments] = useState('');
+  const [modalIsOpen, setModalIsOpen] = useState(true);
+  const [hideOnSubmit, setHideOnSubmit] = useState(false);
+  const { add, clear } = useContext(UserMessagesContext);
+
+  const submit = useCallback(() => {
+    const now = new Date().toISOString();
+    clear('expireEntitlement');
+    patchEntitlement({
+      uuid: entitlement.uuid,
+      requestData: makeRequestData({
+        expiredAt: now,
+        enrollmentCourseRun: entitlement.enrollmentCourseRun,
+        action: EXPIRE,
+        comments,
+      }),
+    }).then((result) => {
+      if (result.errors !== undefined) {
+        result.errors.forEach(error => add(error));
+      } else {
+        const successMessage = {
+          code: null,
+          dismissible: true,
+          text: 'Entitlement successfully expired.',
+          type: 'success',
+          topic: 'expireEntitlement',
+        };
+        setHideOnSubmit(true);
+        add(successMessage);
+        changeHandler();
+      }
+    });
+  });
+
+  const expireEntitlementForm = (
+    <form>
+      <AlertList topic="expireEntitlement" className="mb-3" />
+      <div className="row small">
+        <div className="col-sm-6">
+          Course UUID
+        </div>
+        <div className="col-sm-6">
+          {entitlement.courseUuid}
+        </div>
+      </div>
+      <hr />
+
+      <div className="row small">
+        <div className="col-sm-6">
+          Mode
+        </div>
+        <div className="col-sm-6">
+          {entitlement.mode}
+        </div>
+      </div>
+      <hr />
+      <Input
+        type="textarea"
+        id="comments"
+        name="comments"
+        placeholder="Explanation"
+        defaultValue=""
+        onChange={(event) => setComments(event.target.value)}
+        disabled={hideOnSubmit}
+        ref={forwardedRef}
+      />
+    </form>
+  );
+
+  return (
+    <Modal
+      open={modalIsOpen}
+      onClose={() => {
+        closeHandler(false);
+        setModalIsOpen(false);
+        clear('expireEntitlement');
+      }}
+      title="Expire Entitlement"
+      id="expire-entitlement"
+      dialogClassName="modal-lg"
+      body={(
+        expireEntitlementForm
+      )}
+      buttons={[
+        <Button
+          variant="primary"
+          className={classNames(
+            'mr-3',
+            { disabled: !(entitlement.courseUuid && entitlement.mode && comments) },
+          )}
+          disabled={!(entitlement.courseUuid && entitlement.mode && comments)}
+          hidden={hideOnSubmit}
+          onClick={submit}
+        >
+          Submit
+        </Button>,
+      ]}
+    />
+  );
+}
+
+ExpireEntitlementForm.propTypes = {
+  entitlement: EntitlementPropTypes,
+  changeHandler: PropTypes.func.isRequired,
+  closeHandler: PropTypes.func.isRequired,
+  forwardedRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+};
+
+ExpireEntitlementForm.defaultProps = {
+  entitlement: EntitlementDefaultProps,
+  forwardedRef: null,
+};

--- a/src/users/entitlements/v2/ExpireEntitlementForm.test.jsx
+++ b/src/users/entitlements/v2/ExpireEntitlementForm.test.jsx
@@ -1,0 +1,85 @@
+import { mount } from 'enzyme';
+import { waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { waitForComponentToPaint } from '../../../setupTest';
+import ExpireEntitlementForm from './ExpireEntitlementForm';
+import entitlementFormData from '../../data/test/entitlementForm';
+import UserMessagesProvider from '../../../userMessages/UserMessagesProvider';
+import * as api from '../../data/api';
+
+const ExpireEntitlementFormWrapper = (props) => (
+  <UserMessagesProvider>
+    <ExpireEntitlementForm {...props} />
+  </UserMessagesProvider>
+);
+
+describe('Expire Entitlement Form', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(<ExpireEntitlementFormWrapper {...entitlementFormData} />);
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('Default form render', () => {
+    let expireFormModal = wrapper.find('Modal#expire-entitlement');
+    expect(expireFormModal.prop('open')).toEqual(true);
+    const commentsTextArea = wrapper.find('textarea#comments');
+    expect(commentsTextArea.text()).toEqual('');
+
+    wrapper.find('button.btn-link').simulate('click');
+    expireFormModal = wrapper.find('Modal#expire-entitlement');
+    expect(expireFormModal.prop('open')).toEqual(false);
+  });
+
+  describe('Form Submission', () => {
+    it('Submit button disabled by default', () => {
+      expect(wrapper.find('button.btn-primary').prop('disabled')).toBeTruthy();
+    });
+
+    it('Successful form submission', async () => {
+      const apiMock = jest.spyOn(api, 'patchEntitlement').mockImplementationOnce(() => Promise.resolve({}));
+      expect(apiMock).toHaveBeenCalledTimes(0);
+
+      wrapper.find('textarea#comments').simulate('change', { target: { value: 'expiring entitlement' } });
+      let submitButton = wrapper.find('button.btn-primary');
+      expect(submitButton.prop('disabled')).toBeFalsy();
+      submitButton.simulate('click');
+
+      expect(apiMock).toHaveBeenCalledTimes(1);
+      // The mock call count does not update on time for expect call, therefore, waitFor is used to give enough time
+      // for the call count to update. However, it is possible this might turn out to be flaky.
+      await waitFor(() => expect(entitlementFormData.changeHandler).toHaveBeenCalledTimes(1));
+      apiMock.mockReset();
+
+      submitButton = wrapper.find('button.btn-primary');
+      expect(submitButton).toEqual({});
+    });
+
+    it('Unsuccessful form submission', async () => {
+      const apiMock = jest.spyOn(api, 'patchEntitlement').mockImplementationOnce(() => Promise.resolve({
+        errors: [
+          {
+            code: null,
+            dismissible: true,
+            text: 'Error expiring entitlement',
+            type: 'danger',
+            topic: 'expireEntitlement',
+          },
+        ],
+      }));
+      expect(apiMock).toHaveBeenCalledTimes(0);
+
+      wrapper.find('textarea#comments').simulate('change', { target: { value: 'expiring entitlement' } });
+      wrapper.find('button.btn-primary').simulate('click');
+      await waitForComponentToPaint(wrapper);
+
+      expect(apiMock).toHaveBeenCalledTimes(1);
+      expect(wrapper.find('.alert').text()).toEqual('Error expiring entitlement');
+    });
+  });
+});

--- a/src/users/entitlements/v2/ReissueEntitlementForm.jsx
+++ b/src/users/entitlements/v2/ReissueEntitlementForm.jsx
@@ -1,0 +1,130 @@
+import React, { useCallback, useState, useContext } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button, Input, Modal,
+} from '@edx/paragon';
+import classNames from 'classnames';
+
+import UserMessagesContext from '../../../userMessages/UserMessagesContext';
+import AlertList from '../../../userMessages/AlertList';
+import { patchEntitlement } from '../../data/api';
+import { REISSUE } from '../EntitlementActions';
+import { EntitlementPropTypes, EntitlementDefaultProps } from '../PropTypes';
+import makeRequestData from '../utils';
+
+export default function ReissueEntitlementForm({
+  entitlement,
+  changeHandler,
+  closeHandler,
+  forwardedRef,
+}) {
+  const [comments, setComments] = useState('');
+  const [modalIsOpen, setModalIsOpen] = useState(true);
+  const [hideOnSubmit, setHideOnSubmit] = useState(false);
+  const { add, clear } = useContext(UserMessagesContext);
+
+  const submit = useCallback(() => {
+    clear('reissueEntitlement');
+    patchEntitlement({
+      uuid: entitlement.uuid,
+      requestData: makeRequestData({
+        enrollmentCourseRun: entitlement.enrollmentCourseRun,
+        action: REISSUE,
+        comments,
+      }),
+    }).then((result) => {
+      if (result.errors !== undefined) {
+        result.errors.forEach(error => add(error));
+      } else {
+        const successMessage = {
+          code: null,
+          dismissible: true,
+          text: 'Entitlement successfully reissued.',
+          type: 'success',
+          topic: 'reissueEntitlement',
+        };
+        setHideOnSubmit(true);
+        add(successMessage);
+        changeHandler();
+      }
+    });
+  });
+
+  const reissueEntitlementForm = (
+    <form>
+      <AlertList topic="reissueEntitlement" className="mb-3" />
+      <div className="row small">
+        <div className="col-sm-6">
+          Course UUID
+        </div>
+        <div className="col-sm-6">
+          {entitlement.courseUuid}
+        </div>
+      </div>
+      <hr />
+
+      <div className="row small">
+        <div className="col-sm-6">
+          Mode
+        </div>
+        <div className="col-sm-6">
+          {entitlement.mode}
+        </div>
+      </div>
+      <hr />
+      <Input
+        type="textarea"
+        id="comments"
+        name="comments"
+        placeholder="Explanation"
+        defaultValue=""
+        onChange={(event) => setComments(event.target.value)}
+        disabled={hideOnSubmit}
+        ref={forwardedRef}
+      />
+    </form>
+  );
+
+  return (
+    <Modal
+      open={modalIsOpen}
+      onClose={() => {
+        clear('reissueEntitlement');
+        closeHandler(false);
+        setModalIsOpen(false);
+      }}
+      title="Reissue Entitlement"
+      id="reissue-entitlement"
+      dialogClassName="modal-lg"
+      body={(
+        reissueEntitlementForm
+      )}
+      buttons={[
+        <Button
+          variant="primary"
+          className={classNames(
+            'btn-primary mr-3',
+            { disabled: !(entitlement.courseUuid && entitlement.mode && comments) },
+          )}
+          disabled={!(entitlement.courseUuid && entitlement.mode && comments)}
+          hidden={hideOnSubmit}
+          onClick={submit}
+        >
+          Submit
+        </Button>,
+      ]}
+    />
+  );
+}
+
+ReissueEntitlementForm.propTypes = {
+  entitlement: EntitlementPropTypes,
+  changeHandler: PropTypes.func.isRequired,
+  closeHandler: PropTypes.func.isRequired,
+  forwardedRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+};
+
+ReissueEntitlementForm.defaultProps = {
+  entitlement: EntitlementDefaultProps,
+  forwardedRef: null,
+};

--- a/src/users/entitlements/v2/ReissueEntitlementForm.test.jsx
+++ b/src/users/entitlements/v2/ReissueEntitlementForm.test.jsx
@@ -1,0 +1,85 @@
+import { mount } from 'enzyme';
+import { waitFor } from '@testing-library/react';
+import React from 'react';
+
+import { waitForComponentToPaint } from '../../../setupTest';
+import ReissueEntitlementForm from './ReissueEntitlementForm';
+import entitlementFormData from '../../data/test/entitlementForm';
+import UserMessagesProvider from '../../../userMessages/UserMessagesProvider';
+import * as api from '../../data/api';
+
+const ReissueEntitlementFormWrapper = (props) => (
+  <UserMessagesProvider>
+    <ReissueEntitlementForm {...props} />
+  </UserMessagesProvider>
+);
+
+describe('Reissue Entitlement Form', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(<ReissueEntitlementFormWrapper {...entitlementFormData} />);
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('Default form render', () => {
+    let reissueFormModal = wrapper.find('Modal#reissue-entitlement');
+    expect(reissueFormModal.prop('open')).toEqual(true);
+    const commentsTextArea = wrapper.find('textarea#comments');
+    expect(commentsTextArea.text()).toEqual('');
+
+    wrapper.find('button.btn-link').simulate('click');
+    reissueFormModal = wrapper.find('Modal#reissue-entitlement');
+    expect(reissueFormModal.prop('open')).toEqual(false);
+  });
+
+  describe('Form Submission', () => {
+    it('Submit button disabled by default', () => {
+      expect(wrapper.find('button.btn-primary').prop('disabled')).toBeTruthy();
+    });
+
+    it('Successful form submission', async () => {
+      const apiMock = jest.spyOn(api, 'patchEntitlement').mockImplementationOnce(() => Promise.resolve({}));
+      expect(apiMock).toHaveBeenCalledTimes(0);
+
+      wrapper.find('textarea#comments').simulate('change', { target: { value: 'reissue the expired entitlement' } });
+      let submitButton = wrapper.find('button.btn-primary');
+      expect(submitButton.prop('disabled')).toBeFalsy();
+      submitButton.simulate('click');
+
+      expect(apiMock).toHaveBeenCalledTimes(1);
+      // The mock call count does not update on time for expect call, therefore, waitFor is used to give enough time
+      // for the call count to update. However, it is possible this might turn out to be flaky.
+      await waitFor(() => expect(entitlementFormData.changeHandler).toHaveBeenCalledTimes(1));
+      apiMock.mockReset();
+
+      submitButton = wrapper.find('button.btn-primary');
+      expect(submitButton).toEqual({});
+    });
+
+    it('Unsuccessful form submission', async () => {
+      const apiMock = jest.spyOn(api, 'patchEntitlement').mockImplementationOnce(() => Promise.resolve({
+        errors: [
+          {
+            code: null,
+            dismissible: true,
+            text: 'Error during reissue of entitlement',
+            type: 'danger',
+            topic: 'reissueEntitlement',
+          },
+        ],
+      }));
+      expect(apiMock).toHaveBeenCalledTimes(0);
+
+      wrapper.find('textarea#comments').simulate('change', { target: { value: 'reissue the expired entitlement' } });
+      wrapper.find('button.btn-primary').simulate('click');
+      await waitForComponentToPaint(wrapper);
+
+      expect(apiMock).toHaveBeenCalledTimes(1);
+      expect(wrapper.find('.alert').text()).toEqual('Error during reissue of entitlement');
+    });
+  });
+});

--- a/src/users/v2/UserPage.jsx
+++ b/src/users/v2/UserPage.jsx
@@ -38,7 +38,6 @@ export default function UserPage({ location }) {
   const [searching, setSearching] = useState(false);
   const [data, setData] = useState({ enrollments: null, entitlements: null });
   const [loading, setLoading] = useState(false);
-  const [showEntitlements, setShowEntitlements] = useState(false);
   const [showLicenses, setShowLicenses] = useState(false);
   const { add, clear } = useContext(UserMessagesContext);
 
@@ -104,19 +103,12 @@ export default function UserPage({ location }) {
 
   const handleSearchInputChange = useCallback((searchValue) => {
     setSearching(true);
-    setShowEntitlements(false);
     setShowLicenses(false);
     handleFetchSearchResults(searchValue);
   });
 
   const handleUserSummaryChange = useCallback(() => {
     setSearching(true);
-    handleFetchSearchResults(userIdentifier);
-  });
-
-  const handleEntitlementsChange = useCallback(() => {
-    setShowEntitlements(true);
-    setShowLicenses(true);
     handleFetchSearchResults(userIdentifier);
   });
 
@@ -163,8 +155,6 @@ export default function UserPage({ location }) {
           />
           <EntitlementsV2
             user={data.user.username}
-            changeHandler={handleEntitlementsChange}
-            expanded={showEntitlements}
           />
           <EnrollmentsV2
             user={data.user.username}


### PR DESCRIPTION
[PROD-2493](https://openedx.atlassian.net/browse/PROD-2493)
Adding a new design for creating a new entitlement, reissuing and expiring an existing entitlement forms. Aside from the design-based changes, this PR will change the following:

1. Entitlement component reloads every time a new entitlement is created or an existing entitlement is changed.
2. When either of the three forms is submitted, the submit button is hidden

<img width="779" alt="Screenshot 2021-09-17 at 12 23 14 PM" src="https://user-images.githubusercontent.com/52413434/133768313-07b53783-8dcc-4c89-9e83-0f31b2600f1c.png">
<img width="784" alt="Screenshot 2021-09-17 at 12 23 54 PM" src="https://user-images.githubusercontent.com/52413434/133768209-d397f38b-2978-4c36-a165-510ef72791fe.png">
<img width="780" alt="Screenshot 2021-09-17 at 12 24 02 PM" src="https://user-images.githubusercontent.com/52413434/133768334-658434a3-6438-47ad-ad38-539a4340577a.png">
<img width="780" alt="Screenshot 2021-09-17 at 12 24 08 PM" src="https://user-images.githubusercontent.com/52413434/133768223-8f842e65-a876-4989-a984-d7210d76c88c.png">

