### PR TITLE
feat: add updated user actions

### DIFF
--- a/src/users/account-actions/AccountActions.jsx
+++ b/src/users/account-actions/AccountActions.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import TogglePasswordStatus from './TogglePasswordStatus';
-import ResetPassword from './ResetPassword';
-import PasswordHistory from './PasswordHistory';
+import TogglePasswordStatus from './v2/TogglePasswordStatus';
+import ResetPassword from './v2/ResetPassword';
+import PasswordHistory from './v2/PasswordHistory';
 
 export default function AccountActions({ userData, changeHandler }) {
   return (

--- a/src/users/account-actions/v2/PasswordHistory.jsx
+++ b/src/users/account-actions/v2/PasswordHistory.jsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Modal, Button, Table } from '@edx/paragon';
+import { formatDate } from '../../../utils';
+
+export default function PasswordHistory({
+  passwordStatus,
+}) {
+  const [passwordHistoryData, setPasswordHistoryData] = useState([]);
+  const [passwordHistoryModalIsOpen, setPasswordHistoryModalIsOpen] = useState(false);
+
+  const openHistoryModal = () => {
+    const tableData = passwordStatus.passwordToggleHistory.map(result => ({
+      created: formatDate(result.created),
+      comment: result.comment,
+      disabled: result.disabled ? 'Disabled' : 'Enabled',
+      createdBy: result.createdBy,
+    }));
+    setPasswordHistoryData(tableData);
+    setPasswordHistoryModalIsOpen(true);
+  };
+
+  const userPasswordHistoryColumns = [
+    {
+      label: 'Date',
+      key: 'created',
+    },
+    {
+      label: 'Comment',
+      key: 'comment',
+    },
+    {
+      label: 'Action',
+      key: 'disabled',
+    },
+    {
+      label: 'By',
+      key: 'createdBy',
+    },
+  ];
+
+  return (
+    <div>
+
+      {passwordStatus.passwordToggleHistory.length > 0 && (
+      <Button
+        id="toggle-password-history"
+        variant="outline-primary ml-1"
+        onClick={() => openHistoryModal()}
+      >
+        Show History
+      </Button>
+      )}
+
+      <Modal
+        open={passwordHistoryModalIsOpen}
+        onClose={() => setPasswordHistoryModalIsOpen(false)}
+        title="Enable/Disable History"
+        id="password-history"
+        dialogClassName="modal-xl"
+        body={(
+          <Table
+            data={passwordHistoryData}
+            columns={userPasswordHistoryColumns}
+          />
+          )}
+      />
+    </div>
+  );
+}
+
+PasswordHistory.propTypes = {
+  passwordStatus: PropTypes.shape({
+    passwordToggleHistory: PropTypes.arrayOf(PropTypes.shape(
+      {
+        created: PropTypes.string.isRequired,
+        comment: PropTypes.string.isRequired,
+        disabled: PropTypes.bool.isRequired,
+        createdBy: PropTypes.string.isRequired,
+      },
+    )),
+  }).isRequired,
+};

--- a/src/users/account-actions/v2/PasswordHistory.test.jsx
+++ b/src/users/account-actions/v2/PasswordHistory.test.jsx
@@ -1,0 +1,39 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import PasswordHistory from './PasswordHistory';
+import UserSummaryData from '../../data/test/userSummary';
+
+describe('Password History Component Tests', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    const data = {
+      passwordStatus: UserSummaryData.userData.passwordStatus,
+    };
+    wrapper = mount(<PasswordHistory {...data} />);
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('Password History Modal', () => {
+    const passwordHistoryButton = wrapper.find('button#toggle-password-history');
+    let historyModal = wrapper.find('Modal#password-history');
+
+    expect(historyModal.prop('open')).toEqual(false);
+    expect(passwordHistoryButton.text()).toEqual('Show History');
+    expect(passwordHistoryButton.disabled).toBeFalsy();
+
+    passwordHistoryButton.simulate('click');
+    historyModal = wrapper.find('Modal#password-history');
+
+    expect(historyModal.prop('open')).toEqual(true);
+    expect(historyModal.find('table tbody tr')).toHaveLength(2);
+
+    historyModal.find('button.btn-link').simulate('click');
+    historyModal = wrapper.find('Modal#password-history');
+    expect(historyModal.prop('open')).toEqual(false);
+  });
+});

