### PR TITLE
fix: remove alert duplication

### DIFF
--- a/src/users/data/api.js
+++ b/src/users/data/api.js
@@ -2,6 +2,7 @@ import { ensureConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import * as messages from '../../userMessages/messages';
 import * as AppUrls from './urls';
+import { REISSUE } from '../entitlements/EntitlementActions';
 import { isEmail, sortedCompareDates } from '../../utils';
 
 export async function getEntitlements(username, page = 1) {
@@ -358,7 +359,7 @@ export async function patchEntitlement({
           text:
             'There was an error submitting this entitlement. Check the JavaScript console for detailed errors.',
           type: 'danger',
-          topic: 'entitlements',
+          topic: requestData.support_details[0].action === REISSUE ? 'reissueEntitlement' : 'expireEntitlement',
         },
       ],
     };
@@ -389,7 +390,7 @@ export async function postEntitlement({
           text:
             'There was an error submitting this entitlement. Check the JavaScript console for detailed errors.',
           type: 'danger',
-          topic: 'entitlements',
+          topic: 'createEntitlement',
         },
       ],
     };
@@ -425,7 +426,7 @@ export async function postEnrollment({
           text:
             'There was an error creating the enrollment. Check the JavaScript console for detailed errors.',
           type: 'danger',
-          topic: 'enrollments',
+          topic: 'createEnrollments',
         },
       ],
     };
@@ -466,7 +467,7 @@ export async function patchEnrollment({
           text:
             'There was an error submitting this enrollment. Check the JavaScript console for detailed errors.',
           type: 'danger',
-          topic: 'enrollments',
+          topic: 'changeEnrollments',
         },
       ],
     };

