### PR TITLE
fix: remove tab unmount for main tab

### DIFF
--- a/src/FeatureBasedEnrollments/FeatureBasedEnrollment.test.jsx
+++ b/src/FeatureBasedEnrollments/FeatureBasedEnrollment.test.jsx
@@ -16,6 +16,7 @@ const FeatureBasedEnrollmentWrapper = (props) => (
 describe('Feature Based Enrollment', () => {
   const props = {
     courseId: 'course-v1:testX+test123+2030',
+    apiFetchSignal: true,
   };
 
   let wrapper;

--- a/src/FeatureBasedEnrollments/FeatureBasedEnrollmentIndexPage.jsx
+++ b/src/FeatureBasedEnrollments/FeatureBasedEnrollmentIndexPage.jsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useContext,
   useState,
+  useLayoutEffect,
 } from 'react';
 import PropTypes from 'prop-types';
 import { Input, Button } from '@edx/paragon';
@@ -13,6 +14,7 @@ import UserMessagesContext from '../userMessages/UserMessagesContext';
 import AlertList from '../userMessages/AlertList';
 import { isValidCourseID } from '../utils';
 import FeatureBasedEnrollment from './FeatureBasedEnrollment';
+import { FEATURE_BASED_ENROLLMENT_TAB, TAB_PATH_MAP } from '../SupportToolsTab/constants';
 
 export default function FeatureBasedEnrollmentIndexPage({ location }) {
   const params = new Map(
@@ -81,6 +83,15 @@ export default function FeatureBasedEnrollmentIndexPage({ location }) {
       handleSearchInput(params.get('course_id'));
     }
   }, []);
+
+  // To change the url with appropriate query param if query param info is not present in URL
+  useLayoutEffect(() => {
+    if (searchValue
+        && location.pathname.indexOf(TAB_PATH_MAP[FEATURE_BASED_ENROLLMENT_TAB]) !== -1
+        && !params.get('course_id')) {
+      pushHistoryIfChanged(`${TAB_PATH_MAP[FEATURE_BASED_ENROLLMENT_TAB]}/?course_id=${searchValue}`);
+    }
+  });
 
   return (
     <main className="mt-3 mb-5">

--- a/src/SupportToolsTab/SupportToolsTab.jsx
+++ b/src/SupportToolsTab/SupportToolsTab.jsx
@@ -34,7 +34,6 @@ export default function SupportToolsTab({ location }) {
             }
           }}
           defaultActiveKey={tabKey}
-          unmountOnExit
         >
           <Tab eventKey={LEARNER_INFO_TAB} title="Learner Information">
             <br />

--- a/src/users/v2/UserPage.jsx
+++ b/src/users/v2/UserPage.jsx
@@ -1,7 +1,7 @@
 import { camelCaseObject, history } from '@edx/frontend-platform';
 import PropTypes from 'prop-types';
 import React, {
-  useCallback, useContext, useEffect, useState,
+  useCallback, useContext, useEffect, useState, useLayoutEffect,
 } from 'react';
 import PageLoading from '../../components/common/PageLoading';
 import AlertList from '../../userMessages/AlertList';
@@ -11,7 +11,7 @@ import { isEmail, isValidUsername } from '../../utils/index';
 import { getAllUserData } from '../data/api';
 import UserSearch from '../UserSearch';
 import LearnerInformation from './LearnerInformation';
-import { TAB_PATH_MAP } from '../../SupportToolsTab/constants';
+import { LEARNER_INFO_TAB, TAB_PATH_MAP } from '../../SupportToolsTab/constants';
 
 // Supports urls such as /users/?username={username} and /users/?email={email}
 export default function UserPage({ location }) {
@@ -118,6 +118,19 @@ export default function UserPage({ location }) {
       handleFetchSearchResults(params.get('email'));
     }
   }, [params.get('username'), params.get('email')]);
+
+  // To change the url with appropriate query param if query param info is not present in URL
+  useLayoutEffect(() => {
+    if (userIdentifier
+      && location.pathname.indexOf(TAB_PATH_MAP[LEARNER_INFO_TAB]) !== -1
+      && !(params.get('email') || params.get('username'))) {
+      if (isEmail(userIdentifier)) {
+        pushHistoryIfChanged(`${TAB_PATH_MAP[LEARNER_INFO_TAB]}/?email=${userIdentifier}`);
+      } else if (isValidUsername(userIdentifier)) {
+        pushHistoryIfChanged(`${TAB_PATH_MAP[LEARNER_INFO_TAB]}/?username=${userIdentifier}`);
+      }
+    }
+  });
 
   return (
     <main className="mt-3 mb-5">


### PR DESCRIPTION
### [PROD-2557](https://openedx.atlassian.net/browse/PROD-2557)

### Description
- Remove unmountOnExit from support tools tab so that the main tool does not unmount when the tab is switched. 
- Add useLayoutEffect in User and FBE Index pages responsible for updating url with appropriate query params when the tab is switched(assuming user made a search result on 1 tool, navigated to other, and then returned to original tool)

Ref: https://react-bootstrap.github.io/components/tabs/#tabs-props