--- a/src/users/account-actions/v2/ResetPassword.jsx
+++ b/src/users/account-actions/v2/ResetPassword.jsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Modal, Button, Alert } from '@edx/paragon';
+import { postResetPassword } from '../../data/api';
+
+export default function ResetPassword({
+  email,
+  changeHandler,
+}) {
+  const [resetPasswordModalIsOpen, setResetPasswordModalIsOpen] = useState(false);
+
+  const resetPassword = () => {
+    postResetPassword(email);
+    changeHandler();
+  };
+
+  return (
+    <div>
+      <Button
+        id="reset-password"
+        variant="btn btn-danger ml-1"
+        onClick={() => setResetPasswordModalIsOpen(true)}
+      >Reset Password
+      </Button>
+
+      <Modal
+        open={resetPasswordModalIsOpen}
+        id="user-account-reset-password"
+        buttons={[
+          <Button
+            variant="danger"
+            onClick={resetPassword}
+          >
+            Confirm
+          </Button>,
+        ]}
+        onClose={() => setResetPasswordModalIsOpen(false)}
+        dialogClassName="modal-lg modal-dialog-centered"
+        title="Reset Password"
+        body={(
+          <div>
+            <Alert variant="warning">
+              <p>
+                We will send a message with password recovery instructions to the email address <b>{email}</b>.
+                Do you wish to proceed?
+              </p>
+            </Alert>
+          </div>
+          )}
+      />
+    </div>
+  );
+}
+
+ResetPassword.propTypes = {
+  email: PropTypes.string.isRequired,
+  changeHandler: PropTypes.func.isRequired,
+};

--- a/src/users/account-actions/v2/ResetPassword.test.jsx
+++ b/src/users/account-actions/v2/ResetPassword.test.jsx
@@ -1,0 +1,53 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import * as api from '../../data/api';
+import ResetPassword from './ResetPassword';
+import UserSummaryData from '../../data/test/userSummary';
+
+describe('Reset Password Component Tests', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    const data = {
+      email: UserSummaryData.userData.email,
+      changeHandler: UserSummaryData.changeHandler,
+    };
+    wrapper = mount(<ResetPassword {...data} />);
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('Reset Password button for a User', () => {
+    const passwordResetButton = wrapper.find('#reset-password').hostNodes();
+    expect(passwordResetButton.text()).toEqual('Reset Password');
+  });
+
+  it('Reset Password Modal', () => {
+    const mockApiCall = jest.spyOn(api, 'postResetPassword').mockImplementationOnce(() => Promise.resolve({}));
+    const passwordResetButton = wrapper.find('#reset-password').hostNodes();
+    let resetPasswordModal = wrapper.find('Modal#user-account-reset-password');
+
+    expect(resetPasswordModal.prop('open')).toEqual(false);
+    expect(passwordResetButton.text()).toEqual('Reset Password');
+
+    passwordResetButton.simulate('click');
+    resetPasswordModal = wrapper.find('Modal#user-account-reset-password');
+
+    expect(resetPasswordModal.prop('open')).toEqual(true);
+    expect(resetPasswordModal.prop('title')).toEqual('Reset Password');
+    const confirmAlert = resetPasswordModal.find('.alert-warning');
+    expect(confirmAlert.text()).toEqual(
+      'We will send a message with password recovery instructions to the email address edx@example.com. Do you wish to proceed?',
+    );
+    resetPasswordModal.find('button.btn-danger').hostNodes().simulate('click');
+
+    expect(UserSummaryData.changeHandler).toHaveBeenCalled();
+    resetPasswordModal.find('button.btn-link').simulate('click');
+    resetPasswordModal = wrapper.find('Modal#user-account-reset-password');
+    expect(resetPasswordModal.prop('open')).toEqual(false);
+    mockApiCall.mockRestore();
+  });
+});