--- a/src/users/data/api.test.js
+++ b/src/users/data/api.test.js
@@ -466,9 +466,11 @@ describe('API', () => {
     const entitlementUuid = 'uuid';
 
     const requestData = {
-      action: 'REISSUE',
-      comments: 'Reissue Entitlement',
-      enrollmentCourseRun: 'course-v1:testX',
+      support_details: [{
+        action: 'REISSUE',
+        comments: 'Reissue Entitlement',
+        enrollmentCourseRun: 'course-v1:testX',
+      }],
     };
 
     const expectedError = {
@@ -559,7 +561,7 @@ describe('API', () => {
       it('Unsuccessful patch', async () => {
         mockAdapter.onPatch(patchEntitlementsApiUrl, requestData).reply(() => throwError(400, ''));
         const response = await api.patchEntitlement({ uuid: entitlementUuid, requestData });
-        expect(...response.errors).toEqual(expectedError);
+        expect(...response.errors).toEqual({ ...expectedError, topic: 'expireEntitlement' });
       });
 
       it('Successful patch', async () => {
@@ -575,7 +577,7 @@ describe('API', () => {
       it('Unsuccessful post', async () => {
         mockAdapter.onPost(postEntitlementApiUrl, requestData).reply(() => throwError(400, ''));
         const response = await api.postEntitlement({ requestData });
-        expect(...response.errors).toEqual(expectedError);
+        expect(...response.errors).toEqual({ ...expectedError, topic: 'createEntitlement' });
       });
 
       it('Successful post', async () => {
@@ -630,7 +632,7 @@ describe('API', () => {
         };
         mockAdapter.onPost(enrollmentsApiUrl, requestData).reply(() => throwError(400, ''));
         const response = await api.postEnrollment({ ...apiCallData });
-        expect(...response.errors).toEqual(expectedError);
+        expect(...response.errors).toEqual({ ...expectedError, topic: 'createEnrollments' });
       });
 
       it('Successful enrollment create', async () => {
@@ -671,7 +673,7 @@ describe('API', () => {
         };
         mockAdapter.onPatch(enrollmentsApiUrl, requestData).reply(() => throwError(400, ''));
         const response = await api.patchEnrollment({ ...apiCallData });
-        expect(...response.errors).toEqual(expectedError);
+        expect(...response.errors).toEqual({ ...expectedError, topic: 'changeEnrollments' });
       });
 
       it('Successful enrollment change', async () => {

--- a/src/users/enrollments/ChangeEnrollmentForm.jsx
+++ b/src/users/enrollments/ChangeEnrollmentForm.jsx
@@ -52,7 +52,7 @@ export default function ChangeEnrollmentForm({
   return (
     <section className="card mb-3">
       <form className="card-body">
-        <AlertList topic="enrollments" className="mb-3" />
+        <AlertList topic="changeEnrollments" className="mb-3" />
         <h4 className="card-title">Change Enrollment</h4>
         <div className="form-group">
           <h5>Current Enrollment Data</h5>

--- a/src/users/enrollments/ChangeEnrollmentForm.test.jsx
+++ b/src/users/enrollments/ChangeEnrollmentForm.test.jsx
@@ -59,7 +59,7 @@ describe('Enrollment Change form', () => {
             dismissible: true,
             text: 'Error changing enrollment',
             type: 'danger',
-            topic: 'enrollments',
+            topic: 'changeEnrollments',
           },
         ],
       }));

--- a/src/users/enrollments/CreateEnrollmentForm.jsx
+++ b/src/users/enrollments/CreateEnrollmentForm.jsx
@@ -37,7 +37,7 @@ export default function CreateEnrollmentForm({
           text:
               'New Enrollment successfully created.',
           type: 'success',
-          topic: 'enrollments',
+          topic: 'createEnrollments',
         };
         add(successMessage);
       }
@@ -47,7 +47,7 @@ export default function CreateEnrollmentForm({
   return (
     <section className="card mb-3">
       <form className="card-body">
-        <AlertList topic="enrollments" className="mb-3" />
+        <AlertList topic="createEnrollments" className="mb-3" />
         <h4 className="card-title">Create New Enrollment</h4>
         <hr />
         <div className="form-group">

--- a/src/users/enrollments/CreateEnrollmentForm.test.jsx
+++ b/src/users/enrollments/CreateEnrollmentForm.test.jsx
@@ -58,7 +58,7 @@ describe('Enrollment Create form', () => {
             dismissible: true,
             text: 'Error creating enrollment',
             type: 'danger',
-            topic: 'enrollments',
+            topic: 'createEnrollments',
           },
         ],
       }));

--- a/src/users/entitlements/ExpireEntitlementForm.jsx
+++ b/src/users/entitlements/ExpireEntitlementForm.jsx
@@ -25,7 +25,7 @@ export default function ExpireEntitlementForm({
 
   const submit = useCallback(() => {
     const now = new Date().toISOString();
-    clear('entitlements');
+    clear('expireEntitlement');
     patchEntitlement({
       uuid: entitlement.uuid,
       requestData: makeRequestData({
@@ -46,7 +46,7 @@ export default function ExpireEntitlementForm({
   return (
     <section className="card mb-3">
       <form className="card-body">
-        <AlertList topic="entitlements" className="mb-3" />
+        <AlertList topic="expireEntitlement" className="mb-3" />
         <h4 className="card-title">Expire Entitlement</h4>
         <h5 className="card-subtitle">All fields are required</h5>
         <div className="form-group">

--- a/src/users/entitlements/ExpireEntitlementForm.test.jsx
+++ b/src/users/entitlements/ExpireEntitlementForm.test.jsx
@@ -65,7 +65,7 @@ describe('Expire Entitlement Form', () => {
             dismissible: true,
             text: 'Error expiring entitlement',
             type: 'danger',
-            topic: 'entitlements',
+            topic: 'expireEntitlement',
           },
         ],
       }));

--- a/src/users/entitlements/ReissueEntitlementForm.jsx
+++ b/src/users/entitlements/ReissueEntitlementForm.jsx
@@ -24,7 +24,7 @@ export default function ReissueEntitlementForm({
   const { add, clear } = useContext(UserMessagesContext);
 
   const submit = useCallback(() => {
-    clear('entitlements');
+    clear('reissueEntitlement');
     patchEntitlement({
       uuid: entitlement.uuid,
       requestData: makeRequestData({
@@ -44,7 +44,7 @@ export default function ReissueEntitlementForm({
   return (
     <section className="card mb-3">
       <form className="card-body">
-        <AlertList topic="entitlements" className="mb-3" />
+        <AlertList topic="reissueEntitlement" className="mb-3" />
         <h4 className="card-title">Reissue Entitlement</h4>
         <h5 className="card-subtitle">All fields are required</h5>
         <div className="form-group">

--- a/src/users/entitlements/ReissueEntitlementForm.test.jsx
+++ b/src/users/entitlements/ReissueEntitlementForm.test.jsx
@@ -65,7 +65,7 @@ describe('Reissue Entitlement Form', () => {
             dismissible: true,
             text: 'Error during reissue of entitlement',
             type: 'danger',
-            topic: 'entitlements',
+            topic: 'reissueEntitlement',
           },
         ],
       }));


### PR DESCRIPTION
Removing duplicate alerts as reported in [PROD-2491](https://openedx.atlassian.net/browse/PROD-2491)
Now each alert is shown in their respective component only once. (This issue was present in the existing Support Tools MFE as well)