### PR TITLE
fix: recover entitlement reissue button condition

### DIFF
--- a/src/users/entitlements/v2/Entitlements.jsx
+++ b/src/users/entitlements/v2/Entitlements.jsx
@@ -107,8 +107,8 @@ export default function Entitlements({
                 setUserEntitlement(entitlement);
                 setFormType(REISSUE);
               }}
-              // disable if entitlement has no associated course run or the entitlement is expired
-              disabled={Boolean(!entitlement.enrollmentCourseRun || entitlement.expiredAt)}
+              // disable if entitlement has no associated course run
+              disabled={Boolean(!entitlement.enrollmentCourseRun)}
               className="small"
             >
               Reissue

--- a/src/users/entitlements/v2/Entitlements.test.jsx
+++ b/src/users/entitlements/v2/Entitlements.test.jsx
@@ -132,11 +132,6 @@ describe('Entitlements V2 Listing', () => {
 
   describe('Reissue entitlement button', () => {
     it('Enabled Reissue entitlement button', async () => {
-      entitlementsData.results[0] = { ...entitlementsData.results[0], expiredAt: null };
-      jest.spyOn(api, 'getEntitlements').mockImplementationOnce(() => Promise.resolve(entitlementsData));
-      wrapper = mount(<EntitlementsPageWrapper {...props} />);
-      await waitForComponentToPaint(wrapper);
-
       // We're only checking row 0 of the table since the Reissue button is not disabled
       let dataRow = wrapper.find('table tbody tr').at(0);
       dataRow.find('.dropdown button').simulate('click');


### PR DESCRIPTION
[PROD-2560](https://openedx.atlassian.net/browse/PROD-2560)

After a discussion with Revenue team about if we should keep allowing reissue on an expired entitlement or not. It was decided that if an entitlement is used irrespective of it being expired, the Learner Support User is allowed to reissue that entitlement.
