### PR TITLE
feat: add course title in entitlement course summary

### DIFF
--- a/src/users/courseSummary/v2/CourseSummary.jsx
+++ b/src/users/courseSummary/v2/CourseSummary.jsx
@@ -149,7 +149,11 @@ export default function CourseSummary({
         closeHandler();
         setModalIsOpen(false);
       }}
-      title="Course Summary"
+      title={
+        courseSummaryData && !courseSummaryErrors
+          ? `Course Summary: ${courseSummaryData.title}`
+          : 'Course Summary'
+        }
       id="course-summary"
       dialogClassName="modal-lg"
       body={(

--- a/src/users/courseSummary/v2/CourseSummary.test.jsx
+++ b/src/users/courseSummary/v2/CourseSummary.test.jsx
@@ -38,6 +38,7 @@ describe('Course Summary', () => {
 
     let courseSummaryModal = wrapper.find('Modal#course-summary');
     expect(courseSummaryModal.prop('open')).toEqual(true);
+    expect(courseSummaryModal.find('h2.modal-title').text()).toEqual('Course Summary: Test Course');
 
     const courseRunsTable = wrapper.find('table.course-runs-table');
     expect(courseRunsTable.find('tbody tr').length).toEqual(2);
@@ -77,6 +78,9 @@ describe('Course Summary', () => {
     }));
     wrapper = mount(<CourseSummaryWrapper {...props} />);
     await waitForComponentToPaint(wrapper);
+
+    const courseSummaryModal = wrapper.find('Modal#course-summary');
+    expect(courseSummaryModal.find('h2.modal-title').text()).toEqual('Course Summary');
     const alert = wrapper.find('.alert');
     expect(alert.text()).toEqual('No Course Summary Data found');
   });


### PR DESCRIPTION
### [PROD-2568](https://openedx.atlassian.net/browse/PROD-2568)

### Description

- Add Course Title on course summary of entitlement
- Render default title and update it when the API call is successful
This behavior is present in the old tools and was present in the [design too](https://miro.com/app/board/o9J_lBKXkbI=/) but it was missed during the implementation of v2.


<img width="613" alt="Screenshot 2021-11-12 at 9 43 35 AM" src="https://user-images.githubusercontent.com/40599381/141411269-ec3ae4b6-f108-48fa-859b-0d4b292c1c92.png">
<img width="613" alt="Screenshot 2021-11-12 at 9 43 45 AM" src="https://user-images.githubusercontent.com/40599381/141411281-4ac2c1a0-5b5e-4cac-b7b9-cbe5b6f829a9.png">


