### PR TITLE
feat: add licenses component v2

### DIFF
--- a/src/overrides.scss
+++ b/src/overrides.scss
@@ -45,6 +45,10 @@
   }
 }
 
+.badge-status {
+  border-radius: 3px;
+}
+
 .fbe-table {
   @extend .sso-table;
   font-size: medium;

--- a/src/users/licenses/v2/LicenseCard.jsx
+++ b/src/users/licenses/v2/LicenseCard.jsx
@@ -1,0 +1,102 @@
+import React, {
+  useMemo,
+} from 'react';
+import PropTypes from 'prop-types';
+import {
+  Badge, Card, Row, Col,
+} from '@edx/paragon';
+import TableV2 from '../../../components/Table';
+import { formatDate } from '../../../utils';
+
+export default function LicenseCard({
+  licenseRecord,
+}) {
+  const statusMapping = {
+    activated: 'success',
+    revoked: 'danger',
+    assigned: 'info',
+    unassigned: 'primary',
+  };
+  const tableData = useMemo(() => {
+    if (licenseRecord == null) {
+      return [];
+    }
+    return [licenseRecord].map(record => ({
+      assignedDate: formatDate(record.assignedDate),
+      activationDate: formatDate(record.activationDate),
+      revokedDate: formatDate(record.revokedDate),
+      lastRemindDate: formatDate(record.lastRemindDate),
+      activationLink: <a href={record.activationLink} rel="noopener noreferrer" target="_blank" className="word_break">{record.activationLink}</a>,
+    }));
+  }, [licenseRecord]);
+
+  const columns = React.useMemo(
+    () => [
+      {
+        Header: 'Assigned Date', accessor: 'assignedDate',
+      },
+      {
+        Header: 'Activation Date', accessor: 'activationDate',
+      },
+      {
+        Header: 'Revoked Date', accessor: 'revokedDate',
+      },
+      {
+        Header: 'Last Remind Date', accessor: 'lastRemindDate',
+      },
+      {
+        Header: 'Activation Link', accessor: 'activationLink',
+      },
+    ],
+    [],
+  );
+
+  return (
+    tableData && tableData.length ? (
+      <Card className="pt-2 px-3 mb-1 w-100">
+        <Card.Body className="p-0">
+          <Card.Title as="h3" className="btn-header mt-4">
+            {licenseRecord.subscriptionPlanTitle}
+          </Card.Title>
+          <Row>
+            <Col>
+              <Card.Subtitle align="left" as="h4">
+                <Badge variant={statusMapping[licenseRecord.status]} className="badge-status">{licenseRecord.status}</Badge>
+              </Card.Subtitle>
+            </Col>
+            <Col>
+              <Card.Subtitle align="right" as="h4">
+                Plan Expiration: {formatDate(licenseRecord.subscriptionPlanExpirationDate)}
+              </Card.Subtitle>
+            </Col>
+          </Row>
+
+          <Card.Title as="h5" className="btn-header mt-4">
+            Additional Data
+          </Card.Title>
+          <TableV2
+            data={tableData}
+            columns={columns}
+            styleName="sso-table"
+            id="license-data-new"
+          />
+        </Card.Body>
+      </Card>
+    ) : (
+      <></>
+    )
+  );
+}
+
+LicenseCard.propTypes = {
+  licenseRecord: PropTypes.shape({
+    status: PropTypes.string,
+    assignedDate: PropTypes.string,
+    activationDate: PropTypes.string,
+    revokedDate: PropTypes.string,
+    lastRemindDate: PropTypes.string,
+    activationLink: PropTypes.string,
+    subscriptionPlanTitle: PropTypes.string,
+    subscriptionPlanExpirationDate: PropTypes.string,
+  }).isRequired,
+};

--- a/src/users/licenses/v2/Licenses.jsx
+++ b/src/users/licenses/v2/Licenses.jsx
@@ -1,0 +1,53 @@
+import React, {
+  useState,
+  useEffect,
+} from 'react';
+import PropTypes from 'prop-types';
+import { camelCaseObject } from '@edx/frontend-platform';
+import {
+  Row, Col,
+} from '@edx/paragon';
+import { getLicense } from '../../data/api';
+import PageLoading from '../../../components/common/PageLoading';
+import LicenseCard from './LicenseCard';
+
+export default function Licenses({
+  userEmail,
+}) {
+  const [licenses, setLicensesData] = useState(null);
+  const [status, setStatus] = useState(null);
+
+  useEffect(() => {
+    getLicense(userEmail).then((data) => {
+      const camelCaseData = camelCaseObject(data);
+      setLicensesData(camelCaseData.results);
+      setStatus(camelCaseData.status);
+    });
+  }, [userEmail]);
+
+  return (
+    <section className="mb-3">
+      <h3 id="licenses-title-header" className="ml-4 mt-4">Licenses Subscription</h3>
+      {/* eslint-disable-next-line no-nested-ternary */}
+      {licenses ? (
+        licenses.length ? (
+          <Row id="licenses-records-list">
+            {licenses.map(record => (
+              <Col xs={12}>
+                <LicenseCard licenseRecord={record} />
+              </Col>
+            ))}
+          </Row>
+        ) : (
+          <p className="ml-4">{status}</p>
+        )
+      ) : (
+        <PageLoading srMessage="Loading" />
+      )}
+    </section>
+  );
+}
+
+Licenses.propTypes = {
+  userEmail: PropTypes.string.isRequired,
+};

--- a/src/users/licenses/v2/Licenses.test.jsx
+++ b/src/users/licenses/v2/Licenses.test.jsx
@@ -1,0 +1,44 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { camelCaseObject } from '@edx/frontend-platform';
+import { waitForComponentToPaint } from '../../../setupTest';
+import Licenses from './Licenses';
+import licensesData from '../../data/test/licenses';
+import * as api from '../../data/api';
+
+describe('Single Sign On Records', () => {
+  let wrapper;
+  const props = {
+    userEmail: 'user@example.com',
+  };
+
+  beforeEach(async () => {
+    jest.spyOn(api, 'getLicense').mockImplementationOnce(() => Promise.resolve(camelCaseObject(licensesData)));
+    wrapper = mount(<Licenses {...props} />);
+    await waitForComponentToPaint(wrapper);
+  });
+
+  it('Licenses props', () => {
+    const userEmail = wrapper.prop('userEmail');
+    expect(userEmail).toEqual(props.userEmail);
+  });
+
+  it('Licenses Data', () => {
+    const cardList = wrapper.find('Card');
+    expect(cardList).toHaveLength(licensesData.results.length);
+    expect(wrapper.find('h3#licenses-title-header').text()).toEqual('Licenses Subscription');
+  });
+
+  it('No Licenses Data', async () => {
+    jest.spyOn(api, 'getLicense').mockImplementationOnce(() => Promise.resolve({ ...licensesData, results: [], status: 'No records found.' }));
+    wrapper = mount(<Licenses {...props} />);
+    await waitForComponentToPaint(wrapper);
+
+    expect(wrapper.find('h3#licenses-title-header').text()).toEqual('Licenses Subscription');
+    const cardList = wrapper.find('Card');
+    expect(cardList).toHaveLength(0);
+
+    const noRecordMessage = wrapper.find('p');
+    expect(noRecordMessage.text()).toEqual('No records found.');
+  });
+});

--- a/src/users/licenses/v2/LicensesCard.test.jsx
+++ b/src/users/licenses/v2/LicensesCard.test.jsx
@@ -1,0 +1,57 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { camelCaseObject } from '@edx/frontend-platform';
+import { waitForComponentToPaint } from '../../../setupTest';
+import licenseData from '../../data/test/licenses';
+import LicenseCard from './LicenseCard';
+import { formatDate } from '../../../utils';
+
+describe.each(licenseData.results)('License Record Card', (licenseRecord) => {
+  // prepare data
+  const licenseRecordProp = camelCaseObject(licenseRecord);
+
+  let wrapper;
+  let props;
+
+  beforeEach(async () => {
+    props = {
+      licenseRecord: licenseRecordProp,
+    };
+    wrapper = mount(<LicenseCard {...props} />);
+    await waitForComponentToPaint(wrapper);
+  });
+
+  it('License props', () => {
+    const licenseRecordProps = wrapper.prop('licenseRecord');
+    expect(licenseRecordProps).toEqual(props.licenseRecord);
+  });
+
+  it('No License Data', async () => {
+    props = {
+      licenseRecord: null,
+    };
+    wrapper = mount(<LicenseCard {...props} />);
+    await waitForComponentToPaint(wrapper);
+
+    expect(wrapper.isEmptyRender()).toBeTruthy();
+  });
+
+  it('License Record', () => {
+    const title = wrapper.find('h3.card-title');
+    const status = wrapper.find('h4.card-subtitle').at(0);
+    const expire = wrapper.find('h4.card-subtitle').at(1);
+
+    expect(title.text()).toEqual(licenseRecordProp.subscriptionPlanTitle);
+    expect(status.text()).toEqual(licenseRecordProp.status);
+    expect(expire.text()).toEqual(`Plan Expiration: ${formatDate(licenseRecordProp.subscriptionPlanExpirationDate)}`);
+  });
+
+  it('License Record Additional Data', () => {
+    const dataTable = wrapper.find('Table#license-data-new');
+    const dataHeader = dataTable.find('thead tr th');
+    const dataBody = dataTable.find('tbody tr td');
+
+    expect(dataHeader).toHaveLength(Object.keys(licenseRecordProp).length - 3);
+    expect(dataBody).toHaveLength(Object.keys(licenseRecordProp).length - 3);
+  });
+});

--- a/src/users/v2/LearnerInformation.jsx
+++ b/src/users/v2/LearnerInformation.jsx
@@ -4,7 +4,7 @@ import { Tabs, Tab } from '@edx/paragon';
 import UserSummary from '../UserSummary';
 import EnrollmentsV2 from '../enrollments/v2/Enrollments';
 import SingleSignOnRecords from './SingleSignOnRecords';
-import Licenses from '../licenses/Licenses';
+import Licenses from '../licenses/v2/Licenses';
 import EntitlementsV2 from '../entitlements/v2/Entitlements';
 
 export default function LearnerInformation({

--- a/src/users/v2/LearnerInformation.test.jsx
+++ b/src/users/v2/LearnerInformation.test.jsx
@@ -97,6 +97,6 @@ describe('Learners and Enrollments component', () => {
     const enrollmentsEntitlements = wrapper.find('.tab-content div#learner-information-tabpane-sso');
     expect(enrollmentsEntitlements.html()).toEqual(expect.stringContaining('active'));
     expect(enrollmentsEntitlements.html()).toEqual(expect.stringContaining('SSO Records'));
-    expect(enrollmentsEntitlements.html()).toEqual(expect.stringContaining('Licenses (2)'));
+    expect(enrollmentsEntitlements.html()).toEqual(expect.stringContaining('Licenses Subscription'));
   });
 });

--- a/src/users/v2/SingleSignOnRecords.jsx
+++ b/src/users/v2/SingleSignOnRecords.jsx
@@ -1,6 +1,9 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { camelCaseObject } from '@edx/frontend-platform';
 import PropTypes from 'prop-types';
+import {
+  Row, Col,
+} from '@edx/paragon';
 import UserMessagesContext from '../../userMessages/UserMessagesContext';
 import { getSsoRecords } from '../data/api';
 import PageLoading from '../../components/common/PageLoading';
@@ -30,15 +33,13 @@ export default function SingleSignOnRecords({ username }) {
       {/* eslint-disable-next-line no-nested-ternary */}
       {ssoRecords ? (
         ssoRecords.length ? (
-          <div id="sso-records-list" className="ml-3">
+          <Row id="sso-records-list">
             {ssoRecords.map(record => (
-              <>
-                <div className="row">
-                  <SingleSignOnRecordCard ssoRecord={record} />
-                </div>
-              </>
+              <Col xs={12}>
+                <SingleSignOnRecordCard ssoRecord={record} />
+              </Col>
             ))}
-          </div>
+          </Row>
         ) : (
           <p className="ml-4">No SSO Records were Found.</p>
         ))


### PR DESCRIPTION
## Description
This PR adds Card and List component for Licenses Records as part of Support Tool Redesign.

- uses new Table variant for rendering data Table
- width set to 100% per card as per design
- table width set to auto to avoid table consuming the entire card
- single card per row

## Linked Ticket
[PROD-2505](https://openedx.atlassian.net/browse/PROD-2505)

## Screenshots
No Data:
![image](https://user-images.githubusercontent.com/47540683/134924816-b5a674e0-5cd1-41ff-b0fd-c1413b61f73f.png)
Multiple Records:
![image](https://user-images.githubusercontent.com/47540683/135236102-d466726c-b8d4-4730-9a62-46ebaa3cf939.png)

## How to test locally:
1. Uncomment route component for `usersv2`
2. Setup [edx/license-manager](https://github.com/edx/license-manager) and add subscription by following:
- Add Enterprise Customer: http://localhost:18000/admin/enterprise/enterprisecustomer/
- Add Subscription Plan against Enterprise Customer: http://localhost:18170/admin/subscriptions/subscriptionplan/
- Add License against Subscription Plan: http://localhost:18170/admin/subscriptions/license/
- Note: only use User email to add license against a LMS user

## TODO
- [x] write component test
- [x] remove table and add card per record
