### PR TITLE
feat: add main tab component

### DIFF
--- a/src/FeatureBasedEnrollments/FeatureBasedEnrollmentIndexPage.jsx
+++ b/src/FeatureBasedEnrollments/FeatureBasedEnrollmentIndexPage.jsx
@@ -7,7 +7,6 @@ import React, {
   useState,
 } from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
 import { Input, Button } from '@edx/paragon';
 
 import UserMessagesContext from '../userMessages/UserMessagesContext';
@@ -47,7 +46,7 @@ export default function FeatureBasedEnrollmentIndexPage({ location }) {
         type: 'error',
         topic: 'featureBasedEnrollmentGeneral',
       });
-      history.replace('/feature_based_enrollments');
+      history.replace('/v2/feature_based_enrollments');
       return false;
     }
     return true;
@@ -60,9 +59,9 @@ export default function FeatureBasedEnrollmentIndexPage({ location }) {
         return;
       }
       setSearchValue(inputValue);
-      pushHistoryIfChanged(`/feature_based_enrollments/?course_id=${inputValue}`);
+      pushHistoryIfChanged(`/v2/feature_based_enrollments/?course_id=${inputValue}`);
     } else if (inputValue === '') {
-      history.replace('/feature_based_enrollments');
+      history.replace('/v2/feature_based_enrollments');
     }
   });
 
