### PR TITLE
feat: add program inspector to new support tools

### DIFF
--- a/src/ProgramEnrollments/ProgramEnrollmentsIndexPage.jsx
+++ b/src/ProgramEnrollments/ProgramEnrollmentsIndexPage.jsx
@@ -1,14 +1,35 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import { Tabs, Tab } from '@edx/paragon';
 import LinkProgramEnrollments from './LinkProgramEnrollments';
+import ProgramInspector from './ProgramInspector/ProgramInspector';
 
 export default function ProgramEnrollmentsIndexPage({ location }) {
+  const [eventKey, setEventKey] = useState('program_inspector');
+
+  useEffect(() => {
+    if (location.search) {
+      setEventKey('program_inspector');
+    } else {
+      setEventKey('program_enrollment');
+    }
+  }, [location.search]);
+
   return (
-    <main className="mt-3 mb-5">
-      <div className="col-sm-6 pr-sm-5 link-program-enrollments">
-        <LinkProgramEnrollments location={location} />
-      </div>
-    </main>
+    <>
+      <Tabs id="programs" defaultActiveKey={eventKey} className="programs">
+        <Tab eventKey="program_inspector" title="Program Inspector">
+          <br />
+          <ProgramInspector location={location} />
+        </Tab>
+        <Tab eventKey="program_enrollment" title="Link Program Enrollments">
+          <br />
+          <div className="col-sm-12 px-0">
+            <LinkProgramEnrollments />
+          </div>
+        </Tab>
+      </Tabs>
+    </>
   );
 }
 

--- a/src/ProgramEnrollments/ProgramEnrollmentsIndexPage.test.jsx
+++ b/src/ProgramEnrollments/ProgramEnrollmentsIndexPage.test.jsx
@@ -1,0 +1,98 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { waitForComponentToPaint } from '../setupTest';
+import ProgramEnrollmentsIndexPage from './ProgramEnrollmentsIndexPage';
+import UserMessagesProvider from '../userMessages/UserMessagesProvider';
+import samlProvidersResponseValues from './ProgramInspector/data/test/samlProviders';
+import * as samlApi from './ProgramInspector/data/api';
+
+const ProgramEnrollmentsIndexPageWrapper = (props) => (
+  <MemoryRouter>
+    <UserMessagesProvider>
+      <ProgramEnrollmentsIndexPage {...props} />
+    </UserMessagesProvider>
+  </MemoryRouter>
+);
+
+describe('Program Enrollments Index Page', () => {
+  let wrapper;
+  let location;
+  let samlMock;
+
+  beforeEach(() => {
+    location = { pathname: '/v2/programs', search: '' };
+    samlMock = jest
+      .spyOn(samlApi, 'getSAMLProviderList')
+      .mockImplementationOnce(() => Promise.resolve(samlProvidersResponseValues));
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+    }
+    if (samlMock) {
+      samlMock.mockReset();
+    }
+  });
+
+  it('renders correctly', async () => {
+    wrapper = mount(<ProgramEnrollmentsIndexPageWrapper location={location} />);
+    await waitForComponentToPaint(wrapper);
+
+    const tabs = wrapper.find('nav.nav-tabs a');
+    expect(tabs.length).toEqual(2);
+
+    expect(tabs.at(0).text()).toEqual('Program Inspector');
+    expect(tabs.at(1).text()).toEqual('Link Program Enrollments');
+  });
+
+  it('Link Program Enrollments Tab', async () => {
+    wrapper = mount(<ProgramEnrollmentsIndexPageWrapper location={location} />);
+    await waitForComponentToPaint(wrapper);
+
+    let tabs = wrapper.find('nav.nav-tabs a');
+
+    tabs.at(0).simulate('click');
+    tabs = wrapper.find('nav.nav-tabs a');
+    expect(tabs.at(0).html()).toEqual(expect.stringContaining('active'));
+    expect(tabs.at(1).html()).not.toEqual(expect.stringContaining('active'));
+    expect(wrapper.find('h3').at(1).text()).toEqual(
+      'Link Program Enrollments',
+    );
+  });
+
+  it('Program Inspector Tab', async () => {
+    wrapper = mount(<ProgramEnrollmentsIndexPageWrapper location={location} />);
+    await waitForComponentToPaint(wrapper);
+
+    let tabs = wrapper.find('nav.nav-tabs a');
+
+    tabs.at(1).simulate('click');
+    tabs = wrapper.find('nav.nav-tabs a');
+    expect(tabs.at(0).html()).not.toEqual(expect.stringContaining('active'));
+    expect(tabs.at(1).html()).toEqual(expect.stringContaining('active'));
+    expect(wrapper.find('h3').at(0).text()).toEqual(
+      'Program Enrollments Inspector',
+    );
+  });
+
+  it('page renders without query', async () => {
+    wrapper = mount(<ProgramEnrollmentsIndexPageWrapper location={location} />);
+    await waitForComponentToPaint(wrapper);
+    const tabs = wrapper.find('nav.nav-tabs a');
+
+    expect(tabs.at(0).html()).toEqual(expect.stringContaining('active'));
+    expect(tabs.at(1).html()).not.toEqual(expect.stringContaining('active'));
+  });
+
+  it('page renders with query', async () => {
+    location.search = '?edx_user=&org_key=testX&external_user_key=';
+    wrapper = mount(<ProgramEnrollmentsIndexPageWrapper location={location} />);
+    await waitForComponentToPaint(wrapper);
+    const tabs = wrapper.find('nav.nav-tabs a');
+
+    expect(tabs.at(0).html()).toEqual(expect.stringContaining('active'));
+    expect(tabs.at(1).html()).not.toEqual(expect.stringContaining('active'));
+  });
+});

