### PR TITLE
feat: add certificate tool modal

### DIFF
--- a/src/overrides.scss
+++ b/src/overrides.scss
@@ -90,6 +90,12 @@ $darkCyan: #00262b;
   }
 }
 
+.certificate-info-table {
+  @extend .sso-table;
+  width: 100%;
+  font-size: large;
+}
+
 .custom-expander-table {
   font-size: small;
   margin-left: 10%;

--- a/src/users/enrollments/v2/Certificates.jsx
+++ b/src/users/enrollments/v2/Certificates.jsx
@@ -1,0 +1,198 @@
+import React, {
+  useContext,
+  useEffect,
+  useState,
+  useRef,
+  useLayoutEffect,
+} from 'react';
+import { camelCaseObject, getConfig } from '@edx/frontend-platform';
+import PropTypes from 'prop-types';
+import { Alert, Button, Modal } from '@edx/paragon';
+import PageLoading from '../../../components/common/PageLoading';
+import { formatDate } from '../../../utils';
+import { getCertificate, generateCertificate, regenerateCertificate } from '../../data/api';
+import UserMessagesContext from '../../../userMessages/UserMessagesContext';
+import AlertList from '../../../userMessages/AlertList';
+
+export default function Certificates({
+  username, courseId, closeHandler,
+}) {
+  const { add, clear } = useContext(UserMessagesContext);
+  const [displayCertErrors, setDisplayCertificateErrors] = useState(false);
+  const [certificate, setCertificate] = useState(undefined);
+  const [status, setStatus] = useState(undefined);
+  const [buttonDisabled, setButtonDisabled] = useState(false);
+  const [modalIsOpen, setModalIsOpen] = useState(true);
+  // eslint-disable-next-line no-use-before-define
+  const oldCourseId = usePrevious(courseId);
+  const certificateRef = useRef(null);
+
+  useEffect(() => {
+    setCertificate(undefined);
+  }, [courseId]);
+
+  useEffect(() => {
+    if ((certificate === undefined && !displayCertErrors) || (courseId !== oldCourseId)) {
+      getCertificate(username, courseId).then((result) => {
+        const camelCaseResult = camelCaseObject(result);
+        if (camelCaseResult.errors) {
+          clear('certificates');
+          camelCaseResult.errors.forEach(error => add(error));
+          setDisplayCertificateErrors(true);
+        } else {
+          setDisplayCertificateErrors(false);
+          setCertificate(camelCaseResult);
+        }
+      });
+    }
+  }, [certificate, courseId]);
+
+  useLayoutEffect(() => {
+    if (certificateRef != null) {
+      certificateRef.current.focus();
+    }
+  });
+
+  function usePrevious(value) {
+    const ref = useRef();
+    useEffect(() => {
+      ref.current = value;
+    }, [value]);
+    return ref.current;
+  }
+
+  function postGenerateCertificate() {
+    setButtonDisabled(true);
+    setStatus('Generating New Certificate');
+    generateCertificate(username, certificate.courseKey).then((result) => {
+      if (result.errors) {
+        clear('certificates');
+        result.errors.forEach(error => add(error));
+        setDisplayCertificateErrors(true);
+      } else {
+        setDisplayCertificateErrors(false);
+        setCertificate(undefined);
+      }
+      setButtonDisabled(false);
+      setStatus(undefined);
+    });
+  }
+
+  function postRegenerateCertificate() {
+    setButtonDisabled(true);
+    setStatus('Regenerating Certificate');
+    regenerateCertificate(username, certificate.courseKey).then((result) => {
+      if (result.errors) {
+        clear('certificates');
+        result.errors.forEach(error => add(error));
+        setDisplayCertificateErrors(true);
+      } else {
+        setDisplayCertificateErrors(false);
+        setCertificate(undefined);
+      }
+      setButtonDisabled(false);
+      setStatus(undefined);
+    });
+  }
+
+  const certificateInfo = (
+    <section ref={certificateRef}>
+      {!certificate && !displayCertErrors && <PageLoading srMessage="Loading" /> }
+      {displayCertErrors && <AlertList topic="certificates" />}
+
+      {certificate && !displayCertErrors && (
+
+      <div>
+        {status && (<Alert variant="info">{status}</Alert>)}
+        <table className="certificate-info-table">
+          <tbody>
+
+            <tr>
+              <th>Course ID</th>
+              <td>{certificate.courseKey}</td>
+            </tr>
+
+            <tr>
+              <th>Certificate Type</th>
+              <td>{certificate.type ? certificate.type : 'Not Available'}</td>
+            </tr>
+
+            <tr>
+              <th>Status</th>
+              <td>{certificate.status ? certificate.status : 'Not Available'}</td>
+            </tr>
+
+            <tr>
+              <th>Grade</th>
+              <td>{certificate.grade ? certificate.grade : 'Not Available'}</td>
+            </tr>
+
+            <tr>
+              <th>Last Updated</th>
+              <td>{formatDate(certificate.modified)}</td>
+            </tr>
+
+            <tr>
+              <th>Download URL</th>
+              <td>{certificate.downloadUrl ? <a href={`${getConfig().LMS_BASE_URL}${certificate.downloadUrl}`}>Download</a> : 'Not Available'}</td>
+            </tr>
+
+            <tr>
+              <th>Actions</th>
+              <td>
+                {
+                    certificate.regenerate
+                      ? (
+                        <Button
+                          onClick={postRegenerateCertificate}
+                          id="regenerate-certificate"
+                          variant="outline-danger"
+                          disabled={buttonDisabled}
+                        >
+                          Regenerate
+                        </Button>
+                      )
+                      : (
+                        <Button
+                          onClick={postGenerateCertificate}
+                          id="generate-certificate"
+                          variant="outline-danger"
+                          disabled={buttonDisabled}
+                        >
+                          Generate
+                        </Button>
+                      )
+                }
+
+              </td>
+            </tr>
+          </tbody>
+
+        </table>
+      </div>
+      )}
+    </section>
+  );
+
+  return (
+    <Modal
+      open={modalIsOpen}
+      onClose={() => {
+        closeHandler();
+        setModalIsOpen(false);
+      }}
+      title="Certificate"
+      id="certificate"
+      dialogClassName="modal-lg"
+      body={(
+        certificateInfo
+    )}
+    />
+  );
+}
+
+Certificates.propTypes = {
+  username: PropTypes.string.isRequired,
+  courseId: PropTypes.string.isRequired,
+  closeHandler: PropTypes.func.isRequired,
+};

--- a/src/users/enrollments/v2/Certificates.test.jsx
+++ b/src/users/enrollments/v2/Certificates.test.jsx
@@ -1,0 +1,262 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import { waitForComponentToPaint } from '../../../setupTest';
+import Certificates from './Certificates';
+import { downloadableCertificate, regeneratableCertificate } from '../../data/test/certificates';
+import UserMessagesProvider from '../../../userMessages/UserMessagesProvider';
+import * as api from '../../data/api';
+
+const CertificateWrapper = (props) => (
+  <UserMessagesProvider>
+    <Certificates {...props} />;
+  </UserMessagesProvider>
+);
+
+describe('Certificate component', () => {
+  let apiMock; let wrapper;
+  const testUser = 'testUser';
+  const testCourseId = 'course-v1:testX+test123+2030';
+
+  const props = {
+    username: testUser,
+    courseId: testCourseId,
+    closeHandler: jest.fn(() => {}),
+  };
+
+  afterEach(() => {
+    apiMock.mockRestore();
+  });
+
+  it('Default component render with Modal', async () => {
+    apiMock = jest.spyOn(api, 'getCertificate').mockImplementationOnce(() => Promise.resolve(downloadableCertificate));
+    wrapper = mount(<CertificateWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+
+    const dataRows = wrapper.find('table.certificate-info-table tbody tr');
+    expect(dataRows.length).toEqual(7);
+
+    let certificateModal = wrapper.find('Modal#certificate');
+    expect(certificateModal.prop('open')).toEqual(true);
+
+    wrapper.find('button.btn-link').simulate('click');
+    certificateModal = wrapper.find('Modal#certificate');
+    expect(certificateModal.prop('open')).toEqual(false);
+  });
+
+  it('Downloadable Certificate', async () => {
+    apiMock = jest.spyOn(api, 'getCertificate').mockImplementationOnce(() => Promise.resolve(downloadableCertificate));
+    wrapper = mount(<CertificateWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+
+    const dataRows = wrapper.find('table.certificate-info-table tbody tr');
+    expect(dataRows.length).toEqual(7);
+
+    // Explictly check each row and verify individual piece of data
+    const courseId = dataRows.at(0);
+    expect(courseId.find('th').text()).toEqual('Course ID');
+    expect(courseId.find('td').text()).toEqual(testCourseId);
+
+    // Explictly check each row and verify individual piece of data
+    const certType = dataRows.at(1);
+    expect(certType.find('th').text()).toEqual('Certificate Type');
+    expect(certType.find('td').text()).toEqual('verified');
+
+    const status = dataRows.at(2);
+    expect(status.find('th').text()).toEqual('Status');
+    expect(status.find('td').text()).toEqual('passing');
+
+    const grade = dataRows.at(3);
+    expect(grade.find('th').text()).toEqual('Grade');
+    expect(grade.find('td').text()).toEqual('60');
+
+    const lastUpdated = dataRows.at(4);
+    expect(lastUpdated.find('th').text()).toEqual('Last Updated');
+    expect(lastUpdated.find('td').text()).toEqual('Jan 1, 2020 12:00 AM');
+
+    const downloadUrl = dataRows.at(5);
+    expect(downloadUrl.find('th').text()).toEqual('Download URL');
+    expect(downloadUrl.find('td').text()).toEqual('Download');
+    expect(downloadUrl.find('td').find('a').prop('href')).toEqual('http://localhost:18000/certificates/1234-abcd');
+
+    const action = dataRows.at(6);
+    expect(action.find('th').text()).toEqual('Actions');
+    expect(action.find('button#generate-certificate').length).toEqual(1);
+  });
+
+  it('Regeneratable Certificate', async () => {
+    apiMock = jest.spyOn(api, 'getCertificate').mockImplementationOnce(() => Promise.resolve(regeneratableCertificate));
+    wrapper = mount(<CertificateWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+
+    const dataRows = wrapper.find('table.certificate-info-table tbody tr');
+    expect(dataRows.length).toEqual(7);
+
+    expect(dataRows.at(0).html()).toEqual(expect.stringContaining(regeneratableCertificate.courseKey));
+
+    const action = dataRows.at(6);
+    const actionButton = action.find('button#regenerate-certificate');
+    expect(action.find('th').text()).toEqual('Actions');
+    expect(actionButton.text()).toEqual('Regenerate');
+  });
+
+  it('Missing Certificate Data', async () => {
+    apiMock = jest.spyOn(api, 'getCertificate').mockImplementationOnce(() => Promise.resolve({ courseKey: testCourseId }));
+    wrapper = mount(<CertificateWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+
+    const dataRows = wrapper.find('table.certificate-info-table tbody tr');
+    expect(dataRows.length).toEqual(7);
+    expect(dataRows.at(0).html()).toEqual(expect.stringContaining(regeneratableCertificate.courseKey));
+    expect(dataRows.at(1).find('td').text()).toEqual('Not Available');
+    expect(dataRows.at(2).find('td').text()).toEqual('Not Available');
+    expect(dataRows.at(3).find('td').text()).toEqual('Not Available');
+    expect(dataRows.at(4).find('td').text()).toEqual('N/A');
+    expect(dataRows.at(5).find('td').text()).toEqual('Not Available');
+  });
+
+  it('Certificate Fetch Errors', async () => {
+    apiMock = jest.spyOn(api, 'getCertificate').mockImplementationOnce(() => Promise.resolve({
+      errors: [
+        {
+          code: null,
+          dismissible: true,
+          text: 'No certificate found',
+          type: 'danger',
+          topic: 'certificates',
+        },
+      ],
+    }));
+    wrapper = mount(<CertificateWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+    const alert = wrapper.find('.alert');
+    expect(alert.text()).toEqual('No certificate found');
+  });
+
+  describe('Generate Certificates flow', () => {
+    let generateApiMock;
+
+    afterEach(() => {
+      generateApiMock.mockRestore();
+    });
+
+    it('Successful certificate generation flow', async () => {
+      generateApiMock = jest.spyOn(api, 'generateCertificate').mockImplementationOnce(() => Promise.resolve({}));
+      apiMock = jest.spyOn(api, 'getCertificate').mockImplementationOnce(() => Promise.resolve(downloadableCertificate));
+      // 2nd call to get certificate after generation would yield regenerate certificate data.
+      jest.spyOn(api, 'getCertificate').mockImplementationOnce(() => Promise.resolve(regeneratableCertificate));
+
+      wrapper = mount(<CertificateWrapper {...props} />);
+      await waitForComponentToPaint(wrapper);
+
+      let generateButton = wrapper.find('button#generate-certificate');
+      expect(generateButton.text()).toEqual('Generate');
+      expect(generateButton.prop('disabled')).toBeFalsy();
+
+      generateButton.simulate('click');
+      generateButton = wrapper.find('button#generate-certificate');
+
+      expect(generateButton.prop('disabled')).toBeTruthy();
+      expect(generateApiMock).toHaveBeenCalledTimes(1);
+      expect(wrapper.find('div.alert-info').text()).toEqual('Generating New Certificate');
+
+      // Once the generation api call is successful, the status text will revert
+      // and button will change into regenerate button.
+      await waitForComponentToPaint(wrapper);
+      const regenerateButton = wrapper.find('button#regenerate-certificate');
+      expect(wrapper.find('h3').length).toEqual(0);
+      expect(regenerateButton.text()).toEqual('Regenerate');
+      expect(regenerateButton.prop('disabled')).toBeFalsy();
+      expect(apiMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('Unsuccessful certificate generation flow', async () => {
+      generateApiMock = jest.spyOn(api, 'generateCertificate').mockImplementationOnce(() => Promise.resolve({
+        errors: [
+          {
+            code: null,
+            dismissible: true,
+            text: 'Error generating certificate',
+            type: 'danger',
+            topic: 'certificates',
+          },
+        ],
+      }));
+      apiMock = jest.spyOn(api, 'getCertificate').mockImplementation(() => Promise.resolve(downloadableCertificate));
+
+      wrapper = mount(<CertificateWrapper {...props} />);
+      await waitForComponentToPaint(wrapper);
+
+      const generateButton = wrapper.find('button#generate-certificate');
+      expect(generateButton.text()).toEqual('Generate');
+      expect(generateButton.prop('disabled')).toBeFalsy();
+      generateButton.simulate('click');
+      expect(generateApiMock).toHaveBeenCalledTimes(1);
+
+      await waitForComponentToPaint(wrapper);
+      const alert = wrapper.find('.alert');
+      expect(alert.text()).toEqual('Error generating certificate');
+    });
+  });
+
+  describe('Regenerate Certificates flow', () => {
+    let regenerateApiMock;
+
+    afterEach(() => {
+      regenerateApiMock.mockRestore();
+    });
+
+    it('Successful certificate regeneration flow', async () => {
+      regenerateApiMock = jest.spyOn(api, 'regenerateCertificate').mockImplementationOnce(() => Promise.resolve({}));
+      apiMock = jest.spyOn(api, 'getCertificate').mockImplementation(() => Promise.resolve(regeneratableCertificate));
+
+      wrapper = mount(<CertificateWrapper {...props} />);
+      await waitForComponentToPaint(wrapper);
+
+      let regenerateButton = wrapper.find('button#regenerate-certificate');
+      expect(regenerateButton.text()).toEqual('Regenerate');
+      expect(regenerateButton.prop('disabled')).toBeFalsy();
+
+      regenerateButton.simulate('click');
+      regenerateButton = wrapper.find('button#regenerate-certificate');
+
+      expect(regenerateButton.prop('disabled')).toBeTruthy();
+      expect(regenerateApiMock).toHaveBeenCalledTimes(1);
+      expect(wrapper.find('div.alert-info').text()).toEqual('Regenerating Certificate');
+
+      await waitForComponentToPaint(wrapper);
+      regenerateButton = wrapper.find('button#regenerate-certificate');
+      expect(wrapper.find('h3').length).toEqual(0);
+      expect(regenerateButton.prop('disabled')).toBeFalsy();
+    });
+
+    it('Unsuccessful certificate regeneration flow', async () => {
+      regenerateApiMock = jest.spyOn(api, 'regenerateCertificate').mockImplementationOnce(() => Promise.resolve({
+        errors: [
+          {
+            code: null,
+            dismissible: true,
+            text: 'Error regenerating certificate',
+            type: 'danger',
+            topic: 'certificates',
+          },
+        ],
+      }));
+      apiMock = jest.spyOn(api, 'getCertificate').mockImplementation(() => Promise.resolve(regeneratableCertificate));
+
+      wrapper = mount(<CertificateWrapper {...props} />);
+      await waitForComponentToPaint(wrapper);
+
+      const regenerateButton = wrapper.find('button#regenerate-certificate');
+      expect(regenerateButton.text()).toEqual('Regenerate');
+      expect(regenerateButton.prop('disabled')).toBeFalsy();
+
+      regenerateButton.simulate('click');
+      expect(regenerateApiMock).toHaveBeenCalledTimes(1);
+
+      await waitForComponentToPaint(wrapper);
+      const alert = wrapper.find('.alert');
+      expect(alert.text()).toEqual('Error regenerating certificate');
+    });
+  });
+});

--- a/src/users/enrollments/v2/Enrollments.jsx
+++ b/src/users/enrollments/v2/Enrollments.jsx
@@ -15,7 +15,7 @@ import { camelCaseObject, getConfig } from '@edx/frontend-platform';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faMinus, faPlus } from '@fortawesome/free-solid-svg-icons';
-import Certificates from '../Certificates';
+import Certificates from './Certificates';
 import EnrollmentForm from './EnrollmentForm';
 import { CREATE, CHANGE } from '../constants';
 import PageLoading from '../../../components/common/PageLoading';

--- a/src/users/enrollments/v2/Enrollments.test.jsx
+++ b/src/users/enrollments/v2/Enrollments.test.jsx
@@ -143,7 +143,7 @@ describe('Course Enrollments V2 Listing', () => {
     expect(certificates.html()).toEqual(expect.stringContaining(courseName));
 
     expect(apiMock).toHaveBeenCalledTimes(1);
-    certificates.find('button.btn-outline-secondary').simulate('click');
+    certificates.find('button.btn-link').simulate('click');
     expect(wrapper.find('Certificates')).toEqual({});
     apiMock.mockReset();
   });


### PR DESCRIPTION
### [PROD-2504](https://openedx.atlassian.net/browse/PROD-2504)

### Description
Add a Modal to display the certificate tool. Some styling updates have been done in the certificate tool.

### Screenshots

<img width="1617" alt="Screenshot 2021-09-29 at 3 39 41 PM" src="https://user-images.githubusercontent.com/40599381/135261184-9ec530cc-8849-480c-9507-3c748f9b43b0.png">
<img width="1617" alt="Screenshot 2021-09-29 at 3 39 46 PM" src="https://user-images.githubusercontent.com/40599381/135261197-31832b53-0d4f-45f5-8cae-ccd8843e8f4d.png">
<img width="1617" alt="Screenshot 2021-09-29 at 3 39 56 PM" src="https://user-images.githubusercontent.com/40599381/135261204-e20eb999-ef44-4b15-bb5b-67ac382bcba3.png">
<img width="1617" alt="Screenshot 2021-09-29 at 3 40 02 PM" src="https://user-images.githubusercontent.com/40599381/135261208-27eac4e1-c7b9-4a99-8a57-c713e9d7a218.png">


### Testing Instructions/Notes

- Make sure to have multiple courses and multiple enrollments against a user
- Open certificate Modal for one course enrollment, close it and then open for another enrollment. Verify the data rendered changes(like course id for instance). 
- Generate/Regenerate action happens via an async task. So the response in most cases will be 200 and there will be no imminent visual changes. Keep an eye on LMS logs. Sometimes, the person is not eligible for the certificate(grade, cert not applicable etc.). In that case, no data will be created/updated.
