### PR TITLE
Fix null value error causing page break in v2

### DIFF
--- a/src/users/data/test/ssoRecords.js
+++ b/src/users/data/test/ssoRecords.js
@@ -33,7 +33,7 @@ const ssoRecordsData = [
       access_token: 'longlongtokenid-QWERTYUIOPasdfghjklZXCVBNM',
       token_type: 'Bearer',
       expires: 3599,
-      auth_time: 1630334187,
+      auth_time: null,
     }),
   },
 ];

--- a/src/users/v2/SingleSignOnRecordCard.jsx
+++ b/src/users/v2/SingleSignOnRecordCard.jsx
@@ -23,7 +23,7 @@ export default function SingleSignOnRecordCard({ ssoRecord }) {
     );
 
     Object.keys(data).forEach((key) => {
-      const value = data[key].toString();
+      const value = data[key] ? data[key].toString() : '';
       if (value.length > 14) {
         data[key] = <CopyShowHyperlinks text={value} />;
       }

--- a/src/users/v2/SingleSignOnRecordCard.test.jsx
+++ b/src/users/v2/SingleSignOnRecordCard.test.jsx
@@ -62,10 +62,11 @@ describe.each(ssoRecordsData)('Single Sign On Record Card', (ssoRecordData) => {
     for (let i = 0; i < dataHeader.length; i++) {
       const accesor = dataHeader.at(i).text();
       const text = dataBody.at(i).text();
+      const value = extraData[accesor] ? extraData[accesor].toString() : '';
 
       expect(accesor in extraData).toBeTruthy();
       expect(text).toEqual(
-        extraData[accesor].toString().length > 14 ? 'Copy Show ' : extraData[accesor].toString(),
+        value.length > 14 ? 'Copy Show ' : value,
       );
     }
   });


### PR DESCRIPTION
## Description
This PR fixes null value error on SSO Records in Support Tool v2

- added a small check before using `toString()`

## Linked Ticket
[PROD-2545](https://openedx.atlassian.net/browse/PROD-2545)

## How to test locally:
1. Add dummy data here: `/admin/social_django/usersocialauth/`
2. Populate extra data with null value