--- a/src/users/account-actions/v2/TogglePasswordStatus.jsx
+++ b/src/users/account-actions/v2/TogglePasswordStatus.jsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Modal, Button, Input, Alert,
+} from '@edx/paragon';
+import { postTogglePasswordStatus } from '../../data/api';
+
+import {
+  DISABLE_USER, ENABLE_USER, DISABLE_USER_CONFIRMATION, ENABLE_USER_CONFIRMATION, PASSWORD_STATUS,
+} from '../constants';
+
+export default function TogglePasswordStatus({
+  username,
+  passwordStatus,
+  changeHandler,
+}) {
+  const [disableUserModalIsOpen, setDisableUserModalIsOpen] = useState(false);
+  const [comment, setComment] = useState('');
+
+  const togglePasswordStatus = () => {
+    postTogglePasswordStatus(username, comment).then(() => {
+      changeHandler();
+    });
+  };
+
+  return (
+    <div>
+      <Button
+        id="toggle-password"
+        variant={`${passwordStatus.status === PASSWORD_STATUS.USABLE ? 'danger' : 'primary'}`}
+        onClick={() => setDisableUserModalIsOpen(true)}
+      >
+        {passwordStatus.status === PASSWORD_STATUS.USABLE ? DISABLE_USER : ENABLE_USER}
+      </Button>
+      <Modal
+        open={disableUserModalIsOpen}
+        id="user-account-status-toggle"
+        dialogClassName="modal-lg modal-dialog-centered"
+        buttons={[
+          <Button
+            variant="danger"
+            onClick={togglePasswordStatus}
+          >
+            Confirm
+          </Button>,
+        ]}
+        onClose={() => setDisableUserModalIsOpen(false)}
+        title={`${passwordStatus.status === PASSWORD_STATUS.USABLE ? DISABLE_USER_CONFIRMATION : ENABLE_USER_CONFIRMATION}`}
+        body={(
+          <div>
+            <Alert variant="warning">
+              <p>
+                Please provide the reason for {`${passwordStatus.status === PASSWORD_STATUS.USABLE ? 'disabling' : 'enabling'}`} the user <b>{username}</b>.
+              </p>
+            </Alert>
+            <label htmlFor="comment">Reason: </label>
+            <Input
+              name="comment"
+              type="text"
+              value={comment}
+              onChange={(event) => setComment(event.target.value)}
+            />
+          </div>
+          )}
+      />
+    </div>
+  );
+}
+
+TogglePasswordStatus.propTypes = {
+  username: PropTypes.string.isRequired,
+  passwordStatus: PropTypes.shape({
+    status: PropTypes.string.isRequired,
+  }).isRequired,
+  changeHandler: PropTypes.func.isRequired,
+};

--- a/src/users/account-actions/v2/TogglePasswordStatus.test.jsx
+++ b/src/users/account-actions/v2/TogglePasswordStatus.test.jsx
@@ -1,0 +1,100 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { waitFor } from '@testing-library/react';
+import * as api from '../../data/api';
+import TogglePasswordStatus from './TogglePasswordStatus';
+import UserSummaryData from '../../data/test/userSummary';
+
+describe('Toggle Password Status Component Tests', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    const data = {
+      username: UserSummaryData.userData.username,
+      passwordStatus: UserSummaryData.userData.passwordStatus,
+      changeHandler: UserSummaryData.changeHandler,
+    };
+    wrapper = mount(<TogglePasswordStatus {...data} />);
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  describe('Disable User Button', () => {
+    it('Disable User button for active user', () => {
+      const passwordActionButton = wrapper.find('#toggle-password').hostNodes();
+      expect(passwordActionButton.text()).toEqual('Disable User');
+      expect(passwordActionButton.disabled).toBeFalsy();
+    });
+
+    it('Disable User Modal', async () => {
+      const mockApiCall = jest.spyOn(api, 'postTogglePasswordStatus').mockImplementationOnce(() => Promise.resolve());
+      const passwordActionButton = wrapper.find('#toggle-password').hostNodes();
+      let disableDialogModal = wrapper.find('Modal#user-account-status-toggle');
+
+      expect(disableDialogModal.prop('open')).toEqual(false);
+      expect(passwordActionButton.text()).toEqual('Disable User');
+      expect(passwordActionButton.disabled).toBeFalsy();
+
+      passwordActionButton.simulate('click');
+      disableDialogModal = wrapper.find('Modal#user-account-status-toggle');
+
+      expect(disableDialogModal.prop('open')).toEqual(true);
+      expect(disableDialogModal.prop('title')).toEqual('Disable user confirmation');
+      expect(disableDialogModal.find('.alert-warning').text()).toEqual(
+        'Please provide the reason for disabling the user edx.',
+      );
+      disableDialogModal.find('input[name="comment"]').simulate('change', { target: { value: 'Disable Test User' } });
+      disableDialogModal.find('button.btn-danger').hostNodes().simulate('click');
+
+      await waitFor(() => expect(UserSummaryData.changeHandler).toHaveBeenCalledTimes(1));
+      disableDialogModal.find('button.btn-link').simulate('click');
+      disableDialogModal = wrapper.find('Modal#user-account-status-toggle');
+      expect(disableDialogModal.prop('open')).toEqual(false);
+      mockApiCall.mockRestore();
+    });
+  });
+
+  describe('Enable User Button', () => {
+    beforeEach(() => {
+      const passwordStatusData = { ...UserSummaryData.userData.passwordStatus, status: 'Unusable' };
+      const data = {
+        username: UserSummaryData.userData.username,
+        passwordStatus: passwordStatusData,
+        changeHandler: UserSummaryData.changeHandler,
+      };
+      wrapper = mount(<TogglePasswordStatus {...data} />);
+    });
+
+    it('Enable User button for disabled user', () => {
+      const passwordActionButton = wrapper.find('#toggle-password').hostNodes();
+      expect(passwordActionButton.text()).toEqual('Enable User');
+      expect(passwordActionButton.disabled).toBeFalsy();
+    });
+
+    it('Enable User Modal', async () => {
+      const mockApiCall = jest.spyOn(api, 'postTogglePasswordStatus').mockImplementationOnce(() => Promise.resolve());
+      const passwordActionButton = wrapper.find('#toggle-password').hostNodes();
+      let enableUserModal = wrapper.find('Modal#user-account-status-toggle');
+
+      expect(enableUserModal.prop('open')).toEqual(false);
+      expect(passwordActionButton.text()).toEqual('Enable User');
+      expect(passwordActionButton.disabled).toBeFalsy();
+
+      passwordActionButton.simulate('click');
+      enableUserModal = wrapper.find('Modal#user-account-status-toggle');
+
+      expect(enableUserModal.prop('open')).toEqual(true);
+      expect(enableUserModal.prop('title')).toEqual('Enable user confirmation');
+      expect(enableUserModal.find('.alert-warning').text()).toEqual(
+        'Please provide the reason for enabling the user edx.',
+      );
+      enableUserModal.find('input[name="comment"]').simulate('change', { target: { value: 'Enable Test User' } });
+      enableUserModal.find('button.btn-danger').hostNodes().simulate('click');
+
+      await waitFor(() => expect(UserSummaryData.changeHandler).toHaveBeenCalledTimes(1));
+      mockApiCall.mockRestore();
+    });
+  });
+});