--- a/src/ProgramEnrollments/ProgramInspector/EnrollmentDetails.jsx
+++ b/src/ProgramEnrollments/ProgramInspector/EnrollmentDetails.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Hyperlink } from '@edx/paragon';
+import { getConfig } from '@edx/frontend-platform';
+import TableV2 from '../../components/Table';
+import {
+  CourseColumns,
+  EnrollmentColumns,
+} from './utils/constants';
+
+export default function EnrollmentDetails({ enrollments }) {
+  const { LMS_BASE_URL } = getConfig();
+  return enrollments ? (
+    enrollments.map((enrollment) => (
+      <div key={enrollment.program_uuid} className="enrollments">
+        <h3>
+          Program: {enrollment.program_name} ({enrollment.program_uuid})
+        </h3>
+        <TableV2
+          columns={EnrollmentColumns}
+          data={[
+            {
+              status: enrollment.status,
+              createdAt: enrollment.created,
+              lastUpdate: enrollment.modified,
+              externalUserKey: enrollment.external_user_key,
+            },
+          ]}
+          styleName="custom-table enrollment-details"
+        />
+        <div>
+          <h5>Program Course Enrollments</h5>
+          <TableV2
+            columns={CourseColumns}
+            data={enrollment.program_course_enrollments.map(
+              (programCourseEnrollment) => ({
+                courseKey: (
+                  <Hyperlink
+                    destination={`${LMS_BASE_URL}${programCourseEnrollment.course_url}`}
+                  >
+                    {programCourseEnrollment.course_key}
+                  </Hyperlink>
+                ),
+                status: programCourseEnrollment.status,
+                created: programCourseEnrollment.created,
+                update: programCourseEnrollment.modified,
+                courseID: programCourseEnrollment.course_enrollment
+                  ? programCourseEnrollment.course_enrollment.course_id
+                  : 'N/A',
+                isActive:
+                  programCourseEnrollment.course_enrollment
+                  && programCourseEnrollment.course_enrollment.is_active
+                    ? 'True'
+                    : 'False',
+                mode: programCourseEnrollment.course_enrollment?.mode,
+              }),
+            )}
+            styleName="custom-table course-enrollment-details"
+          />
+        </div>
+      </div>
+    ))
+  ) : (
+    <></>
+  );
+}
+
+EnrollmentDetails.propTypes = {
+  enrollments: PropTypes.arrayOf(
+    PropTypes.shape({
+      created: PropTypes.string,
+      external_user_key: PropTypes.string,
+      modified: PropTypes.string,
+      program_course_enrollments: PropTypes.arrayOf(
+        PropTypes.shape({
+          course_key: PropTypes.string,
+          course_url: PropTypes.string,
+          created: PropTypes.string,
+          modified: PropTypes.string,
+          status: PropTypes.string,
+          course_enrollment: PropTypes.shape({
+            course_id: PropTypes.string,
+            is_active: PropTypes.bool,
+            mode: PropTypes.string,
+          }),
+        }),
+      ),
+    }),
+  ),
+};
+
+EnrollmentDetails.defaultProps = {
+  enrollments: null,
+};

--- a/src/ProgramEnrollments/ProgramInspector/EnrollmentDetails.test.jsx
+++ b/src/ProgramEnrollments/ProgramInspector/EnrollmentDetails.test.jsx
@@ -1,0 +1,105 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { waitForComponentToPaint } from '../../setupTest';
+import UserMessagesProvider from '../../userMessages/UserMessagesProvider';
+import EnrollmentDetails from './EnrollmentDetails';
+import { programInspectorSuccessResponse } from './data/test/programInspector';
+
+const EnrollmentDetailsWrapper = (props) => (
+  <MemoryRouter>
+    <UserMessagesProvider>
+      <EnrollmentDetails {...props} />
+    </UserMessagesProvider>
+  </MemoryRouter>
+);
+
+describe('Enrollment Details', () => {
+  let wrapper;
+  const data = programInspectorSuccessResponse.learner_program_enrollments.enrollments[0];
+
+  it('Enrollment Details render', async () => {
+    wrapper = mount(
+      <EnrollmentDetailsWrapper
+        enrollments={
+          programInspectorSuccessResponse.learner_program_enrollments.enrollments
+        }
+      />,
+    );
+    await waitForComponentToPaint(wrapper);
+
+    const heading = wrapper.find('.enrollments h3');
+    expect(heading.text()).toEqual(
+      `Program: ${data.program_name} (${data.program_uuid})`,
+    );
+  });
+
+  it.each([{ enrollment: null }, { enrollment: undefined }])(
+    'Enrollment Details do not render',
+    async ({ enrollment }) => {
+      wrapper = mount(<EnrollmentDetailsWrapper enrollments={enrollment} />);
+      await waitForComponentToPaint(wrapper);
+
+      const heading = wrapper.find('.enrollments h3');
+      expect(heading.exists()).toBeFalsy();
+    },
+  );
+
+  it('Enrollment details table render', async () => {
+    wrapper = mount(
+      <EnrollmentDetailsWrapper
+        enrollments={
+          programInspectorSuccessResponse.learner_program_enrollments.enrollments
+        }
+      />,
+    );
+    await waitForComponentToPaint(wrapper);
+
+    const row = wrapper.find('.enrollment-details tbody tr');
+    expect(row.find('td').at(0).text()).toEqual(data.status);
+    expect(row.find('td').at(1).text()).toEqual(data.created);
+    expect(row.find('td').at(2).text()).toEqual(data.modified);
+    expect(row.find('td').at(3).text()).toEqual(data.external_user_key);
+  });
+
+  it.each([
+    { audit: 'True', index: 0 },
+    { audit: 'False', index: 1 },
+  ])(
+    'Program course enrollments table render Audit',
+    async ({ audit, index }) => {
+      wrapper = mount(
+        <EnrollmentDetailsWrapper
+          enrollments={
+            programInspectorSuccessResponse.learner_program_enrollments.enrollments
+          }
+        />,
+      );
+      await waitForComponentToPaint(wrapper);
+      const programCourseEnrollments = data.program_course_enrollments[index];
+      expect(wrapper.find('.enrollments h5').text()).toEqual(
+        'Program Course Enrollments',
+      );
+      const row = wrapper.find('.course-enrollment-details tbody tr').at(index);
+      expect(row.find('td').at(0).find('a').text()).toEqual(
+        programCourseEnrollments.course_key,
+      );
+      expect(row.find('td').at(1).text()).toEqual(
+        programCourseEnrollments.status,
+      );
+      expect(row.find('td').at(2).text()).toEqual(
+        programCourseEnrollments.created,
+      );
+      expect(row.find('td').at(3).text()).toEqual(
+        programCourseEnrollments.modified,
+      );
+      expect(row.find('td').at(4).text()).toEqual(
+        programCourseEnrollments.course_enrollment.course_id,
+      );
+      expect(row.find('td').at(5).text()).toEqual(audit);
+      expect(row.find('td').at(6).text()).toEqual(
+        programCourseEnrollments.course_enrollment.mode,
+      );
+    },
+  );
+});

