### PR TITLE
fix: format authTime as date string

### DIFF
--- a/src/users/v2/SingleSignOnRecordCard.jsx
+++ b/src/users/v2/SingleSignOnRecordCard.jsx
@@ -24,7 +24,10 @@ export default function SingleSignOnRecordCard({ ssoRecord }) {
 
     Object.keys(data).forEach((key) => {
       const value = data[key] ? data[key].toString() : '';
-      if (value.length > 14) {
+
+      if (key === 'authTime') {
+        data[key] = formatDate(data[key]);
+      } else if (value.length > 14) {
         data[key] = <CopyShowHyperlinks text={value} />;
       }
     });

--- a/src/users/v2/SingleSignOnRecordCard.test.jsx
+++ b/src/users/v2/SingleSignOnRecordCard.test.jsx
@@ -65,9 +65,13 @@ describe.each(ssoRecordsData)('Single Sign On Record Card', (ssoRecordData) => {
       const value = extraData[accesor] ? extraData[accesor].toString() : '';
 
       expect(accesor in extraData).toBeTruthy();
-      expect(text).toEqual(
-        value.length > 14 ? 'Copy Show ' : value,
-      );
+      if (accesor === 'authTime') {
+        expect(text).toEqual(formatDate(extraData[accesor]));
+      } else {
+        expect(text).toEqual(
+          value.length > 14 ? 'Copy Show ' : value,
+        );
+      }
     }
   });
 });


### PR DESCRIPTION
## Description
This PR format `authTime` field as human readable date format. 

## Linked Ticket
[PROD-2550](https://openedx.atlassian.net/browse/PROD-2550)

## Screenshots 
Before | After
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/47540683/139533860-2c36e9c6-11a5-43ce-828f-4b68ebbabd7b.png) | ![image](https://user-images.githubusercontent.com/47540683/139533846-b8705f56-2362-4415-9ab7-ec8299f325da.png)