### PR TITLE
feat: add verified name to user summary

### DIFF
--- a/src/users/v2/UserSummary.jsx
+++ b/src/users/v2/UserSummary.jsx
@@ -27,6 +27,11 @@ export default function UserSummary({
                 </tr>
 
                 <tr>
+                  <th>Verified Name</th>
+                  <td>{userData.verifiedName}</td>
+                </tr>
+
+                <tr>
                   <th>Username</th>
                   <td>{userData.username}</td>
                 </tr>
@@ -102,6 +107,7 @@ export default function UserSummary({
 UserSummary.propTypes = {
   userData: PropTypes.shape({
     name: PropTypes.string,
+    verifiedName: PropTypes.string,
     username: PropTypes.string,
     id: PropTypes.number,
     email: PropTypes.string,

--- a/src/users/v2/UserSummary.test.jsx
+++ b/src/users/v2/UserSummary.test.jsx
@@ -59,6 +59,10 @@ describe('User Summary Component Tests', () => {
           value: 'edx',
         },
         {
+          header: 'Verified Name',
+          value: '',
+        },
+        {
           header: 'Username',
           value: 'edx',
         },
@@ -111,8 +115,8 @@ describe('User Summary Component Tests', () => {
     const getActivationKeyRow = (data) => {
       mountUserSummaryWrapper(data);
       const dataTable = wrapper.find('#account-table table');
-      const rowName = dataTable.find('tbody tr').at(4).find('th').at(0);
-      const rowValue = dataTable.find('tbody tr').at(4).find('td').at(0);
+      const rowName = dataTable.find('tbody tr').at(5).find('th').at(0);
+      const rowValue = dataTable.find('tbody tr').at(5).find('td').at(0);
 
       return {
         rowName,


### PR DESCRIPTION
### [PROD-2602](https://openedx.atlassian.net/browse/PROD-2602)

### Description
This PR is related to the request to add a verified name in support tools MFE on the account information section. The verified name is defined in edx-name-affirmation's VerifiedName model.  See https://openedx.atlassian.net/wiki/spaces/PT/pages/2629928102/Name+Affirmation+Re-imagine+IDV on how it looks. 
This PR adds a user field Verified Name in User Summary that returns the latest approved verified name.


### Testing Instructions
[Backend PR](https://github.com/edx/edx-platform/pull/29624)


Screenshot:
<img width="633" alt="Screenshot 2022-01-12 at 5 06 12 PM" src="https://user-images.githubusercontent.com/56605828/149137354-68723145-3f3f-414b-8176-e1428e4c649a.png">
