### PR TITLE
feat: add user summary v2

### DIFF
--- a/src/FeatureBasedEnrollments/FeatureBasedEnrollmentIndexPage.test.jsx
+++ b/src/FeatureBasedEnrollments/FeatureBasedEnrollmentIndexPage.test.jsx
@@ -39,6 +39,7 @@ describe('Feature Based Enrollment Index Page', () => {
   });
 
   it('default page render with query param course id', async () => {
+    const apiMock = jest.spyOn(api, 'default').mockImplementationOnce(() => Promise.resolve({}));
     location.search = `?course_id=${courseId}`;
     wrapper = mount(<FeatureBasedEnrollmentIndexPageWrapper location={location} />);
 
@@ -50,6 +51,7 @@ describe('Feature Based Enrollment Index Page', () => {
     expect(homePageLink.text()).toEqual('< Back to Tools');
     expect(courseIdInput.prop('defaultValue')).toEqual(courseId);
     expect(searchButton.text()).toEqual('Search');
+    apiMock.mockReset();
   });
 
   it('valid search value', async () => {

--- a/src/overrides.scss
+++ b/src/overrides.scss
@@ -1,12 +1,14 @@
 // Reverting the container width to 1440px to keep the support tools styling consistent
 // See https://github.com/edx/paragon/pull/533 for paragon breaking change
 
+$darkCyan: #00262b;
+
 .learner-information {
   color: black;
   .nav-link.active {
     border-color: #fff;
-    color: #00262B;
-    border-bottom-color: #00262B;
+    color: $darkCyan;
+    border-bottom-color: $darkCyan;
     border-width: medium;
   }
 }
@@ -47,6 +49,35 @@
 
 .badge-status {
   border-radius: 3px;
+}
+
+.account-info {
+  font-size: large;
+  width: auto;
+  border: none;
+  border-radius: 0;
+
+  border-right: 1px solid lightgray;
+
+  table th {
+    margin: 0.5rem;
+    padding: 0.5rem;
+    border-bottom: 1px solid lightgray;
+    width: 30%;
+  }
+  table td {
+    margin: 0.5rem;
+    padding: 0.5rem;
+    border-bottom: 1px solid lightgray;
+    word-break: break-word;
+    width: 70%;
+  }
+}
+
+.account-actions {
+  border: 1px solid lightgray;
+  font-size: medium;
+  border-radius: 0.375rem;
 }
 
 .fbe-table {

--- a/src/users/account-actions/AccountActions.jsx
+++ b/src/users/account-actions/AccountActions.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import TogglePasswordStatus from './TogglePasswordStatus';
+import ResetPassword from './ResetPassword';
+import PasswordHistory from './PasswordHistory';
+
+export default function AccountActions({ userData, changeHandler }) {
+  return (
+    <>
+      <h3 className="w-100">Account Actions</h3>
+      <TogglePasswordStatus
+        username={userData.username}
+        passwordStatus={userData.passwordStatus}
+        changeHandler={changeHandler}
+      />
+      <ResetPassword
+        email={userData.email}
+        changeHandler={changeHandler}
+      />
+      <PasswordHistory
+        passwordStatus={userData.passwordStatus}
+      />
+    </>
+  );
+}
+
+AccountActions.propTypes = {
+  userData: PropTypes.shape({
+    username: PropTypes.string,
+    email: PropTypes.string,
+    passwordStatus: PropTypes.shape({
+      status: PropTypes.string,
+      passwordToggleHistory: PropTypes.arrayOf(PropTypes.shape(
+        {
+          created: PropTypes.string.isRequired,
+          comment: PropTypes.string.isRequired,
+          disabled: PropTypes.bool.isRequired,
+          createdBy: PropTypes.string.isRequired,
+        },
+      )),
+    }),
+  }).isRequired,
+  changeHandler: PropTypes.func.isRequired,
+};

--- a/src/users/account-actions/AccountActions.test.jsx
+++ b/src/users/account-actions/AccountActions.test.jsx
@@ -1,0 +1,34 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import AccountActions from './AccountActions';
+import UserSummaryData from '../data/test/userSummary';
+
+describe('Account Actions Component Tests', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(<AccountActions {...UserSummaryData} />);
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('Action Buttons rendered', () => {
+    const passwordHistoryButton = wrapper.find('button#toggle-password-history');
+    const toggleUserStatusButton = wrapper.find('button#toggle-password');
+    const passwordResetEmailButton = wrapper.find('button#reset-password');
+
+    expect(passwordHistoryButton.text()).toEqual('Show History');
+    expect(passwordHistoryButton.disabled).toBeFalsy();
+
+    expect(toggleUserStatusButton.text()).toEqual('Disable User');
+    expect(toggleUserStatusButton.disabled).toBeFalsy();
+
+    expect(passwordResetEmailButton.text()).toEqual('Reset Password');
+    expect(passwordResetEmailButton.disabled).toBeFalsy();
+
+    expect(wrapper.find('h3').text()).toEqual('Account Actions');
+  });
+});

--- a/src/users/account-actions/PasswordHistory.jsx
+++ b/src/users/account-actions/PasswordHistory.jsx
@@ -69,5 +69,14 @@ export default function PasswordHistory({
 }
 
 PasswordHistory.propTypes = {
-  passwordStatus: PropTypes.string.isRequired,
+  passwordStatus: PropTypes.shape({
+    passwordToggleHistory: PropTypes.arrayOf(PropTypes.shape(
+      {
+        created: PropTypes.string.isRequired,
+        comment: PropTypes.string.isRequired,
+        disabled: PropTypes.bool.isRequired,
+        createdBy: PropTypes.string.isRequired,
+      },
+    )),
+  }).isRequired,
 };

--- a/src/users/account-actions/TogglePasswordStatus.jsx
+++ b/src/users/account-actions/TogglePasswordStatus.jsx
@@ -60,6 +60,8 @@ export default function TogglePasswordStatus({
 
 TogglePasswordStatus.propTypes = {
   username: PropTypes.string.isRequired,
-  passwordStatus: PropTypes.string.isRequired,
+  passwordStatus: PropTypes.shape({
+    status: PropTypes.string.isRequired,
+  }).isRequired,
   changeHandler: PropTypes.func.isRequired,
 };

--- a/src/users/v2/LearnerInformation.jsx
+++ b/src/users/v2/LearnerInformation.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from '@edx/paragon';
-import UserSummary from '../UserSummary';
+import UserSummary from './UserSummary';
 import EnrollmentsV2 from '../enrollments/v2/Enrollments';
 import SingleSignOnRecords from './SingleSignOnRecords';
 import Licenses from '../licenses/v2/Licenses';

--- a/src/users/v2/LearnerInformation.test.jsx
+++ b/src/users/v2/LearnerInformation.test.jsx
@@ -67,7 +67,7 @@ describe('Learners and Enrollments component', () => {
 
     const accountInfo = wrapper.find('.tab-content div#learner-information-tabpane-account');
     expect(accountInfo.html()).toEqual(expect.stringContaining('active'));
-    expect(accountInfo.find('#account-table h4').text()).toEqual('Account');
+    expect(accountInfo.find('#account-table h3').text()).toEqual('Account Details');
   });
 
   it('Enrollments/Entitlements Tab', () => {

--- a/src/users/v2/UserSummary.jsx
+++ b/src/users/v2/UserSummary.jsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { formatDate } from '../../utils';
+import { getAccountActivationUrl } from '../data/urls';
+import IdentityVerificationStatus from '../IdentityVerificationStatus';
+import OnboardingStatus from '../OnboardingStatus';
+import AccountActions from '../account-actions/AccountActions';
+
+export default function UserSummary({
+  userData,
+  changeHandler,
+}) {
+  return (
+    <section className="mb-3">
+      <div className="d-flex flex-row flex-wrap">
+        <div className="col-sm-6">
+
+          <div id="account-table" className="flex-column pr-4 m-3 card account-info">
+            <h3>Account Details</h3>
+            <table>
+              <tbody>
+
+                <tr>
+                  <th>Full Name</th>
+                  <td>{userData.name}</td>
+                </tr>
+
+                <tr>
+                  <th>Username</th>
+                  <td>{userData.username}</td>
+                </tr>
+
+                <tr>
+                  <th>LMS User ID</th>
+                  <td>{userData.id}</td>
+                </tr>
+
+                <tr>
+                  <th>Email</th>
+                  <td>{userData.email}</td>
+                </tr>
+
+                <tr>
+                  <th>{!userData.isActive ? 'Activation Key/Link' : 'Active'}</th>
+                  <td>
+                    {
+                    // eslint-disable-next-line no-nested-ternary
+                    userData.isActive
+                      ? 'yes'
+                      : (
+                        userData.activationKey !== null
+                          ? <a href={getAccountActivationUrl(userData.activationKey)} rel="noopener noreferrer" target="_blank" className="word_break">{userData.activationKey}</a>
+                          : 'N/A'
+                      )
+                    }
+                  </td>
+                </tr>
+
+                <tr>
+                  <th>Country</th>
+                  <td>{userData.country}</td>
+                </tr>
+
+                <tr>
+                  <th>Join Date/Time</th>
+                  <td>{formatDate(userData.dateJoined)}</td>
+                </tr>
+
+                <tr>
+                  <th>Last Login</th>
+                  <td>{formatDate(userData.lastLogin)}</td>
+                </tr>
+
+                <tr>
+                  <th>Password Status</th>
+                  <td>{userData.passwordStatus.status}</td>
+                </tr>
+
+              </tbody>
+
+            </table>
+          </div>
+        </div>
+        <div className="col-sm-6">
+          <div className="row p-4 m-3 account-actions" id="account-actions">
+            <AccountActions userData={userData} changeHandler={changeHandler} />
+          </div>
+          <div className="flex-column">
+            <IdentityVerificationStatus username={userData.username} />
+            <OnboardingStatus username={userData.username} />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+UserSummary.propTypes = {
+  userData: PropTypes.shape({
+    name: PropTypes.string,
+    username: PropTypes.string,
+    id: PropTypes.number,
+    email: PropTypes.string,
+    activationKey: PropTypes.string,
+    isActive: PropTypes.bool,
+    country: PropTypes.string,
+    dateJoined: PropTypes.string,
+    lastLogin: PropTypes.string,
+    passwordStatus: PropTypes.shape({
+      status: PropTypes.string,
+      passwordToggleHistory: PropTypes.arrayOf(PropTypes.shape(
+        {
+          created: PropTypes.string.isRequired,
+          comment: PropTypes.string.isRequired,
+          disabled: PropTypes.bool.isRequired,
+          createdBy: PropTypes.string.isRequired,
+        },
+      )),
+    }),
+  }).isRequired,
+  changeHandler: PropTypes.func.isRequired,
+};

--- a/src/users/v2/UserSummary.test.jsx
+++ b/src/users/v2/UserSummary.test.jsx
@@ -1,0 +1,148 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import * as api from '../data/api';
+import UserSummary from './UserSummary';
+import UserSummaryData from '../data/test/userSummary';
+import UserMessagesProvider from '../../userMessages/UserMessagesProvider';
+import idvStatusData from '../data/test/idvStatus';
+import enrollmentsData from '../data/test/enrollments';
+import onboardingStatusData from '../data/test/onboardingStatus';
+import { waitForComponentToPaint } from '../../setupTest';
+
+const UserSummaryWrapper = (props) => (
+  <UserMessagesProvider>
+    <UserSummary {...props} />
+  </UserMessagesProvider>
+);
+
+describe('User Summary Component Tests', () => {
+  let wrapper;
+
+  const mountUserSummaryWrapper = async (data) => {
+    jest.spyOn(api, 'getUserVerificationStatus').mockImplementationOnce(() => Promise.resolve(idvStatusData));
+    jest.spyOn(api, 'getEnrollments').mockImplementationOnce(() => Promise.resolve(enrollmentsData));
+    jest.spyOn(api, 'getOnboardingStatus').mockImplementationOnce(() => Promise.resolve(onboardingStatusData));
+    wrapper = mount(<UserSummaryWrapper {...data} />);
+    await waitForComponentToPaint(wrapper);
+  };
+
+  beforeEach(() => {
+    mountUserSummaryWrapper(UserSummaryData);
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  describe('Default Correct Data Values', () => {
+    it('User Data Values', () => {
+      const ComponentUserData = wrapper.prop('userData');
+      const ExpectedUserData = UserSummaryData.userData;
+      Object.keys(ComponentUserData).forEach(key => {
+        expect(ComponentUserData[key]).not.toEqual(undefined);
+        expect(ExpectedUserData[key]).not.toEqual(undefined);
+        expect(ComponentUserData[key]).toEqual(ExpectedUserData[key]);
+      });
+    });
+
+    it('Data Table Render', () => {
+      const dataTable = wrapper.find('#account-table table tr');
+      const expectedData = [
+        {
+          header: 'Full Name',
+          value: 'edx',
+        },
+        {
+          header: 'Username',
+          value: 'edx',
+        },
+        {
+          header: 'LMS User ID',
+          value: '1',
+        },
+        {
+          header: 'Email',
+          value: 'edx@example.com',
+        },
+        {
+          header: 'Active',
+          value: 'yes',
+        },
+        {
+          header: 'Country',
+          value: 'US',
+        },
+        {
+          header: 'Join Date/Time',
+          value: 'N/A',
+        },
+        {
+          header: 'Last Login',
+          value: 'N/A',
+        },
+        {
+          header: 'Password Status',
+          value: 'Usable',
+        },
+      ];
+      expectedData.forEach((item, index) => {
+        expect(dataTable.at(index).find('th').text()).toEqual(item.header);
+        expect(dataTable.at(index).find('td').text()).toEqual(item.value);
+      });
+    });
+
+    it('Account Actions', () => {
+      const actionsContainer = wrapper.find('div#account-actions');
+
+      expect(actionsContainer.find('h3').text()).toEqual('Account Actions');
+      expect(actionsContainer.find('button#toggle-password').text()).toEqual('Disable User');
+      expect(actionsContainer.find('button#reset-password').text()).toEqual('Reset Password');
+      expect(actionsContainer.find('button#toggle-password-history').text()).toEqual('Show History');
+    });
+  });
+
+  describe('Registration Activation Field', () => {
+    const getActivationKeyRow = (data) => {
+      mountUserSummaryWrapper(data);
+      const dataTable = wrapper.find('#account-table table');
+      const rowName = dataTable.find('tbody tr').at(4).find('th').at(0);
+      const rowValue = dataTable.find('tbody tr').at(4).find('td').at(0);
+
+      return {
+        rowName,
+        rowValue,
+      };
+    };
+
+    it('Active User Data', () => {
+      const { rowName, rowValue } = getActivationKeyRow(UserSummaryData);
+      expect(rowName.text()).not.toEqual('Activation Key/Link');
+      expect(rowValue.text()).not.toEqual(UserSummaryData.userData.activationKey);
+    });
+
+    it('Inactive User Data ', () => {
+      const InActiveUserData = { ...UserSummaryData.userData, isActive: false };
+      const InActiveUserSummaryData = { ...UserSummaryData, userData: InActiveUserData };
+      const { rowName, rowValue } = getActivationKeyRow(InActiveUserSummaryData);
+      expect(rowName.text()).toEqual('Activation Key/Link');
+      expect(rowValue.text()).toEqual(UserSummaryData.userData.activationKey);
+    });
+
+    it('Active User With No Registration Data ', () => {
+      const InActiveUserData = { ...UserSummaryData.userData, activationKey: null };
+      const InActiveUserSummaryData = { ...UserSummaryData, userData: InActiveUserData };
+      const { rowName, rowValue } = getActivationKeyRow(InActiveUserSummaryData);
+      expect(rowName.text()).not.toEqual('Activation Key/Link');
+      expect(rowValue.text()).not.toEqual(UserSummaryData.userData.activationKey);
+    });
+
+    it('Inactive User With No Registration Data ', () => {
+      const InActiveUserData = { ...UserSummaryData.userData, activationKey: null, isActive: false };
+      const InActiveUserSummaryData = { ...UserSummaryData, userData: InActiveUserData };
+      const { rowName, rowValue } = getActivationKeyRow(InActiveUserSummaryData);
+      expect(rowName.text()).toEqual('Activation Key/Link');
+      expect(rowValue.text()).toEqual('N/A');
+    });
+  });
+});


### PR DESCRIPTION
### [PROD-2506](https://openedx.atlassian.net/browse/PROD-2506)

### Description
Add User Summary/Account information v2 component. Besides the component addition, a few updates are:

- Fixing propType warning for account actions
- Updating one FBE component test
- Creating a new wrapper component for account actions

### Screenshots
<img width="1617" alt="Screenshot 2021-09-28 at 4 28 20 PM" src="https://user-images.githubusercontent.com/40599381/135079302-902bbd7c-cbd5-4154-9c22-bec2a811cecb.png">
<img width="1617" alt="Screenshot 2021-09-28 at 4 28 33 PM" src="https://user-images.githubusercontent.com/40599381/135079307-190700e2-0d84-4aef-bb21-f93824109145.png">

<img width="1617" alt="Screenshot 2021-09-28 at 4 28 05 PM" src="https://user-images.githubusercontent.com/40599381/135079289-367348fc-26f2-44ba-87df-f188fbb2900b.png">


### Testing Instructions/Pointers
- Uncomment usersv2 route from index page
- Add a valid username/email info
- manually edit any value to be a much larger value and see if there are any overflow issues
- To check activation key, create a user manually from LMS via Sign up. Once created, change their active status to False from admin. 

