### PR TITLE
feat: add default redirect to v2

### DIFF
--- a/src/supportHeader/ToggleVersion.jsx
+++ b/src/supportHeader/ToggleVersion.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { Form } from '@edx/paragon';
 import { AppContext } from '@edx/frontend-platform/react';
 import { TAB_PATH_MAP } from '../SupportToolsTab/constants';
@@ -20,6 +20,14 @@ export default function ToggleVersion() {
       window.location.href = window.location.href.replace(config.BASE_URL, `${config.BASE_URL}/v2`);
     }
   };
+
+  useEffect(() => {
+    if (sessionStorage.getItem('redirect') === null) {
+      sessionStorage.setItem('redirect', 'false');
+      if (window.location.href.indexOf('/v2') === -1) { handleChange(); }
+    }
+  }, []);
+
   return (
     <Form.Check
       type="switch"


### PR DESCRIPTION
## Description
This PR adds default redirect to v2 on first load by leveraging [session storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage). Please note that there will be no redirect on subsequent switching or page loads until session storage expires i.e. tab or browser closes. 

## Linked Ticket
[PROD-2554](https://openedx.atlassian.net/browse/PROD-2554)

## To Test:
- Redirect to v2 on first load
- No redirect on toggle switch
- State reset on tab / browser close
- Behavior on different browsers