@@ -82,19 +81,15 @@ export default function FeatureBasedEnrollmentIndexPage({ location }) {
   }, []);
 
   return (
-    <main className="ml-5 mr-5 mt-3 mb-5">
-
-      <section className="mb-3">
-        <Link to="/">&lt; Back to Tools</Link>
-      </section>
+    <main className="mt-3 mb-5">
 
       <AlertList topic="featureBasedEnrollmentGeneral" className="mb-3" />
 
       <section className="mb-3">
         <form className="form-inline">
           <label htmlFor="courseId">Course ID</label>
-          <Input ref={searchRef} className="flex-grow-1 mr-1" name="courseId" type="text" defaultValue={searchValue} />
-          <Button type="submit" onClick={submit} variant="primary">Search</Button>
+          <Input ref={searchRef} className="mr-1 col-sm-4" name="courseId" type="text" defaultValue={searchValue} />
+          <Button type="submit" onClick={submit} className="ml-1 col-sm-1" variant="primary">Search</Button>
         </form>
       </section>
 

--- a/src/FeatureBasedEnrollments/FeatureBasedEnrollmentIndexPage.test.jsx
+++ b/src/FeatureBasedEnrollments/FeatureBasedEnrollmentIndexPage.test.jsx
@@ -22,18 +22,15 @@ describe('Feature Based Enrollment Index Page', () => {
   const courseId = 'course-v1:testX+test123+2030';
 
   beforeEach(() => {
-    location = { pathname: '/feature_based_enrollments', search: '' };
+    location = { pathname: '/v2/feature_based_enrollments', search: '' };
   });
 
   it('default page render', async () => {
     wrapper = mount(<FeatureBasedEnrollmentIndexPageWrapper location={location} />);
 
-    const homePageLink = wrapper.find('a');
     const courseIdInput = wrapper.find('input[name="courseId"]');
     const searchButton = wrapper.find('button.btn-primary');
 
-    expect(homePageLink.prop('href')).toEqual('/');
-    expect(homePageLink.text()).toEqual('< Back to Tools');
     expect(courseIdInput.prop('defaultValue')).toEqual(undefined);
     expect(searchButton.text()).toEqual('Search');
   });
@@ -42,13 +39,11 @@ describe('Feature Based Enrollment Index Page', () => {
     const apiMock = jest.spyOn(api, 'default').mockImplementationOnce(() => Promise.resolve({}));
     location.search = `?course_id=${courseId}`;
     wrapper = mount(<FeatureBasedEnrollmentIndexPageWrapper location={location} />);
+    await waitForComponentToPaint(wrapper);
 
-    const homePageLink = wrapper.find('a');
     const courseIdInput = wrapper.find('input[name="courseId"]');
     const searchButton = wrapper.find('button.btn-primary');
 
-    expect(homePageLink.prop('href')).toEqual('/');
-    expect(homePageLink.text()).toEqual('< Back to Tools');
     expect(courseIdInput.prop('defaultValue')).toEqual(courseId);
     expect(searchButton.text()).toEqual('Search');
     apiMock.mockReset();
@@ -66,7 +61,7 @@ describe('Feature Based Enrollment Index Page', () => {
     await waitForComponentToPaint(wrapper);
     expect(apiMock).toHaveBeenCalledTimes(1);
     expect(wrapper.find('Card')).toHaveLength(2);
-    expect(history.push).toHaveBeenCalledWith(`/feature_based_enrollments/?course_id=${courseId}`);
+    expect(history.push).toHaveBeenCalledWith(`/v2/feature_based_enrollments/?course_id=${courseId}`);
 
     apiMock.mockReset();
     history.push.mockReset();
@@ -83,7 +78,7 @@ describe('Feature Based Enrollment Index Page', () => {
     await waitForComponentToPaint(wrapper);
     expect(apiMock).toHaveBeenCalledTimes(0);
     expect(wrapper.find('Card')).toHaveLength(0);
-    expect(history.replace).toHaveBeenCalledWith('/feature_based_enrollments');
+    expect(history.replace).toHaveBeenCalledWith('/v2/feature_based_enrollments');
 
     apiMock.mockReset();
     history.replace.mockReset();
@@ -101,7 +96,7 @@ describe('Feature Based Enrollment Index Page', () => {
     expect(apiMock).toHaveBeenCalledTimes(0);
     expect(wrapper.find('Card')).toHaveLength(0);
     expect(wrapper.find('.alert').text()).toEqual('Supplied course ID "invalid-value" is either invalid or incorrect.');
-    expect(history.replace).toHaveBeenCalledWith('/feature_based_enrollments');
+    expect(history.replace).toHaveBeenCalledWith('/v2/feature_based_enrollments');
 
     apiMock.mockReset();
     history.replace.mockReset();

--- a/src/SupportToolsTab/SupportToolsTab.jsx
+++ b/src/SupportToolsTab/SupportToolsTab.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Tabs, Tab } from '@edx/paragon';
+import { history } from '@edx/frontend-platform';
+import { FEATURE_BASED_ENROLLMENT_TAB, LEARNER_INFO_TAB, TAB_PATH_MAP } from './constants';
+import UserPage from '../users/v2/UserPage';
+import FeatureBasedEnrollmentIndexPage from '../FeatureBasedEnrollments/FeatureBasedEnrollmentIndexPage';
+
+export default function SupportToolsTab({ location }) {
+  let tabKey = LEARNER_INFO_TAB;
+  if (location.pathname.indexOf(TAB_PATH_MAP[FEATURE_BASED_ENROLLMENT_TAB]) !== -1) {
+    tabKey = FEATURE_BASED_ENROLLMENT_TAB;
+  }
+
+  return (
+    <>
+      <section className="mx-5 mt-3">
+        <h2 className="font-weight-bold">Support Tools</h2>
+        <p>Suite of tools used by support team to help triage and resolve select learner issues.</p>
+      </section>
+      <section className="mx-5">
+        <Tabs
+          className="support-tools-tab"
+          id="support-tools-tab"
+          onSelect={(key) => {
+            if (key in TAB_PATH_MAP) {
+              history.replace(TAB_PATH_MAP[key]);
+            }
+          }}
+          defaultActiveKey={tabKey}
+          unmountOnExit
+        >
+          <Tab eventKey={LEARNER_INFO_TAB} title="Learner Information">
+            <br />
+            <UserPage location={location} />
+          </Tab>
+
+          <Tab eventKey={FEATURE_BASED_ENROLLMENT_TAB} title="Feature Based Enrollment">
+            <br />
+            <FeatureBasedEnrollmentIndexPage location={location} />
+          </Tab>
+
+        </Tabs>
+      </section>
+    </>
+  );
+}
+
+SupportToolsTab.propTypes = {
+  location: PropTypes.shape({
+    pathname: PropTypes.string,
+    search: PropTypes.string,
+  }).isRequired,
+};

--- a/src/SupportToolsTab/SupportToolsTab.test.jsx
+++ b/src/SupportToolsTab/SupportToolsTab.test.jsx
@@ -1,0 +1,77 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { history } from '@edx/frontend-platform';
+import UserMessagesProvider from '../userMessages/UserMessagesProvider';
+import SupportToolsTab from './SupportToolsTab';
+
+const SupportToolsTabWrapper = (props) => (
+  <MemoryRouter>
+    <UserMessagesProvider>
+      <SupportToolsTab {...props} />
+    </UserMessagesProvider>
+  </MemoryRouter>
+);
+
+describe('Support Tools Main tab', () => {
+  let wrapper; let location;
+
+  beforeEach(() => {
+    location = { pathname: '/v2', search: '' };
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('default page render', () => {
+    wrapper = mount(<SupportToolsTabWrapper location={location} />);
+
+    const tabs = wrapper.find('nav.nav-tabs a');
+    expect(tabs.length).toEqual(2);
+    expect(tabs.at(0).text()).toEqual('Learner Information');
+    expect(tabs.at(1).text()).toEqual('Feature Based Enrollment');
+
+    expect(wrapper.find('h2').text()).toEqual('Support Tools');
+    expect(wrapper.find('p').text()).toEqual(
+      'Suite of tools used by support team to help triage and resolve select learner issues.',
+    );
+  });
+
+  it('Path changes on Tab switch', () => {
+    history.replace = jest.fn();
+    wrapper = mount(<SupportToolsTabWrapper location={location} />);
+
+    let tabs = wrapper.find('nav.nav-tabs a');
+
+    tabs.at(1).simulate('click');
+    tabs = wrapper.find('nav.nav-tabs a');
+    const fbeTab = wrapper.find('div.tab-content div#support-tools-tab-tabpane-feature-based-enrollment');
+    expect(history.replace).toHaveBeenCalledWith('/v2/feature_based_enrollments');
+    expect(tabs.at(0).html()).not.toEqual(expect.stringContaining('active'));
+    expect(tabs.at(1).html()).toEqual(expect.stringContaining('active'));
+    expect(fbeTab.html()).toEqual(expect.stringContaining('active'));
+    expect(fbeTab.find('label').text()).toEqual('Course ID');
+
+    tabs.at(0).simulate('click');
+    tabs = wrapper.find('nav.nav-tabs a');
+    const learnerTab = wrapper.find('div.tab-content div#support-tools-tab-tabpane-learner-information');
+    expect(history.replace).toHaveBeenCalledWith('/v2/learner_information');
+    expect(tabs.at(0).html()).toEqual(expect.stringContaining('active'));
+    expect(tabs.at(1).html()).not.toEqual(expect.stringContaining('active'));
+    expect(learnerTab.html()).toEqual(expect.stringContaining('active'));
+    expect(learnerTab.find('label').text()).toEqual('Username or Email');
+
+    history.replace.mockReset();
+  });
+
+  it('default tab changes based on pathname', () => {
+    location = { pathname: '/v2/feature_based_enrollments', search: '' };
+
+    wrapper = mount(<SupportToolsTabWrapper location={location} />);
+    const tabs = wrapper.find('nav.nav-tabs a');
+
+    expect(tabs.at(0).html()).not.toEqual(expect.stringContaining('active'));
+    expect(tabs.at(1).html()).toEqual(expect.stringContaining('active'));
+  });
+});

--- a/src/SupportToolsTab/constants.js
+++ b/src/SupportToolsTab/constants.js
@@ -1,0 +1,7 @@
+export const LEARNER_INFO_TAB = 'learner-information';
+export const FEATURE_BASED_ENROLLMENT_TAB = 'feature-based-enrollment';
+
+export const TAB_PATH_MAP = {
+  [LEARNER_INFO_TAB]: '/v2/learner_information',
+  [FEATURE_BASED_ENROLLMENT_TAB]: '/v2/feature_based_enrollments',
+};

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -14,6 +14,7 @@ import SupportHomePage from './supportHome/SupportHomePage';
 import Header from './supportHeader';
 import appMessages from './i18n';
 import UserPage from './users/UserPage';
+// import SupportToolsTab from './SupportToolsTab/SupportToolsTab';
 // import UserPageV2 from './users/v2/UserPage';
 // import FBEIndexPage from './FeatureBasedEnrollments/FeatureBasedEnrollmentIndexPage';
 import UserMessagesProvider from './userMessages/UserMessagesProvider';
@@ -37,8 +38,9 @@ subscribe(APP_READY, () => {
         <Switch>
           <Route exact path="/" component={SupportHomePage} />
           <Route path="/users" component={UserPage} />
-          {/* <Route path="/usersv2" component={UserPageV2} /> */}
-          {/* <Route path="/feature_based_enrollments" component={FBEIndexPage} /> */}
+          {/* <Route path="/v2" component={SupportToolsTab} /> */}
+          {/* <Route path="/v2/learner_information" component={UserPageV2} /> */}
+          {/* <Route path="/v2/feature_based_enrollments" component={FBEIndexPage} /> */}
         </Switch>
       </UserMessagesProvider>
     </AppProvider>,

--- a/src/overrides.scss
+++ b/src/overrides.scss
@@ -1,6 +1,3 @@
-// Reverting the container width to 1440px to keep the support tools styling consistent
-// See https://github.com/edx/paragon/pull/533 for paragon breaking change
-
 $darkCyan: #00262b;
 
 .learner-information {
@@ -14,6 +11,8 @@ $darkCyan: #00262b;
 }
 
 .container-fluid {
+  // Reverting the container width to 1440px to keep the support tools styling consistent
+  // See https://github.com/edx/paragon/pull/533 for paragon breaking change
   max-width: 1440px;
 }
 
@@ -114,4 +113,19 @@ $darkCyan: #00262b;
 
 .text-center {
   margin: auto;
+}
+
+.support-tools-tab {
+  border-bottom: none;
+
+  .nav-link {
+    border: 1px solid lightgray;
+    color: black;
+  }
+
+  .nav-link.active {
+    background-color: $darkCyan;
+    color: white;
+    font-weight: normal;
+  }
 }

--- a/src/users/v2/UserPage.jsx
+++ b/src/users/v2/UserPage.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import React, {
   useCallback, useContext, useEffect, useState,
 } from 'react';
-import { Link } from 'react-router-dom';
 import PageLoading from '../../components/common/PageLoading';
 import AlertList from '../../userMessages/AlertList';
 import { USER_IDENTIFIER_INVALID_ERROR } from '../../userMessages/messages';
@@ -45,13 +44,13 @@ export default function UserPage({ location }) {
   function processSearchResult(searchValue, result) {
     if (result.errors.length > 0) {
       result.errors.forEach((error) => add(error));
-      history.replace('/usersv2');
+      history.replace('/v2/learner_information');
       document.title = 'Support Tools | edX';
     } else if (isEmail(searchValue)) {
-      pushHistoryIfChanged(`/usersv2/?email=${searchValue}`);
+      pushHistoryIfChanged(`/v2/learner_information/?email=${searchValue}`);
       document.title = `Support Tools | edX | ${searchValue}`;
     } else if (isValidUsername(searchValue)) {
-      pushHistoryIfChanged(`/usersv2/?username=${searchValue}`);
+      pushHistoryIfChanged(`/v2/learner_information/?username=${searchValue}`);
       document.title = `Support Tools | edX | ${searchValue}`;
     }
 
@@ -69,7 +68,7 @@ export default function UserPage({ location }) {
         type: 'error',
         topic: 'general',
       });
-      history.replace('/users');
+      history.replace('/v2/learner_information');
       return false;
     }
     return true;
@@ -90,7 +89,7 @@ export default function UserPage({ location }) {
       // This is the case of an empty search (maybe a user wanted to clear out what they were seeing)
     } else if (searchValue === '') {
       clear('general');
-      history.replace('/users');
+      history.replace('/v2/learner_information');
       setLoading(false);
       setSearching(false);
     }
@@ -120,10 +119,7 @@ export default function UserPage({ location }) {
   }, [params.get('username'), params.get('email')]);
 
   return (
-    <main className="ml-5 mr-5 mt-3 mb-5">
-      <section className="mb-3">
-        <Link to="/">&lt; Back to Tools</Link>
-      </section>
+    <main className="mt-3 mb-5">
       <AlertList topic="general" className="mb-3" />
       {/* NOTE: the "key" here causes the UserSearch component to re-render completely when the
       user identifier changes.  Doing so clears out the search box. */}
@@ -138,11 +134,6 @@ export default function UserPage({ location }) {
           user={data.user}
           changeHandler={handleUserSummaryChange}
         />
-      )}
-      {!loading && !userIdentifier && (
-        <section>
-          <p>Please search for a username or email.</p>
-        </section>
       )}
     </main>
   );


### PR DESCRIPTION
### [PROD-2480](https://openedx.atlassian.net/browse/PROD-2480)

### Description
Adds a tab to navigate between the main components of support tools. The default tab is Learner Information tab but if a query_param based path is already present in URL and the page is reloaded, the default tab will change accordingly(e.g. reloading FBE page). The individual tab component is unmounted on the tab switch so that when the user re-navigates, the component re-renders in a clean state.


### Screenshots
<img width="1670" alt="Screenshot 2021-10-01 at 12 06 04 PM" src="https://user-images.githubusercontent.com/40599381/135579516-b61326ba-ca4a-4757-9fcc-3bc2cbe95cff.png">
<img width="1670" alt="Screenshot 2021-10-01 at 12 06 15 PM" src="https://user-images.githubusercontent.com/40599381/135579518-f4bb31f6-4cdf-40d1-9d4f-273affaf64e6.png">

<img width="1670" alt="Screenshot 2021-10-01 at 12 05 38 PM" src="https://user-images.githubusercontent.com/40599381/135579501-7a933105-2681-468c-a751-d1569c8a3d1c.png">
<img width="1670" alt="Screenshot 2021-10-01 at 12 05 56 PM" src="https://user-images.githubusercontent.com/40599381/135579513-382ce5b6-acea-464e-be0c-8123e07f5d6d.png">



### Testing Instructions/Notes
- Uncomment main tab, FBE, and user page links and component imports.
- Verify the tab switch updates the url.
- Reloading a query_param page(like v2/feature_based_enrollments/?course_id=<course_id>) changes the active tab
- Query param in the url starts the search upon loading