--- a/src/ProgramEnrollments/ProgramInspector/ProgramInspector.jsx
+++ b/src/ProgramEnrollments/ProgramInspector/ProgramInspector.jsx
@@ -1,0 +1,221 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Alert, Col, Row, Button, Input,
+} from '@edx/paragon';
+import { history } from '@edx/frontend-platform';
+import { getSsoRecords } from '../../users/data/api';
+import EnrollmentDetails from './EnrollmentDetails';
+import SingleSignOnRecordCard from '../../users/v2/SingleSignOnRecordCard';
+import {
+  getProgramEnrollmentsInspector,
+  getSAMLProviderList,
+} from './data/api';
+import VerifiedName from '../../users/v2/VerifiedName';
+
+export default function ProgramInspector({ location }) {
+  const params = new Map(
+    location.search
+      .slice(1) // removes '?' mark from start
+      .split('&')
+      .map((queryParams) => queryParams.split('=')),
+  );
+
+  const [ssoRecord, setSsoRecord] = useState(undefined);
+  const [error, setError] = useState(undefined);
+  const [learnerProgramEnrollment, setLearnerProgramEnrollment] = useState(undefined);
+  const [username, setUsername] = useState(params.get('edx_user'));
+  const [activeOrgKey, setActiveOrgKey] = useState(params.get('org_key'));
+  const [orgKeyList, setOrgKeyList] = useState(undefined);
+  const [externalUserKey, setExternalUserKey] = useState(params.get('external_user_key'));
+  const [clickEventCall, setClickEventCall] = useState(false);
+
+  const getOrgKeyList = () => (orgKeyList
+    ? orgKeyList.map((data) => ({
+      value: data,
+      label: data,
+    }))
+    : orgKeyList);
+
+  const handleSubmit = () => {
+    if (!username && !externalUserKey) {
+      setUsername(undefined);
+      setExternalUserKey(undefined);
+      setLearnerProgramEnrollment(undefined);
+      setSsoRecord(undefined);
+      history.push('/v2/programs');
+    } else {
+      const newLink = `/v2/programs?edx_user=${
+        username || ''
+      }&org_key=${activeOrgKey}&external_user_key=${externalUserKey || ''}`;
+      if (newLink === location.pathname + location.search) {
+        setClickEventCall(!clickEventCall);
+      } else {
+        history.push(newLink);
+      }
+    }
+  };
+
+  const submit = useCallback((event) => {
+    event.preventDefault();
+    handleSubmit();
+    return false;
+  });
+
+  const fetchInspectorData = (param) => {
+    if (param) {
+      getProgramEnrollmentsInspector({
+        param,
+      }).then((response) => {
+        setError(response.error);
+        setActiveOrgKey(response.org_keys);
+        setLearnerProgramEnrollment(response.learner_program_enrollments);
+      });
+    }
+  };
+
+  useEffect(() => {
+    fetchInspectorData(location.search);
+  }, [location.search, clickEventCall]);
+
+  useEffect(() => {
+    if (!orgKeyList) {
+      getSAMLProviderList().then((response) => {
+        setOrgKeyList(response);
+        if (response && response.length) {
+          setActiveOrgKey(response[0]);
+        }
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    setSsoRecord(null);
+    if (learnerProgramEnrollment && learnerProgramEnrollment.user) {
+      getSsoRecords(learnerProgramEnrollment.user.username).then((response) => {
+        response.map((data) => {
+          if (data.provider === activeOrgKey) {
+            setSsoRecord(data);
+          }
+          return data;
+        });
+      });
+    }
+  }, [learnerProgramEnrollment]);
+
+  return (
+    <>
+      {error && !Array.isArray(error) && (
+        <Alert variant="danger">{error}</Alert>
+      )}
+      <h3>Program Enrollments Inspector</h3>
+      <section className="my-3">
+        <form>
+          <div className="d-flex">
+            <div className="col-sm-4 pl-0">
+              <label htmlFor="username">edX username or email</label>
+              <Input
+                className="col-sm-12"
+                name="username"
+                type="text"
+                defaultValue={username}
+                onChange={(e) => (e.target.value
+                  ? setUsername(e.target.value)
+                  : setUsername(undefined))}
+                placeholder="edx@example.com"
+              />
+            </div>
+            <div className="col-sm-4">
+              <label htmlFor="orgKey">Identity-providing institution</label>
+              <Input
+                className="col-sm-12"
+                name="orgKey"
+                type="select"
+                defaultValue={activeOrgKey}
+                options={getOrgKeyList()}
+                onChange={(e) => setActiveOrgKey(e.target.value)}
+              />
+            </div>
+            <div className="col-sm-4 pr-0">
+              <label htmlFor="externalKey">Institution user key</label>
+              <Input
+                className="col-sm-12"
+                name="externalKey"
+                type="text"
+                defaultValue={externalUserKey}
+                onChange={(e) => (e.target.value
+                  ? setExternalUserKey(e.target.value)
+                  : setExternalUserKey(undefined))}
+                placeholder="ex. GTPersonDirectoryID for GT Students"
+              />
+            </div>
+          </div>
+          <Button type="submit" className="mt-4" onClick={submit}>
+            Search Program Records
+          </Button>
+        </form>
+      </section>
+
+      {learnerProgramEnrollment && learnerProgramEnrollment.user && (
+        <>
+          <div className="d-flex">
+            <div className="col-sm-6 my-3 pl-0 mr-1">
+              <Row className="inspector-name-row mx-1">
+                <Col>
+                  <p className="h5">Username</p>
+                </Col>
+                <Col>
+                  <p className="small mb-0">
+                    {learnerProgramEnrollment.user.username}
+                  </p>
+                </Col>
+              </Row>
+              <Row className="mt-2 inspector-name-row  mx-1">
+                <Col>
+                  <p className="h5">Email</p>
+                </Col>
+                <Col>
+                  <p className="small mb-0">
+                    {learnerProgramEnrollment.user.email}
+                  </p>
+                </Col>
+              </Row>
+              {learnerProgramEnrollment && learnerProgramEnrollment.user && (
+                <div className="pt-3">
+                  <VerifiedName
+                    username={learnerProgramEnrollment.user.username}
+                  />
+                </div>
+              )}
+            </div>
+            {ssoRecord ? (
+              <div className="col-sm-6 ml-1">
+                <h4>SSO Records</h4>
+                <SingleSignOnRecordCard ssoRecord={ssoRecord} />
+              </div>
+            ) : (
+              <div className="col-sm-6 ml-1">
+                <Alert variant="danger">SSO Record Not Found</Alert>
+              </div>
+            )}
+          </div>
+          <div className="mt-2">
+            {learnerProgramEnrollment
+              && learnerProgramEnrollment.enrollments && (
+                <EnrollmentDetails
+                  enrollments={learnerProgramEnrollment.enrollments}
+                />
+            )}
+          </div>
+        </>
+      )}
+    </>
+  );
+}
+
+ProgramInspector.propTypes = {
+  location: PropTypes.shape({
+    pathname: PropTypes.string,
+    search: PropTypes.string,
+  }).isRequired,
+};

--- a/src/ProgramEnrollments/ProgramInspector/ProgramInspector.test.jsx
+++ b/src/ProgramEnrollments/ProgramInspector/ProgramInspector.test.jsx
@@ -1,0 +1,147 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { history } from '@edx/frontend-platform';
+import { waitForComponentToPaint } from '../../setupTest';
+import UserMessagesProvider from '../../userMessages/UserMessagesProvider';
+import * as api from './data/api';
+import ProgramInspector from './ProgramInspector';
+import {
+  programInspectorSuccessResponse,
+  programInspectorErrorResponse,
+} from './data/test/programInspector';
+import ssoRecordsData from '../../users/data/test/ssoRecords';
+import * as ssoApi from '../../users/data/api';
+import samlProvidersResponseValues from './data/test/samlProviders';
+import verifiedNameHistory from '../../users/data/test/verifiedNameHistory';
+
+const ProgramEnrollmentsWrapper = (props) => (
+  <MemoryRouter>
+    <UserMessagesProvider>
+      <ProgramInspector {...props} />
+    </UserMessagesProvider>
+  </MemoryRouter>
+);
+
+describe('Program Inspector', () => {
+  let wrapper;
+  let location;
+  let apiMock;
+  let samlMock;
+  let ssoMock;
+  let verifiedNameMock;
+
+  const data = {
+    username: 'verified',
+    orgKey: samlProvidersResponseValues[0],
+    externalKey: 'testuser',
+  };
+
+  beforeEach(() => {
+    location = {
+      pathname: '/v2/programs',
+      search: '?edx_user=&org_key=&external_user_key=',
+    };
+    ssoMock = jest
+      .spyOn(ssoApi, 'getSsoRecords')
+      .mockImplementationOnce(() => Promise.resolve(ssoRecordsData));
+    samlMock = jest
+      .spyOn(api, 'getSAMLProviderList')
+      .mockImplementationOnce(() => Promise.resolve(samlProvidersResponseValues));
+    verifiedNameMock = jest
+      .spyOn(ssoApi, 'getVerifiedNameHistory')
+      .mockImplementationOnce(() => Promise.resolve(verifiedNameHistory));
+  });
+
+  afterEach(() => {
+    if (apiMock) {
+      apiMock.mockReset();
+    }
+    samlMock.mockReset();
+    ssoMock.mockReset();
+    verifiedNameMock.mockReset();
+  });
+
+  it('default render', async () => {
+    wrapper = mount(<ProgramEnrollmentsWrapper location={location} />);
+    apiMock = jest
+      .spyOn(api, 'getProgramEnrollmentsInspector')
+      .mockImplementationOnce(() => Promise.resolve(programInspectorErrorResponse));
+
+    await waitForComponentToPaint(wrapper);
+
+    const usernameInput = wrapper.find("input[name='username']");
+    const externalKeyInput = wrapper.find("input[name='externalKey']");
+    expect(usernameInput.prop('defaultValue')).toEqual('');
+    expect(externalKeyInput.prop('defaultValue')).toEqual('');
+  });
+
+  it('render when username', async () => {
+    history.push = jest.fn();
+    apiMock = jest
+      .spyOn(api, 'getProgramEnrollmentsInspector')
+      .mockImplementationOnce(() => Promise.resolve(programInspectorSuccessResponse));
+    wrapper = mount(<ProgramEnrollmentsWrapper location={location} />);
+
+    await waitForComponentToPaint(wrapper);
+
+    wrapper.find("input[name='username']").simulate('change',
+      { target: { value: data.username } });
+    wrapper.find("select[name='orgKey']").simulate('change',
+      { target: { value: data.orgKey } });
+    wrapper.find('button.btn-primary').simulate('click');
+
+    expect(history.push).toHaveBeenCalledWith(
+      `/v2/programs?edx_user=${data.username}&org_key=${data.orgKey}&external_user_key=`,
+    );
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find('.inspector-name-row p.h5').at(0).text()).toEqual(
+      'Username',
+    );
+    expect(wrapper.find('.inspector-name-row p.small').at(0).text()).toEqual(
+      programInspectorSuccessResponse.learner_program_enrollments.user.username,
+    );
+    expect(wrapper.find('.inspector-name-row p.h5').at(1).text()).toEqual(
+      'Email',
+    );
+    expect(wrapper.find('.inspector-name-row p.small').at(1).text()).toEqual(
+      programInspectorSuccessResponse.learner_program_enrollments.user.email,
+    );
+    history.push.mockReset();
+  });
+
+  it('render when external_user_key', async () => {
+    history.push = jest.fn();
+    apiMock = jest
+      .spyOn(api, 'getProgramEnrollmentsInspector')
+      .mockImplementationOnce(() => Promise.resolve(programInspectorSuccessResponse));
+    wrapper = mount(<ProgramEnrollmentsWrapper location={location} />);
+
+    await waitForComponentToPaint(wrapper);
+
+    wrapper.find("input[name='externalKey']").simulate('change',
+      { target: { value: data.externalKey } });
+    wrapper.find("select[name='orgKey']").simulate('change',
+      { target: { value: data.orgKey } });
+    wrapper.find('button.btn-primary').simulate('click');
+
+    expect(history.push).toHaveBeenCalledWith(
+      `/v2/programs?edx_user=&org_key=${data.orgKey}&external_user_key=${data.externalKey}`,
+    );
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find('.inspector-name-row p.h5').at(0).text()).toEqual(
+      'Username',
+    );
+    expect(wrapper.find('.inspector-name-row p.small').at(0).text()).toEqual(
+      programInspectorSuccessResponse.learner_program_enrollments.user.username,
+    );
+    expect(wrapper.find('.inspector-name-row p.h5').at(1).text()).toEqual(
+      'Email',
+    );
+    expect(wrapper.find('.inspector-name-row p.small').at(1).text()).toEqual(
+      programInspectorSuccessResponse.learner_program_enrollments.user.email,
+    );
+
+    history.push.mockReset();
+  });
+});

--- a/src/ProgramEnrollments/ProgramInspector/data/api.js
+++ b/src/ProgramEnrollments/ProgramInspector/data/api.js
@@ -1,0 +1,44 @@
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { getConfig } from '@edx/frontend-platform';
+
+const { LMS_BASE_URL } = getConfig();
+
+export async function getProgramEnrollmentsInspector({ params }) {
+  const apiUrl = `${LMS_BASE_URL}/support/program_enrollments_inspector_details${params}`;
+  try {
+    const { data } = await getAuthenticatedHttpClient().get(apiUrl);
+    return data;
+  } catch (error) {
+    return {
+      error: [
+        {
+          code: null,
+          dismissible: true,
+          text: 'Unexpected error while fetching Program Inspector Data',
+          type: 'error',
+          topic: 'programInspectorData',
+        },
+      ],
+    };
+  }
+}
+
+export async function getSAMLProviderList() {
+  const apiUrl = `${LMS_BASE_URL}/support/get_saml_providers/`;
+  try {
+    const { data } = await getAuthenticatedHttpClient().get(apiUrl);
+    return data;
+  } catch (error) {
+    return {
+      error: [
+        {
+          code: null,
+          dismissible: true,
+          text: 'Unexpected error while fetching SAML Providers',
+          type: 'error',
+          topic: 'programInspectorSAMLProviders',
+        },
+      ],
+    };
+  }
+}

--- a/src/ProgramEnrollments/ProgramInspector/data/api.test.js
+++ b/src/ProgramEnrollments/ProgramInspector/data/api.test.js
@@ -1,0 +1,125 @@
+import MockAdapter from 'axios-mock-adapter';
+import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { programInspectorSuccessResponse } from './test/programInspector';
+import * as api from './api';
+import samlProvidersResponseValues from './test/samlProviders';
+
+describe('Program Inspector API', () => {
+  let mockAdapter;
+
+  const params = {
+    org_key: 'testX',
+    external_user_key: 'testuser',
+    edx_user: 'verified',
+  };
+
+  const programInspectorApiUrl = `${getConfig().LMS_BASE_URL
+  }/support/program_enrollments_inspector_details?`
+    + `edx_user=${params.edx_user}&org_key=${params.org_key}&external_user_key=${params.external_user_key}`;
+
+  const throwError = (errorCode, dataString) => {
+    const error = new Error();
+    error.customAttributes = {
+      httpErrorStatus: errorCode,
+      httpErrorResponseData: JSON.stringify(dataString),
+    };
+    throw error;
+  };
+
+  beforeEach(() => {
+    mockAdapter = new MockAdapter(getAuthenticatedHttpClient(), {
+      onNoMatch: 'throwException',
+    });
+  });
+
+  afterEach(() => {
+    mockAdapter.reset();
+  });
+
+  it('Successful api fetch', async () => {
+    mockAdapter
+      .onGet(programInspectorApiUrl)
+      .reply(200, programInspectorSuccessResponse);
+
+    const response = await api.getProgramEnrollmentsInspector({
+      params: `?edx_user=${params.edx_user}&org_key=${params.org_key}&external_user_key=${params.external_user_key}`,
+    });
+    expect(response).toEqual(programInspectorSuccessResponse);
+  });
+
+  it('Unsuccessful api fetch', async () => {
+    const expectedErrors = [
+      {
+        code: null,
+        dismissible: true,
+        text: 'Unexpected error while fetching Program Inspector Data',
+        type: 'error',
+        topic: 'programInspectorData',
+      },
+    ];
+
+    mockAdapter
+      .onGet(programInspectorApiUrl)
+      .reply(() => throwError(500, 'Server Error'));
+
+    const response = await api.getProgramEnrollmentsInspector({
+      params: `?edx_user=${params.edx_user}&org_key=${params.org_key}&external_user_key=${params.external_user_key}`,
+    });
+    expect(response.error).toEqual(expectedErrors);
+  });
+});
+
+describe('Get SAML Providers API', () => {
+  let mockAdapter;
+
+  const samlProvidersApiUrl = `${getConfig().LMS_BASE_URL
+  }/support/get_saml_providers/`;
+
+  const throwError = (errorCode, dataString) => {
+    const error = new Error();
+    error.customAttributes = {
+      httpErrorStatus: errorCode,
+      httpErrorResponseData: JSON.stringify(dataString),
+    };
+    throw error;
+  };
+
+  beforeEach(() => {
+    mockAdapter = new MockAdapter(getAuthenticatedHttpClient(), {
+      onNoMatch: 'throwException',
+    });
+  });
+
+  afterEach(() => {
+    mockAdapter.reset();
+  });
+
+  it('Successful api fetch', async () => {
+    mockAdapter
+      .onGet(samlProvidersApiUrl)
+      .reply(200, samlProvidersResponseValues);
+
+    const response = await api.getSAMLProviderList();
+    expect(response).toEqual(samlProvidersResponseValues);
+  });
+
+  it('Unsuccessful api fetch', async () => {
+    const expectedErrors = [
+      {
+        code: null,
+        dismissible: true,
+        text: 'Unexpected error while fetching SAML Providers',
+        type: 'error',
+        topic: 'programInspectorSAMLProviders',
+      },
+    ];
+
+    mockAdapter
+      .onGet(samlProvidersApiUrl)
+      .reply(() => throwError(500, 'Server Error'));
+
+    const response = await api.getSAMLProviderList();
+    expect(response.error).toEqual(expectedErrors);
+  });
+});

--- a/src/ProgramEnrollments/ProgramInspector/data/test/programInspector.js
+++ b/src/ProgramEnrollments/ProgramInspector/data/test/programInspector.js
@@ -1,0 +1,59 @@
+export const programInspectorSuccessResponse = {
+  error: '',
+  learner_program_enrollments: {
+    enrollments: [
+      {
+        created: '2022-01-27T03:54:31',
+        modified: '2022-01-27T03:54:31',
+        external_user_key: 'testuser',
+        status: 'enrolled',
+        program_uuid: 'c72af4c6-7e40-40ff-8580-c8b31107883e',
+        program_name: 'edX Demonstration Program',
+        program_course_enrollments: [
+          {
+            course_key: 'course-v1:edX+DemoX+Demo_Course',
+            course_url: '/courses/course-v1:edX+DemoX+Demo_Course/course/',
+            created: '2022-01-27T03:59:45',
+            modified: '2022-01-27T03:59:45',
+            status: 'active',
+            course_enrollment: {
+              course_id: 'course-v1:edX+DemoX+Demo_Course',
+              is_active: true,
+              mode: 'audit',
+            },
+          },
+          {
+            course_key: 'course-v1:edX+DemoX+Demo_Course',
+            course_url: '/courses/course-v1:edX+DemoX+Demo_Course/course/',
+            created: '2022-01-27T03:59:45',
+            modified: '2022-01-27T03:59:45',
+            status: 'active',
+            course_enrollment: {
+              course_id: 'course-v1:edX+DemoX+Demo_Course',
+              is_active: false,
+              mode: 'audit',
+            },
+          },
+        ],
+      },
+    ],
+    id_verification: {
+      error: '',
+      should_display: false,
+      status: 'approved',
+      status_date: '2022-01-27T04:30:14.273438Z',
+      verification_expiry: '',
+    },
+    user: {
+      email: 'verified@example.com',
+      username: 'verified',
+    },
+  },
+  org_keys: 'testX',
+};
+
+export const programInspectorErrorResponse = {
+  error: 'Could not find edx account with wrongAccount',
+  learner_program_enrollments: {},
+  org_keys: 'testX',
+};

--- a/src/ProgramEnrollments/ProgramInspector/data/test/samlProviders.js
+++ b/src/ProgramEnrollments/ProgramInspector/data/test/samlProviders.js
@@ -1,0 +1,2 @@
+const samlProvidersResponseValues = ['testX', 'donut_org', 'tri_org'];
+export default samlProvidersResponseValues;

--- a/src/ProgramEnrollments/ProgramInspector/utils/constants.js
+++ b/src/ProgramEnrollments/ProgramInspector/utils/constants.js
@@ -1,0 +1,49 @@
+export const CourseColumns = [
+  {
+    Header: 'Course Key',
+    accessor: 'courseKey',
+  },
+  {
+    Header: 'Status',
+    accessor: 'status',
+  },
+  {
+    Header: 'Created At',
+    accessor: 'created',
+  },
+  {
+    Header: 'Last Update',
+    accessor: 'update',
+  },
+  {
+    Header: 'Couse ID',
+    accessor: 'courseID',
+  },
+  {
+    Header: 'Is Active',
+    accessor: 'isActive',
+  },
+  {
+    Header: 'Mode/Track',
+    accessor: 'mode',
+  },
+];
+
+export const EnrollmentColumns = [
+  {
+    Header: 'Status',
+    accessor: 'status',
+  },
+  {
+    Header: 'Created At',
+    accessor: 'createdAt',
+  },
+  {
+    Header: 'Last Update',
+    accessor: 'lastUpdate',
+  },
+  {
+    Header: 'External User key',
+    accessor: 'externalUserKey',
+  },
+];

--- a/src/ProgramEnrollments/data/api.test.js
+++ b/src/ProgramEnrollments/data/api.test.js
@@ -11,8 +11,7 @@ describe('Link Program Enrollments API', () => {
     programID: '8bee627e-d85e-4a76-be41-d58921da666e',
     usernamePairText: 'testuser,verified',
   };
-  const lpeDetailsApiUrl = `${
-    getConfig().LMS_BASE_URL
+  const lpeDetailsApiUrl = `${getConfig().LMS_BASE_URL
   }/support/link_program_enrollments_details/`;
 
   const throwError = (errorCode, dataString) => {

--- a/src/SupportToolsTab/SupportToolsTab.jsx
+++ b/src/SupportToolsTab/SupportToolsTab.jsx
@@ -64,7 +64,7 @@ export default function SupportToolsTab({ location }) {
             <br />
             <FeatureBasedEnrollmentIndexPage location={location} />
           </Tab>
-          <Tab eventKey={PROGRAM_ENROLLMENT_TAB} title="Program Enrollments">
+          <Tab eventKey={PROGRAM_ENROLLMENT_TAB} title="Program Information">
             <br />
             <ProgramEnrollmentsIndexPage location={location} />
           </Tab>

--- a/src/SupportToolsTab/SupportToolsTab.test.jsx
+++ b/src/SupportToolsTab/SupportToolsTab.test.jsx
@@ -31,11 +31,11 @@ describe('Support Tools Main tab', () => {
   it('default page render', () => {
     wrapper = mount(<SupportToolsTabWrapper location={location} />);
 
-    const tabs = wrapper.find('nav.nav-tabs a');
+    const tabs = wrapper.find('nav.support-tools-tab.nav-tabs a');
     expect(tabs.length).toEqual(3);
     expect(tabs.at(0).text()).toEqual('Learner Information');
     expect(tabs.at(1).text()).toEqual('Feature Based Enrollment');
-    expect(tabs.at(2).text()).toEqual('Program Enrollments');
+    expect(tabs.at(2).text()).toEqual('Program Information');
 
     expect(wrapper.find('h2').text()).toEqual('Support Tools');
     expect(wrapper.find('p').text()).toEqual(
@@ -50,7 +50,7 @@ describe('Support Tools Main tab', () => {
     let tabs = wrapper.find('nav.nav-tabs a');
 
     tabs.at(1).simulate('click');
-    tabs = wrapper.find('nav.nav-tabs a');
+    tabs = wrapper.find('nav.support-tools-tab.nav-tabs a');
     const fbeTab = wrapper.find('div.tab-content div#support-tools-tab-tabpane-feature-based-enrollment');
     expect(history.replace).toHaveBeenCalledWith(TAB_PATH_MAP['feature-based-enrollment']);
     expect(tabs.at(0).html()).not.toEqual(expect.stringContaining('active'));
@@ -60,7 +60,7 @@ describe('Support Tools Main tab', () => {
     expect(fbeTab.find('label').text()).toEqual('Course ID');
 
     tabs.at(0).simulate('click');
-    tabs = wrapper.find('nav.nav-tabs a');
+    tabs = wrapper.find('nav.support-tools-tab.nav-tabs a');
     const learnerTab = wrapper.find('div.tab-content div#support-tools-tab-tabpane-learner-information');
     expect(history.replace).toHaveBeenCalledWith(TAB_PATH_MAP['learner-information']);
     expect(tabs.at(0).html()).toEqual(expect.stringContaining('active'));
@@ -70,8 +70,8 @@ describe('Support Tools Main tab', () => {
     expect(learnerTab.find('label').text()).toEqual('Username, Email or LMS User ID');
 
     tabs.at(2).simulate('click');
-    tabs = wrapper.find('nav.nav-tabs a');
-    expect(history.replace).toHaveBeenCalledWith(TAB_PATH_MAP['program-enrollment']);
+    tabs = wrapper.find('nav.support-tools-tab.nav-tabs a');
+    expect(history.replace).toHaveBeenCalledWith(TAB_PATH_MAP.programs);
     expect(tabs.at(0).html()).not.toEqual(expect.stringContaining('active'));
     expect(tabs.at(1).html()).not.toEqual(expect.stringContaining('active'));
     expect(tabs.at(2).html()).toEqual(expect.stringContaining('active'));
@@ -83,7 +83,7 @@ describe('Support Tools Main tab', () => {
     location = { pathname: TAB_PATH_MAP['feature-based-enrollment'], search: '' };
 
     wrapper = mount(<SupportToolsTabWrapper location={location} />);
-    const tabs = wrapper.find('nav.nav-tabs a');
+    const tabs = wrapper.find('nav.support-tools-tab.nav-tabs a');
 
     expect(tabs.at(0).html()).not.toEqual(expect.stringContaining('active'));
     expect(tabs.at(1).html()).toEqual(expect.stringContaining('active'));
@@ -94,18 +94,18 @@ describe('Support Tools Main tab', () => {
     location = { pathname: TAB_PATH_MAP['learner-information'], search: '' };
 
     wrapper = mount(<SupportToolsTabWrapper location={location} />);
-    const tabs = wrapper.find('nav.nav-tabs a');
+    const tabs = wrapper.find('nav.support-tools-tab.nav-tabs a');
 
     expect(tabs.at(0).html()).toEqual(expect.stringContaining('active'));
     expect(tabs.at(1).html()).not.toEqual(expect.stringContaining('active'));
     expect(tabs.at(2).html()).not.toEqual(expect.stringContaining('active'));
   });
 
-  it('default tab changes based on program-enrollment pathname', () => {
-    location = { pathname: TAB_PATH_MAP['program-enrollment'], search: '' };
+  it('default tab changes based on programs pathname', () => {
+    location = { pathname: TAB_PATH_MAP.programs, search: '' };
 
     wrapper = mount(<SupportToolsTabWrapper location={location} />);
-    const tabs = wrapper.find('nav.nav-tabs a');
+    const tabs = wrapper.find('nav.support-tools-tab.nav-tabs a');
 
     expect(tabs.at(0).html()).not.toEqual(expect.stringContaining('active'));
     expect(tabs.at(1).html()).not.toEqual(expect.stringContaining('active'));

--- a/src/SupportToolsTab/constants.js
+++ b/src/SupportToolsTab/constants.js
@@ -1,9 +1,9 @@
 export const LEARNER_INFO_TAB = 'learner-information';
 export const FEATURE_BASED_ENROLLMENT_TAB = 'feature-based-enrollment';
-export const PROGRAM_ENROLLMENT_TAB = 'program-enrollment';
+export const PROGRAM_ENROLLMENT_TAB = 'programs';
 
 export const TAB_PATH_MAP = {
   [LEARNER_INFO_TAB]: '/v2/learner_information',
   [FEATURE_BASED_ENROLLMENT_TAB]: '/v2/feature_based_enrollments',
-  [PROGRAM_ENROLLMENT_TAB]: '/v2/program_enrollment',
+  [PROGRAM_ENROLLMENT_TAB]: '/v2/programs',
 };

--- a/src/overrides.scss
+++ b/src/overrides.scss
@@ -154,13 +154,6 @@ $darkCyan: #00262b;
   }
 }
 
-.link-program-enrollments {
-  border: none;
-  border-radius: 0;
-  border-right: 1px solid lightgray;
-  padding-left: 0;
-}
-
 .background-light-gray {
   background: lightgrey;
 }
@@ -173,4 +166,8 @@ $darkCyan: #00262b;
   font-size: 15px;
   padding-top: 15px;
   padding-bottom: 15px;
+}
+
+.inspector-name-row{
+  border-bottom: 1px solid black;
 }


### PR DESCRIPTION
This is a feature update for Program inspector tools to MFEs. This is the front to a backend in the edx-platform.

Ticket LInk: [PROG-2479](https://openedx.atlassian.net/browse/PROD-2479?atlOrigin=eyJpIjoiNzZmMWFlOTY0ZDMzNGNkY2IzOWI3ODFlZmQwYjZlNjgiLCJwIjoiaiJ9)

Testing instructions:
Follow the instructions on [backend PR](https://github.com/openedx/edx-platform/pull/29732)

How it's looking: 
<img width="1680" alt="Screenshot 2022-02-07 at 2 59 01 AM" src="https://user-images.githubusercontent.com/56605828/152703121-50a08415-7bde-47ef-98c2-5ad5519de0c0.png">
<img width="1680" alt="Screenshot 2022-02-07 at 2 58 50 AM" src="https://user-images.githubusercontent.com/56605828/152703126-bf59fd61-2137-47d8-928f-c12a76b5ba24.png">

The backend has currently following issues, which are being worked on: 
- It does not search for username, SSO and verified user name for an external user key.