### PR TITLE
fix: fix zero showing when enterprise course enrollments length is 0

### DIFF
--- a/src/users/enrollments/v2/Enrollments.jsx
+++ b/src/users/enrollments/v2/Enrollments.jsx
@@ -240,7 +240,7 @@ export default function Enrollments({
           columns={extraColumns}
           styleName="custom-expander-table"
         />
-        {row.original.enterpriseCourseEnrollments?.length && (
+        {row.original.enterpriseCourseEnrollments?.length > 0 && (
           <>
             <hr />
             <div className="custom-expander-table">


### PR DESCRIPTION
Fixes the issue shown below.

![image](https://user-images.githubusercontent.com/17792243/151189671-a05986c3-84d0-49ec-aeea-c9a24c5abab1.png)
