### PR TITLE
feat: add feature based enrollment components

### DIFF
--- a/src/FeatureBasedEnrollments/FeatureBasedEnrollment.jsx
+++ b/src/FeatureBasedEnrollments/FeatureBasedEnrollment.jsx
@@ -1,0 +1,67 @@
+import React, {
+  useEffect,
+  useContext,
+  useState,
+} from 'react';
+import { camelCaseObject } from '@edx/frontend-platform';
+import { Row, Col } from '@edx/paragon';
+import PropTypes from 'prop-types';
+
+import UserMessagesContext from '../userMessages/UserMessagesContext';
+import AlertList from '../userMessages/AlertList';
+import getFeatureBasedEnrollmentDetails from './data/api';
+import PageLoading from '../components/common/PageLoading';
+import FeatureBasedEnrollmentCard from './FeatureBasedEnrollmentCard';
+
+export default function FeatureBasedEnrollment({ courseId }) {
+  const [fbeData, setFBEData] = useState(undefined);
+  const { add, clear } = useContext(UserMessagesContext);
+
+  useEffect(() => {
+    clear('featureBasedEnrollment');
+    setFBEData(undefined);
+    getFeatureBasedEnrollmentDetails(courseId).then((response) => {
+      const camelCaseResponse = camelCaseObject(response);
+      if (camelCaseResponse.errors) {
+        camelCaseResponse.errors.forEach(error => add(error));
+      } else {
+        setFBEData(camelCaseResponse);
+      }
+    });
+  }, [courseId]);
+
+  return (
+    <section className="mb-3">
+      <AlertList topic="featureBasedEnrollment" className="mb-3" />
+      <h3 id="fbe-title-header" className="my-4">Feature Based Enrollment Configuration</h3>
+
+      {/* eslint-disable-next-line no-nested-ternary */}
+      {fbeData
+        ? (
+          (Object.keys(fbeData).length > 0
+            ? (
+              <>
+                <h4 className="my-4">Course Title: {fbeData.courseName}</h4>
+                <Row>
+                  <Col>
+                    <FeatureBasedEnrollmentCard title="Content Type Gating" fbeData={fbeData.gatingConfig} />
+                  </Col>
+                  <Col>
+                    <FeatureBasedEnrollmentCard title="Duration Config" fbeData={fbeData.durationConfig} />
+                  </Col>
+                </Row>
+              </>
+            )
+            : (<p className="my-4">No Feature Based Enrollment Configurations were found.</p>)
+          )
+        )
+        : (
+          <PageLoading srMessage="Loading" />
+        )}
+    </section>
+  );
+}
+
+FeatureBasedEnrollment.propTypes = {
+  courseId: PropTypes.string.isRequired,
+};

