### PR TITLE
feat: add loader and submit button features

### DIFF
--- a/src/users/enrollments/v2/ChangeEnrollmentForm.jsx
+++ b/src/users/enrollments/v2/ChangeEnrollmentForm.jsx
@@ -20,6 +20,7 @@ export default function ChangeEnrollmentForm({
   const [comments, setComments] = useState('');
   const [hideOnSubmit, setHideOnSubmit] = useState(false);
   const [modalIsOpen, setModalIsOpen] = useState(true);
+  const [showLoader, setShowLoader] = useState(false);
   const { add, clear } = useContext(UserMessagesContext);
 
   reasons[0] = { label: 'Reason for Change', value: '', disabled: true };
@@ -28,16 +29,14 @@ export default function ChangeEnrollmentForm({
     const modeList = [];
     modeList.push({ label: 'New Mode', value: '', disabled: true });
     enrollment.courseModes.map(enrollmentMode => (
-      modeList.push(enrollmentMode.slug)
+      !(enrollmentMode.slug === enrollment.mode) && modeList.push(enrollmentMode.slug)
     ));
-    if (!modeList.some(enrollmentMode => enrollmentMode === enrollment.mode)) {
-      modeList.push(enrollment.mode);
-    }
     return modeList;
   };
 
   const submit = useCallback(() => {
     clear('changeEnrollments');
+    setShowLoader(true);
     const sendReason = (reason === 'other') ? comments : reason;
     patchEnrollment({
       user,
@@ -60,6 +59,7 @@ export default function ChangeEnrollmentForm({
         add(successMessage);
         changeHandler();
       }
+      setShowLoader(false);
     });
   });
 
@@ -147,15 +147,19 @@ export default function ChangeEnrollmentForm({
         changeEnrollmentForm
       )}
       buttons={[
-        <Button
-          variant="primary"
-          disabled={!(mode && reason)}
-          className="mr-3"
-          onClick={submit}
-          hidden={hideOnSubmit}
-        >
-          Submit
-        </Button>,
+        showLoader
+          ? (<div className="spinner-border text-primary" role="status" />)
+          : (
+            <Button
+              variant="primary"
+              disabled={!(mode && reason)}
+              className="mr-3"
+              onClick={submit}
+              hidden={hideOnSubmit}
+            >
+              Submit
+            </Button>
+          ),
       ]}
     />
   );

--- a/src/users/enrollments/v2/ChangeEnrollmentForm.test.jsx
+++ b/src/users/enrollments/v2/ChangeEnrollmentForm.test.jsx
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { waitForComponentToPaint } from '../../../setupTest';
@@ -31,7 +30,7 @@ describe('Enrollment Change form', () => {
     const modeSelectionDropdown = wrapper.find('select#mode');
     const modeChangeReasonDropdown = wrapper.find('select#reason');
     const commentsTextarea = wrapper.find('textarea#comments');
-    expect(modeSelectionDropdown.find('option')).toHaveLength(3);
+    expect(modeSelectionDropdown.find('option')).toHaveLength(2);
     expect(modeChangeReasonDropdown.find('option')).toHaveLength(5);
     expect(commentsTextarea.text()).toEqual('');
 
@@ -48,12 +47,15 @@ describe('Enrollment Change form', () => {
       wrapper.find('select#reason').simulate('change', { target: { value: 'Other' } });
       wrapper.find('select#mode').simulate('change', { target: { value: 'verified' } });
       wrapper.find('textarea#comments').simulate('change', { target: { value: 'test mode change' } });
+      expect(wrapper.find('div.spinner-border').length).toEqual(0);
       wrapper.find('button.btn-primary').simulate('click');
+      expect(wrapper.find('div.spinner-border').length).toEqual(1);
       expect(apiMock).toHaveBeenCalledTimes(1);
 
-      // The mock call count does not update on time for expect call, therefore, waitFor is used to give enough time
-      // for the call count to update. However, it is possible this might turn out to be flaky.
-      await waitFor(() => expect(changeEnrollmentFormData.changeHandler).toHaveBeenCalledTimes(1));
+      await waitForComponentToPaint(wrapper);
+      expect(changeEnrollmentFormData.changeHandler).toHaveBeenCalledTimes(1);
+      expect(wrapper.find('div.spinner-border').length).toEqual(0);
+
       apiMock.mockReset();
       const submitButton = wrapper.find('button.btn-primary');
       expect(submitButton).toEqual({});

--- a/src/users/enrollments/v2/CreateEnrollmentForm.jsx
+++ b/src/users/enrollments/v2/CreateEnrollmentForm.jsx
@@ -20,10 +20,12 @@ export default function CreateEnrollmentForm({
   const [reason, setReason] = useState('');
   const [comments, setComments] = useState('');
   const [modalIsOpen, setModalIsOpen] = useState(true);
+  const [showLoader, setShowLoader] = useState(false);
   const { add, clear } = useContext(UserMessagesContext);
 
   const submit = useCallback(() => {
     clear('createEnrollments');
+    setShowLoader(true);
     const sendReason = (reason === 'other') ? comments : reason;
     postEnrollment({
       user,
@@ -44,6 +46,7 @@ export default function CreateEnrollmentForm({
         add(successMessage);
         changeHandler();
       }
+      setShowLoader(false);
     });
   });
 
@@ -104,14 +107,18 @@ export default function CreateEnrollmentForm({
         createEnrollmentForm
       )}
       buttons={[
-        <Button
-          variant="primary"
-          disabled={!(courseID && reason)}
-          className="mr-3"
-          onClick={submit}
-        >
-          Submit
-        </Button>,
+        showLoader
+          ? (<div className="spinner-border text-primary" role="status" />)
+          : (
+            <Button
+              variant="primary"
+              disabled={!(courseID && reason)}
+              className="mr-3"
+              onClick={submit}
+            >
+              Submit
+            </Button>
+          ),
       ]}
     />
   );

--- a/src/users/enrollments/v2/CreateEnrollmentForm.test.jsx
+++ b/src/users/enrollments/v2/CreateEnrollmentForm.test.jsx
@@ -48,11 +48,14 @@ describe('Enrollment Create form', () => {
       wrapper.find('select#reason').simulate('change', { target: { value: 'Other' } });
       wrapper.find('select#mode').simulate('change', { target: { value: 'verified' } });
       wrapper.find('textarea#comments').simulate('change', { target: { value: 'test create enrollment' } });
+      expect(wrapper.find('div.spinner-border').length).toEqual(0);
       wrapper.find('button.btn-primary').simulate('click');
+      expect(wrapper.find('div.spinner-border').length).toEqual(1);
       expect(apiMock).toHaveBeenCalledTimes(1);
 
       await waitForComponentToPaint(wrapper);
       expect(wrapper.find('.alert').text()).toEqual('New Enrollment successfully created.');
+      expect(wrapper.find('div.spinner-border').length).toEqual(0);
       apiMock.mockReset();
     });
 

--- a/src/users/entitlements/v2/CreateEntitlementForm.jsx
+++ b/src/users/entitlements/v2/CreateEntitlementForm.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import {
   Button, Input, Modal,
 } from '@edx/paragon';
-import classNames from 'classnames';
 
 import UserMessagesContext from '../../../userMessages/UserMessagesContext';
 import AlertList from '../../../userMessages/AlertList';
@@ -22,12 +21,12 @@ export default function CreateEntitlementForm({
   const [mode, setMode] = useState(entitlement.mode);
   const [comments, setComments] = useState('');
   const [modalIsOpen, setModalIsOpen] = useState(true);
-  const [disableSubmit, setDisableSubmit] = useState(false);
+  const [showLoader, setShowLoader] = useState(false);
   const { add, clear } = useContext(UserMessagesContext);
 
   const submit = useCallback(() => {
     clear('createEntitlement');
-    setDisableSubmit(true);
+    setShowLoader(true);
     postEntitlement({
       requestData: {
         course_uuid: courseUuid,
@@ -40,7 +39,7 @@ export default function CreateEntitlementForm({
         }],
       },
     }).then((result) => {
-      setDisableSubmit(false);
+      setShowLoader(false);
       if (result.errors !== undefined) {
         result.errors.forEach(error => add(error));
       } else {
@@ -110,17 +109,18 @@ export default function CreateEntitlementForm({
         createEntitlementForm
       )}
       buttons={[
-        <Button
-          variant="primary"
-          disabled={!(courseUuid && mode && comments) || (disableSubmit)}
-          className={classNames(
-            'mr-3',
-            { disabled: !(courseUuid && mode && comments) || (disableSubmit) },
-          )}
-          onClick={submit}
-        >
-          Submit
-        </Button>,
+        showLoader
+          ? (<div className="spinner-border text-primary" role="status" />)
+          : (
+            <Button
+              variant="primary"
+              disabled={!(courseUuid && mode && comments)}
+              className="mr-3"
+              onClick={submit}
+            >
+              Submit
+            </Button>
+          ),
       ]}
     />
   );

--- a/src/users/entitlements/v2/CreateEntitlementForm.test.jsx
+++ b/src/users/entitlements/v2/CreateEntitlementForm.test.jsx
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { waitForComponentToPaint } from '../../../setupTest';
@@ -54,12 +53,14 @@ describe('Create Entitlement Form', () => {
       wrapper.find('textarea#comments').simulate('change', { target: { value: 'creating new entitlement' } });
       const submitButton = wrapper.find('button.btn-primary');
       expect(submitButton.prop('disabled')).toBeFalsy();
+      expect(wrapper.find('div.spinner-border').length).toEqual(0);
       submitButton.simulate('click');
+      expect(wrapper.find('div.spinner-border').length).toEqual(1);
 
       expect(apiMock).toHaveBeenCalledTimes(1);
-      // The mock call count does not update on time for expect call, therefore, waitFor is used to give enough time
-      // for the call count to update. However, it is possible this might turn out to be flaky.
-      await waitFor(() => expect(entitlementFormData.changeHandler).toHaveBeenCalledTimes(1));
+      await waitForComponentToPaint(wrapper);
+      expect(entitlementFormData.changeHandler).toHaveBeenCalledTimes(1);
+      expect(wrapper.find('div.spinner-border').length).toEqual(0);
       apiMock.mockReset();
     });
 

--- a/src/users/entitlements/v2/ExpireEntitlementForm.jsx
+++ b/src/users/entitlements/v2/ExpireEntitlementForm.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import {
   Button, Input, Modal,
 } from '@edx/paragon';
-import classNames from 'classnames';
 
 import UserMessagesContext from '../../../userMessages/UserMessagesContext';
 import AlertList from '../../../userMessages/AlertList';
@@ -20,12 +19,14 @@ export default function ExpireEntitlementForm({
 }) {
   const [comments, setComments] = useState('');
   const [modalIsOpen, setModalIsOpen] = useState(true);
-  const [hideOnSubmit, setHideOnSubmit] = useState(false);
+  const [showLoader, setShowLoader] = useState(false);
+  const [hideSubmit, setHideSubmit] = useState(false);
   const { add, clear } = useContext(UserMessagesContext);
 
   const submit = useCallback(() => {
     const now = new Date().toISOString();
     clear('expireEntitlement');
+    setShowLoader(true);
     patchEntitlement({
       uuid: entitlement.uuid,
       requestData: makeRequestData({
@@ -45,10 +46,11 @@ export default function ExpireEntitlementForm({
           type: 'success',
           topic: 'expireEntitlement',
         };
-        setHideOnSubmit(true);
+        setHideSubmit(true);
         add(successMessage);
         changeHandler();
       }
+      setShowLoader(false);
     });
   });
 
@@ -81,7 +83,7 @@ export default function ExpireEntitlementForm({
         placeholder="Explanation"
         defaultValue=""
         onChange={(event) => setComments(event.target.value)}
-        disabled={hideOnSubmit}
+        disabled={hideSubmit}
         ref={forwardedRef}
       />
     </form>
@@ -102,18 +104,19 @@ export default function ExpireEntitlementForm({
         expireEntitlementForm
       )}
       buttons={[
-        <Button
-          variant="primary"
-          className={classNames(
-            'mr-3',
-            { disabled: !(entitlement.courseUuid && entitlement.mode && comments) },
-          )}
-          disabled={!(entitlement.courseUuid && entitlement.mode && comments)}
-          hidden={hideOnSubmit}
-          onClick={submit}
-        >
-          Submit
-        </Button>,
+        showLoader
+          ? (<div className="spinner-border text-primary" role="status" />)
+          : (
+            <Button
+              variant="primary"
+              className="mr-3"
+              disabled={!(entitlement.courseUuid && entitlement.mode && comments)}
+              hidden={hideSubmit}
+              onClick={submit}
+            >
+              Submit
+            </Button>
+          ),
       ]}
     />
   );

--- a/src/users/entitlements/v2/ExpireEntitlementForm.test.jsx
+++ b/src/users/entitlements/v2/ExpireEntitlementForm.test.jsx
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { waitForComponentToPaint } from '../../../setupTest';
@@ -48,12 +47,14 @@ describe('Expire Entitlement Form', () => {
       wrapper.find('textarea#comments').simulate('change', { target: { value: 'expiring entitlement' } });
       let submitButton = wrapper.find('button.btn-primary');
       expect(submitButton.prop('disabled')).toBeFalsy();
+      expect(wrapper.find('div.spinner-border').length).toEqual(0);
       submitButton.simulate('click');
+      expect(wrapper.find('div.spinner-border').length).toEqual(1);
 
       expect(apiMock).toHaveBeenCalledTimes(1);
-      // The mock call count does not update on time for expect call, therefore, waitFor is used to give enough time
-      // for the call count to update. However, it is possible this might turn out to be flaky.
-      await waitFor(() => expect(entitlementFormData.changeHandler).toHaveBeenCalledTimes(1));
+      await waitForComponentToPaint(wrapper);
+      expect(entitlementFormData.changeHandler).toHaveBeenCalledTimes(1);
+      expect(wrapper.find('div.spinner-border').length).toEqual(0);
       apiMock.mockReset();
 
       submitButton = wrapper.find('button.btn-primary');

--- a/src/users/entitlements/v2/ReissueEntitlementForm.jsx
+++ b/src/users/entitlements/v2/ReissueEntitlementForm.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import {
   Button, Input, Modal,
 } from '@edx/paragon';
-import classNames from 'classnames';
 
 import UserMessagesContext from '../../../userMessages/UserMessagesContext';
 import AlertList from '../../../userMessages/AlertList';
@@ -20,11 +19,13 @@ export default function ReissueEntitlementForm({
 }) {
   const [comments, setComments] = useState('');
   const [modalIsOpen, setModalIsOpen] = useState(true);
-  const [hideOnSubmit, setHideOnSubmit] = useState(false);
+  const [showLoader, setShowLoader] = useState(false);
+  const [hideSubmit, setHideSubmit] = useState(false);
   const { add, clear } = useContext(UserMessagesContext);
 
   const submit = useCallback(() => {
     clear('reissueEntitlement');
+    setShowLoader(true);
     patchEntitlement({
       uuid: entitlement.uuid,
       requestData: makeRequestData({
@@ -43,10 +44,11 @@ export default function ReissueEntitlementForm({
           type: 'success',
           topic: 'reissueEntitlement',
         };
-        setHideOnSubmit(true);
+        setHideSubmit(true);
         add(successMessage);
         changeHandler();
       }
+      setShowLoader(false);
     });
   });
 
@@ -79,7 +81,7 @@ export default function ReissueEntitlementForm({
         placeholder="Explanation"
         defaultValue=""
         onChange={(event) => setComments(event.target.value)}
-        disabled={hideOnSubmit}
+        disabled={hideSubmit}
         ref={forwardedRef}
       />
     </form>
@@ -100,18 +102,19 @@ export default function ReissueEntitlementForm({
         reissueEntitlementForm
       )}
       buttons={[
-        <Button
-          variant="primary"
-          className={classNames(
-            'btn-primary mr-3',
-            { disabled: !(entitlement.courseUuid && entitlement.mode && comments) },
-          )}
-          disabled={!(entitlement.courseUuid && entitlement.mode && comments)}
-          hidden={hideOnSubmit}
-          onClick={submit}
-        >
-          Submit
-        </Button>,
+        showLoader
+          ? (<div className="spinner-border text-primary" role="status" />)
+          : (
+            <Button
+              variant="primary"
+              className="mr-3"
+              disabled={!(entitlement.courseUuid && entitlement.mode && comments)}
+              hidden={hideSubmit}
+              onClick={submit}
+            >
+              Submit
+            </Button>
+          ),
       ]}
     />
   );

--- a/src/users/entitlements/v2/ReissueEntitlementForm.test.jsx
+++ b/src/users/entitlements/v2/ReissueEntitlementForm.test.jsx
@@ -1,5 +1,4 @@
 import { mount } from 'enzyme';
-import { waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { waitForComponentToPaint } from '../../../setupTest';
@@ -48,12 +47,14 @@ describe('Reissue Entitlement Form', () => {
       wrapper.find('textarea#comments').simulate('change', { target: { value: 'reissue the expired entitlement' } });
       let submitButton = wrapper.find('button.btn-primary');
       expect(submitButton.prop('disabled')).toBeFalsy();
+      expect(wrapper.find('div.spinner-border').length).toEqual(0);
       submitButton.simulate('click');
+      expect(wrapper.find('div.spinner-border').length).toEqual(1);
 
       expect(apiMock).toHaveBeenCalledTimes(1);
-      // The mock call count does not update on time for expect call, therefore, waitFor is used to give enough time
-      // for the call count to update. However, it is possible this might turn out to be flaky.
-      await waitFor(() => expect(entitlementFormData.changeHandler).toHaveBeenCalledTimes(1));
+      await waitForComponentToPaint(wrapper);
+      expect(entitlementFormData.changeHandler).toHaveBeenCalledTimes(1);
+      expect(wrapper.find('div.spinner-border').length).toEqual(0);
       apiMock.mockReset();
 
       submitButton = wrapper.find('button.btn-primary');


### PR DESCRIPTION
[PROD-2510](https://openedx.atlassian.net/browse/PROD-2510)

This PR adds the following:

1. Shows a loader whenever submit button is pressed until the request is completed (also avoids multiple patch/post requests)
2. Submit button is hidden for all actions except create action AFTER the request has been completed
3. New Mode input updated. Now it doesn't include the active enrollment mode.
![image](https://user-images.githubusercontent.com/52413434/136025013-2d138255-0d74-457f-8721-d6bd6ab6b265.png)