--- a/src/users/v2/IdentityVerificationStatus.jsx
+++ b/src/users/v2/IdentityVerificationStatus.jsx
@@ -119,6 +119,7 @@ export default function IdentityVerificationStatus({
         onClose={() => setIsIdvModalOpen(false)}
         title={detailIdvDataTitle}
         id="idv-extra-data"
+        dialogClassName="modal-lg modal-dialog-centered"
         body={(
           <TableV2
             data={detailIdvData}


### PR DESCRIPTION
### [PROD-2523](https://openedx.atlassian.net/browse/PROD-2523)

### Description

Add v2 account actions components
- Fix the width issue with Password history Modal
- Use warning alerts with ResetPassword and Enable/Disable user action

Besides the account action changes, IDV Modal has been updated to be vertically centered and converted into a large modal.

### Testing Instructions

- Uncomment learner info import in index
- Verify the style and feel of all the components
- Enable and disable a learner account multiple times and verify the size of Password History Modal 

### Screenshots
<img width="1670" alt="Screenshot 2021-10-04 at 8 58 56 PM" src="https://user-images.githubusercontent.com/40599381/135885358-9c4d251e-7e1b-4b6c-acba-ad19b5cc43c3.png">
<img width="1670" alt="Screenshot 2021-10-04 at 8 59 05 PM" src="https://user-images.githubusercontent.com/40599381/135885391-d97efff7-a245-418c-bce1-cdd691e8deeb.png">
<img width="1670" alt="Screenshot 2021-10-05 at 12 38 44 PM" src="https://user-images.githubusercontent.com/40599381/135980804-cd998108-55eb-4b6c-aee5-eaca74fbb214.png">
<img width="1670" alt="Screenshot 2021-10-05 at 12 39 03 PM" src="https://user-images.githubusercontent.com/40599381/135980819-9b14a79e-8bfd-49a5-89d9-f351c85326ba.png">
<img width="1670" alt="Screenshot 2021-10-05 at 12 38 24 PM" src="https://user-images.githubusercontent.com/40599381/135980781-4ac1fe4b-f410-438e-8a1e-16137347b4df.png">