--- a/src/FeatureBasedEnrollments/FeatureBasedEnrollment.test.jsx
+++ b/src/FeatureBasedEnrollments/FeatureBasedEnrollment.test.jsx
@@ -1,0 +1,85 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { waitForComponentToPaint } from '../setupTest';
+import FeatureBasedEnrollment from './FeatureBasedEnrollment';
+import UserMessagesProvider from '../userMessages/UserMessagesProvider';
+import { fbeEnabledResponse } from './data/test/featureBasedEnrollment';
+
+import * as api from './data/api';
+
+const FeatureBasedEnrollmentWrapper = (props) => (
+  <UserMessagesProvider>
+    <FeatureBasedEnrollment {...props} />
+  </UserMessagesProvider>
+);
+
+describe('Feature Based Enrollment', () => {
+  const props = {
+    courseId: 'course-v1:testX+test123+2030',
+  };
+
+  let wrapper;
+
+  beforeEach(async () => {
+    // api file has only one default export, so that will be spied-on
+    jest.spyOn(api, 'default').mockImplementationOnce(() => Promise.resolve(fbeEnabledResponse));
+    wrapper = mount(<FeatureBasedEnrollmentWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('default props', () => {
+    const courseId = wrapper.prop('courseId');
+    expect(courseId).toEqual(props.courseId);
+  });
+
+  it('Successful fetch for FBE data', async () => {
+    const cardList = wrapper.find('Card');
+    const courseTitle = wrapper.find('h4');
+
+    expect(cardList).toHaveLength(2);
+    expect(wrapper.find('h3#fbe-title-header').text()).toEqual('Feature Based Enrollment Configuration');
+    expect(courseTitle.text()).toEqual('Course Title: test course');
+  });
+
+  it('No FBE Data', async () => {
+    jest.spyOn(api, 'default').mockImplementationOnce(() => Promise.resolve({}));
+    wrapper = mount(<FeatureBasedEnrollmentWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+
+    const cardList = wrapper.find('Card');
+    const noRecordMessage = wrapper.find('p');
+
+    expect(cardList).toHaveLength(0);
+    expect(wrapper.find('h3#fbe-title-header').text()).toEqual('Feature Based Enrollment Configuration');
+    expect(noRecordMessage.text()).toEqual('No Feature Based Enrollment Configurations were found.');
+  });
+
+  it('Page Loading component render', async () => {
+    wrapper = mount(<FeatureBasedEnrollmentWrapper {...props} />);
+    expect(wrapper.find('PageLoading').html()).toEqual(expect.stringContaining('Loading'));
+  });
+
+  it('Error fetching FBE data', async () => {
+    const fbeErrors = {
+      errors: [
+        {
+          code: null,
+          dismissible: true,
+          text: 'Error fetching FBE Data',
+          type: 'error',
+          topic: 'featureBasedEnrollment',
+        },
+      ],
+    };
+    jest.spyOn(api, 'default').mockImplementationOnce(() => Promise.resolve(fbeErrors));
+    wrapper = mount(<FeatureBasedEnrollmentWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+
+    const alert = wrapper.find('.alert');
+    expect(alert.text()).toEqual('Error fetching FBE Data');
+  });
+});

--- a/src/FeatureBasedEnrollments/FeatureBasedEnrollmentCard.jsx
+++ b/src/FeatureBasedEnrollments/FeatureBasedEnrollmentCard.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Card, Badge,
+} from '@edx/paragon';
+import { formatDate } from '../utils';
+
+export default function FeatureBasedEnrollmentCard({ title, fbeData }) {
+  return (
+    <Card className="px-3 mb-1">
+      <Card.Body className="p-0">
+        <Card.Title as="h3" className="btn-header mt-4">
+          {title} { fbeData.enabled ? <Badge variant="success">Enabled</Badge> : <Badge variant="danger">Disabled</Badge> }
+        </Card.Title>
+
+        <table className="fbe-table">
+          <tbody>
+
+            <tr>
+              <th>Enabled As Of</th>
+              <td>{fbeData.enabledAsOf !== 'N/A' ? formatDate(fbeData.enabledAsOf) : fbeData.enabledAsOf}</td>
+            </tr>
+
+            <tr>
+              <th>Reason</th>
+              <td>{fbeData.reason}</td>
+            </tr>
+
+          </tbody>
+
+        </table>
+      </Card.Body>
+    </Card>
+  );
+}
+
+FeatureBasedEnrollmentCard.propTypes = {
+  title: PropTypes.string.isRequired,
+  fbeData: PropTypes.shape({
+    enabled: PropTypes.bool.isRequired,
+    reason: PropTypes.string.isRequired,
+    enabledAsOf: PropTypes.string.isRequired,
+  }).isRequired,
+};

--- a/src/FeatureBasedEnrollments/FeatureBasedEnrollmentCard.test.jsx
+++ b/src/FeatureBasedEnrollments/FeatureBasedEnrollmentCard.test.jsx
@@ -1,0 +1,85 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import FeatureBasedEnrollmentCard from './FeatureBasedEnrollmentCard';
+import {
+  fbeDurationConfigEnabled,
+  fbeDurationConfigDisabled,
+  fbeGatingConfigEnabled,
+  fbeGatingConfigDisabled,
+} from './data/test/featureBasedEnrollment';
+
+describe('Feature Based Enrollment Card Component', () => {
+  let wrapper;
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  describe('Gating config', () => {
+    const title = 'Gating Config';
+
+    it('Gating config enabled', () => {
+      wrapper = mount(<FeatureBasedEnrollmentCard title={title} fbeData={fbeGatingConfigEnabled} />);
+      const header = wrapper.find('h3.card-title');
+      const dataTable = wrapper.find('table.fbe-table tr');
+      const dateRow = dataTable.at(0);
+      const reasonRow = dataTable.at(1);
+
+      expect(header.text()).toEqual('Gating Config Enabled');
+      expect(dateRow.find('th').at(0).text()).toEqual('Enabled As Of');
+      expect(dateRow.find('td').at(0).text()).toEqual('Jan 1, 2020 12:00 AM');
+
+      expect(reasonRow.find('th').at(0).text()).toEqual('Reason');
+      expect(reasonRow.find('td').at(0).text()).toEqual('Site');
+    });
+
+    it('Gating config disabled', () => {
+      wrapper = mount(<FeatureBasedEnrollmentCard title={title} fbeData={fbeGatingConfigDisabled} />);
+      const header = wrapper.find('h3.card-title');
+      const dataTable = wrapper.find('table.fbe-table tr');
+      const dateRow = dataTable.at(0);
+      const reasonRow = dataTable.at(1);
+
+      expect(header.text()).toEqual('Gating Config Disabled');
+      expect(dateRow.find('th').at(0).text()).toEqual('Enabled As Of');
+      expect(dateRow.find('td').at(0).text()).toEqual('N/A');
+
+      expect(reasonRow.find('th').at(0).text()).toEqual('Reason');
+      expect(reasonRow.find('td').at(0).text()).toEqual('');
+    });
+  });
+
+  describe('Duration config', () => {
+    const title = 'Duration Config';
+
+    it('Duration config enabled', () => {
+      wrapper = mount(<FeatureBasedEnrollmentCard title={title} fbeData={fbeDurationConfigEnabled} />);
+      const header = wrapper.find('h3.card-title');
+      const dataTable = wrapper.find('table.fbe-table tr');
+      const dateRow = dataTable.at(0);
+      const reasonRow = dataTable.at(1);
+
+      expect(header.text()).toEqual('Duration Config Enabled');
+      expect(dateRow.find('th').at(0).text()).toEqual('Enabled As Of');
+      expect(dateRow.find('td').at(0).text()).toEqual('Feb 1, 2020 12:00 AM');
+
+      expect(reasonRow.find('th').at(0).text()).toEqual('Reason');
+      expect(reasonRow.find('td').at(0).text()).toEqual('Site Config');
+    });
+
+    it('Duration config disabled', () => {
+      wrapper = mount(<FeatureBasedEnrollmentCard title={title} fbeData={fbeDurationConfigDisabled} />);
+      const header = wrapper.find('h3.card-title');
+      const dataTable = wrapper.find('table.fbe-table tr');
+      const dateRow = dataTable.at(0);
+      const reasonRow = dataTable.at(1);
+
+      expect(header.text()).toEqual('Duration Config Disabled');
+      expect(dateRow.find('th').at(0).text()).toEqual('Enabled As Of');
+      expect(dateRow.find('td').at(0).text()).toEqual('N/A');
+
+      expect(reasonRow.find('th').at(0).text()).toEqual('Reason');
+      expect(reasonRow.find('td').at(0).text()).toEqual('');
+    });
+  });
+});

--- a/src/FeatureBasedEnrollments/FeatureBasedEnrollmentIndexPage.jsx
+++ b/src/FeatureBasedEnrollments/FeatureBasedEnrollmentIndexPage.jsx
@@ -1,0 +1,111 @@
+import { history } from '@edx/frontend-platform';
+import React, {
+  useRef,
+  useEffect,
+  useCallback,
+  useContext,
+  useState,
+} from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { Input, Button } from '@edx/paragon';
+
+import UserMessagesContext from '../userMessages/UserMessagesContext';
+import AlertList from '../userMessages/AlertList';
+import { isValidCourseID } from '../utils';
+import FeatureBasedEnrollment from './FeatureBasedEnrollment';
+
+export default function FeatureBasedEnrollmentIndexPage({ location }) {
+  const params = new Map(
+    location.search
+      .slice(1) // removes '?' mark from start
+      .split('&')
+      .map(queryParams => queryParams.split('=')),
+  );
+
+  const searchRef = useRef();
+  const { add, clear } = useContext(UserMessagesContext);
+  const [searchValue, setSearchValue] = useState(params.get('course_id') || undefined);
+
+  if (params.has('course_id')) {
+    const courseId = params.get('course_id');
+    params.set('course_id', decodeURIComponent(courseId));
+  }
+
+  function pushHistoryIfChanged(nextUrl) {
+    if (nextUrl !== location.pathname + location.search) {
+      history.push(nextUrl);
+    }
+  }
+
+  function validateInput(inputValue) {
+    if (!isValidCourseID(inputValue)) {
+      add({
+        code: null,
+        dismissible: false,
+        text: `Supplied course ID "${inputValue}" is either invalid or incorrect.`,
+        type: 'error',
+        topic: 'featureBasedEnrollmentGeneral',
+      });
+      history.replace('/feature_based_enrollments');
+      return false;
+    }
+    return true;
+  }
+
+  const handleSearchInput = useCallback((inputValue) => {
+    clear('featureBasedEnrollmentGeneral');
+    if (inputValue !== undefined && inputValue !== '') {
+      if (!validateInput(inputValue)) {
+        return;
+      }
+      setSearchValue(inputValue);
+      pushHistoryIfChanged(`/feature_based_enrollments/?course_id=${inputValue}`);
+    } else if (inputValue === '') {
+      history.replace('/feature_based_enrollments');
+    }
+  });
+
+  const submit = useCallback((event) => {
+    const inputValue = searchRef.current.value;
+    setSearchValue(undefined);
+    event.preventDefault();
+    handleSearchInput(inputValue);
+    return false;
+  });
+
+  // Run this once when the user re-loads the page with course_id query param present in url
+  useEffect(() => {
+    if (params.get('course_id')) {
+      handleSearchInput(params.get('course_id'));
+    }
+  }, []);
+
+  return (
+    <main className="ml-5 mr-5 mt-3 mb-5">
+
+      <section className="mb-3">
+        <Link to="/">&lt; Back to Tools</Link>
+      </section>
+
+      <AlertList topic="featureBasedEnrollmentGeneral" className="mb-3" />
+
+      <section className="mb-3">
+        <form className="form-inline">
+          <label htmlFor="courseId">Course ID</label>
+          <Input ref={searchRef} className="flex-grow-1 mr-1" name="courseId" type="text" defaultValue={searchValue} />
+          <Button type="submit" onClick={submit} variant="primary">Search</Button>
+        </form>
+      </section>
+
+      {searchValue && <FeatureBasedEnrollment courseId={searchValue} />}
+    </main>
+  );
+}
+
+FeatureBasedEnrollmentIndexPage.propTypes = {
+  location: PropTypes.shape({
+    pathname: PropTypes.string,
+    search: PropTypes.string,
+  }).isRequired,
+};

--- a/src/FeatureBasedEnrollments/FeatureBasedEnrollmentIndexPage.test.jsx
+++ b/src/FeatureBasedEnrollments/FeatureBasedEnrollmentIndexPage.test.jsx
@@ -1,0 +1,107 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { history } from '@edx/frontend-platform';
+import { waitForComponentToPaint } from '../setupTest';
+import FeatureBasedEnrollmentIndexPage from './FeatureBasedEnrollmentIndexPage';
+import UserMessagesProvider from '../userMessages/UserMessagesProvider';
+import { fbeEnabledResponse } from './data/test/featureBasedEnrollment';
+
+import * as api from './data/api';
+
+const FeatureBasedEnrollmentIndexPageWrapper = (props) => (
+  <MemoryRouter>
+    <UserMessagesProvider>
+      <FeatureBasedEnrollmentIndexPage {...props} />
+    </UserMessagesProvider>
+  </MemoryRouter>
+);
+
+describe('Feature Based Enrollment Index Page', () => {
+  let location; let wrapper;
+  const courseId = 'course-v1:testX+test123+2030';
+
+  beforeEach(() => {
+    location = { pathname: '/feature_based_enrollments', search: '' };
+  });
+
+  it('default page render', async () => {
+    wrapper = mount(<FeatureBasedEnrollmentIndexPageWrapper location={location} />);
+
+    const homePageLink = wrapper.find('a');
+    const courseIdInput = wrapper.find('input[name="courseId"]');
+    const searchButton = wrapper.find('button.btn-primary');
+
+    expect(homePageLink.prop('href')).toEqual('/');
+    expect(homePageLink.text()).toEqual('< Back to Tools');
+    expect(courseIdInput.prop('defaultValue')).toEqual(undefined);
+    expect(searchButton.text()).toEqual('Search');
+  });
+
+  it('default page render with query param course id', async () => {
+    location.search = `?course_id=${courseId}`;
+    wrapper = mount(<FeatureBasedEnrollmentIndexPageWrapper location={location} />);
+
+    const homePageLink = wrapper.find('a');
+    const courseIdInput = wrapper.find('input[name="courseId"]');
+    const searchButton = wrapper.find('button.btn-primary');
+
+    expect(homePageLink.prop('href')).toEqual('/');
+    expect(homePageLink.text()).toEqual('< Back to Tools');
+    expect(courseIdInput.prop('defaultValue')).toEqual(courseId);
+    expect(searchButton.text()).toEqual('Search');
+  });
+
+  it('valid search value', async () => {
+    const apiMock = jest.spyOn(api, 'default').mockImplementationOnce(() => Promise.resolve(fbeEnabledResponse));
+    history.push = jest.fn();
+
+    wrapper = mount(<FeatureBasedEnrollmentIndexPageWrapper location={location} />);
+
+    wrapper.find('input[name="courseId"]').instance().value = courseId;
+    wrapper.find('button.btn-primary').simulate('click');
+
+    await waitForComponentToPaint(wrapper);
+    expect(apiMock).toHaveBeenCalledTimes(1);
+    expect(wrapper.find('Card')).toHaveLength(2);
+    expect(history.push).toHaveBeenCalledWith(`/feature_based_enrollments/?course_id=${courseId}`);
+
+    apiMock.mockReset();
+    history.push.mockReset();
+  });
+
+  it('empty search value does not yield anything', async () => {
+    const apiMock = jest.spyOn(api, 'default').mockImplementationOnce(() => Promise.resolve(fbeEnabledResponse));
+    history.replace = jest.fn();
+    wrapper = mount(<FeatureBasedEnrollmentIndexPageWrapper location={location} />);
+
+    wrapper.find('input[name="courseId"]').instance().value = '';
+    wrapper.find('button.btn-primary').simulate('click');
+
+    await waitForComponentToPaint(wrapper);
+    expect(apiMock).toHaveBeenCalledTimes(0);
+    expect(wrapper.find('Card')).toHaveLength(0);
+    expect(history.replace).toHaveBeenCalledWith('/feature_based_enrollments');
+
+    apiMock.mockReset();
+    history.replace.mockReset();
+  });
+
+  it('Invalid search value', async () => {
+    const apiMock = jest.spyOn(api, 'default').mockImplementationOnce(() => Promise.resolve(fbeEnabledResponse));
+    history.replace = jest.fn();
+    wrapper = mount(<FeatureBasedEnrollmentIndexPageWrapper location={location} />);
+
+    wrapper.find('input[name="courseId"]').instance().value = 'invalid-value';
+    wrapper.find('button.btn-primary').simulate('click');
+
+    await waitForComponentToPaint(wrapper);
+    expect(apiMock).toHaveBeenCalledTimes(0);
+    expect(wrapper.find('Card')).toHaveLength(0);
+    expect(wrapper.find('.alert').text()).toEqual('Supplied course ID "invalid-value" is either invalid or incorrect.');
+    expect(history.replace).toHaveBeenCalledWith('/feature_based_enrollments');
+
+    apiMock.mockReset();
+    history.replace.mockReset();
+  });
+});

--- a/src/FeatureBasedEnrollments/data/api.js
+++ b/src/FeatureBasedEnrollments/data/api.js
@@ -1,0 +1,24 @@
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { getConfig } from '@edx/frontend-platform';
+
+const { LMS_BASE_URL } = getConfig();
+
+export default async function getFeatureBasedEnrollmentDetails(courseId) {
+  const apiUrl = `${LMS_BASE_URL}/support/feature_based_enrollment_details/${courseId}`;
+  try {
+    const { data } = await getAuthenticatedHttpClient().get(apiUrl);
+    return data;
+  } catch (error) {
+    return {
+      errors: [
+        {
+          code: null,
+          dismissible: true,
+          text: `Unexpected error while fetching gating information for Course ${courseId}`,
+          type: 'error',
+          topic: 'featureBasedEnrollment',
+        },
+      ],
+    };
+  }
+}

--- a/src/FeatureBasedEnrollments/data/api.test.js
+++ b/src/FeatureBasedEnrollments/data/api.test.js
@@ -1,0 +1,53 @@
+import MockAdapter from 'axios-mock-adapter';
+import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+import { fbeEnabledResponse } from './test/featureBasedEnrollment';
+import * as api from './api';
+
+describe('Feature Based Enrollment API', () => {
+  let mockAdapter;
+
+  const testCourseId = 'course-v1:testX+test123+2030';
+  const fbeDetailsApiUrl = `${getConfig().LMS_BASE_URL}/support/feature_based_enrollment_details/${testCourseId}`;
+
+  const throwError = (errorCode, dataString) => {
+    const error = new Error();
+    error.customAttributes = {
+      httpErrorStatus: errorCode,
+      httpErrorResponseData: JSON.stringify(dataString),
+    };
+    throw error;
+  };
+
+  beforeEach(() => {
+    mockAdapter = new MockAdapter(getAuthenticatedHttpClient(), { onNoMatch: 'throwException' });
+  });
+  afterEach(() => {
+    mockAdapter.reset();
+  });
+
+  it('Successful api fetch', async () => {
+    mockAdapter.onGet(fbeDetailsApiUrl).reply(200, fbeEnabledResponse);
+
+    const response = await api.default(testCourseId);
+    expect(response).toEqual(fbeEnabledResponse);
+  });
+
+  it('Unsuccessful api fetch', async () => {
+    const expectedErrors = [
+      {
+        code: null,
+        dismissible: true,
+        text: 'Unexpected error while fetching gating information for Course course-v1:testX+test123+2030',
+        type: 'error',
+        topic: 'featureBasedEnrollment',
+      },
+    ];
+
+    mockAdapter.onGet(fbeDetailsApiUrl).reply(() => throwError(500, 'Server Error'));
+
+    const response = await api.default(testCourseId);
+    expect(response.errors).toEqual(expectedErrors);
+  });
+});

--- a/src/FeatureBasedEnrollments/data/test/featureBasedEnrollment.js
+++ b/src/FeatureBasedEnrollments/data/test/featureBasedEnrollment.js
@@ -1,0 +1,30 @@
+export const fbeGatingConfigEnabled = {
+  enabled: true,
+  enabledAsOf: new Date('2020/01/01').toISOString(),
+  reason: 'Site',
+};
+
+export const fbeDurationConfigEnabled = {
+  enabled: true,
+  enabledAsOf: new Date('2020/02/01').toISOString(),
+  reason: 'Site Config',
+};
+
+export const fbeGatingConfigDisabled = {
+  enabled: false,
+  enabledAsOf: 'N/A',
+  reason: '',
+};
+
+export const fbeDurationConfigDisabled = {
+  enabled: false,
+  enabledAsOf: 'N/A',
+  reason: '',
+};
+
+export const fbeEnabledResponse = {
+  courseId: 'course-v1:testX+test123+2030',
+  courseName: 'test course',
+  gatingConfig: fbeGatingConfigEnabled,
+  durationConfig: fbeDurationConfigEnabled,
+};

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -15,6 +15,7 @@ import Header from './supportHeader';
 import appMessages from './i18n';
 import UserPage from './users/UserPage';
 // import UserPageV2 from './users/v2/UserPage';
+// import FBEIndexPage from './FeatureBasedEnrollments/FeatureBasedEnrollmentIndexPage';
 import UserMessagesProvider from './userMessages/UserMessagesProvider';
 
 import './index.scss';
@@ -37,6 +38,7 @@ subscribe(APP_READY, () => {
           <Route exact path="/" component={SupportHomePage} />
           <Route path="/users" component={UserPage} />
           {/* <Route path="/usersv2" component={UserPageV2} /> */}
+          {/* <Route path="/feature_based_enrollments" component={FBEIndexPage} /> */}
         </Switch>
       </UserMessagesProvider>
     </AppProvider>,

--- a/src/overrides.scss
+++ b/src/overrides.scss
@@ -26,11 +26,22 @@
   th {
     margin: 0;
     padding: 0.5rem;
-    border-bottom: 1px solid black;
+    border-bottom: 1px solid gray;
   }
   td {
     margin: 0;
     padding: 0.5rem;
+    border-bottom: 1px solid gray;
+  }
+}
+
+.fbe-table {
+  @extend .sso-table;
+  font-size: medium;
+
+  tr:last-child th,
+  tr:last-child td {
+    border-bottom: none;
   }
 }
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,6 @@
 import moment from 'moment';
 
+const COURSE_ID_REGEX = '[^/+]+(/|\\+)[^/+]+(/|\\+)[^/?]+';
 const EMAIL_REGEX = '^[a-zA-Z0-9\'!#$&*._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$';
 const USERNAME_REGEX = '^[\\w.@_+-]+$';
 
@@ -14,6 +15,8 @@ export const formatDate = (date) => {
 export const isEmail = (value) => Boolean(value && value.match(EMAIL_REGEX));
 
 export const isValidUsername = (searchValue) => Boolean(searchValue && searchValue.match(USERNAME_REGEX));
+
+export const isValidCourseID = (value) => Boolean(value && value.match(COURSE_ID_REGEX));
 
 export function sort(firstElement, secondElement, key, direction) {
   const directionIsAsc = direction === 'asc';

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -1,5 +1,5 @@
 import {
-  isEmail, isValidUsername, formatDate, sort, titleCase, sortedCompareDates,
+  isEmail, isValidUsername, formatDate, sort, titleCase, sortedCompareDates, isValidCourseID,
 } from './index';
 
 describe('Test Utils', () => {
@@ -16,14 +16,18 @@ describe('Test Utils', () => {
     ];
     const validUsername = ['staff', 'admin123'];
     const invalidUsername = ['', ' ', undefined, 'invalid username', '%invalid'];
-    test.each(validEmails)('isEmail return true for %s', (email) => {
+
+    const validCourseID = ['course-v1:testX+test101+2020', 'course-v1/testX/test101/2020'];
+    const invalidCourseID = ['invalid-course-id', 'course-v1:testX+test101', 'no-id'];
+
+    test.each(validEmails)('isEmail returns true for %s', (email) => {
       expect(isEmail(email)).toBe(true);
     });
-    test.each(invalidEmails)('isEmail return false for %s', (email) => {
+    test.each(invalidEmails)('isEmail returns false for %s', (email) => {
       expect(isEmail(email)).toBe(false);
     });
 
-    test.each(validUsername)('isValidUsername return true for %s', (username) => {
+    test.each(validUsername)('isValidUsername returns true for %s', (username) => {
       expect(isValidUsername(username)).toBe(true);
     });
     test.each(invalidUsername)(
@@ -32,6 +36,14 @@ describe('Test Utils', () => {
         expect(isValidUsername(username)).toBe(false);
       },
     );
+
+    test.each(validCourseID)('isValidCourseID returns true for %s', (courseId) => {
+      expect(isValidCourseID(courseId)).toBe(true);
+    });
+
+    test.each(invalidCourseID)('isValidCourseID returns false for %s', (courseId) => {
+      expect(isValidCourseID(courseId)).toBe(false);
+    });
   });
 
   describe('Format Date', () => {


### PR DESCRIPTION
### [PROD-2477](https://openedx.atlassian.net/browse/PROD-2477)

### Description
Adds the component to get feature-based enrollment details for a particular course. To test out the component,

1. Uncomment FBE route and component import from index.js
2. Create a course in studio. Make sure the course has both audit and verified modes(http://localhost:18000/admin/course_modes/coursemode/)
3. Set the course start date in past
4. Navigate to http://localhost:18000/admin/content_type_gating/contenttypegatingconfig/add/.
Create a record at the site level with Enabled = Yes and Enabled As Of set to some date in the past.
5. Repeat the last step for http://localhost:18000/admin/course_duration_limits/coursedurationlimitconfig/add/

First verify that the FBE api(http://localhost:18000/support/feature_based_enrollment_details/<course_id>) returns some response instead of being an empty dict. If the empty dict is returned, try associating the created course with the configs added in 4 & 5. There is a field present in that config model. 

**NOTE: There is a small issue with FBE component at the moment. When the course id is added in the search bar, search button is clicked and a valid response is returned, clicking the search button again without changing the value does not result in any api call. The child component triggers useEffect only when the course id has changed. This will be fixed in a followup PR**


### Things to verify

- Valid/Invalid course ids behavior
- addition/update of query param in the url when changing the value
- adding a query param manually, refreshing the page, and make sure input field has that value

### Screenshots
<img width="1675" alt="Screenshot 2021-09-22 at 10 21 04 PM" src="https://user-images.githubusercontent.com/40599381/134391448-7315602a-4ff6-46ce-b826-af78dae88066.png">


<img width="1675" alt="Screenshot 2021-09-22 at 10 21 29 PM" src="https://user-images.githubusercontent.com/40599381/134391478-2d8690e3-4582-4639-b44d-fb44d4fa5210.png">

<img width="1675" alt="Screenshot 2021-09-22 at 10 22 21 PM" src="https://user-images.githubusercontent.com/40599381/134391622-e7046c7e-c256-4221-9bd2-92c42e170725.png">

