### PR TITLE
feat: Display verified-in and current-status data on onboarding status

### DIFF
--- a/src/overrides.scss
+++ b/src/overrides.scss
@@ -168,3 +168,10 @@ $darkCyan: #00262b;
 .mb-60 {
   margin-bottom: 60px;
 }
+
+.no-record-text {
+  text-align: center;
+  font-size: 15px;
+  padding-top: 15px;
+  padding-bottom: 15px;
+}

--- a/src/overrides.scss
+++ b/src/overrides.scss
@@ -170,7 +170,6 @@ $darkCyan: #00262b;
 }
 
 .no-record-text {
-  text-align: center;
   font-size: 15px;
   padding-top: 15px;
   padding-bottom: 15px;

--- a/src/users/OnboardingStatus.test.jsx
+++ b/src/users/OnboardingStatus.test.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { waitForComponentToPaint } from '../setupTest';
 import OnboardingStatus from './OnboardingStatus';
 import UserMessagesProvider from '../userMessages/UserMessagesProvider';
-import onboardingStatusData from './data/test/onboardingStatus';
+import { onboardingStatusData } from './data/test/onboardingStatus';
 import enrollmentsData from './data/test/enrollments';
 import { titleCase, formatDate } from '../utils';
 

--- a/src/users/data/api.js
+++ b/src/users/data/api.js
@@ -365,7 +365,18 @@ export async function getV2OnboardingStatus(username) {
     );
     return data;
   } catch (error) {
-    return defaultResponse;
+    let errorText = 'Error while fetching data';
+
+    try {
+      if (error.customAttributes?.httpErrorResponseData) {
+        errorText = JSON.parse(error.customAttributes.httpErrorResponseData);
+      }
+    } catch (e) {
+      // In case there is something wrong with the response, use the default
+      // error message
+    }
+
+    return { ...defaultResponse, error: errorText };
   }
 }
 

--- a/src/users/data/api.js
+++ b/src/users/data/api.js
@@ -354,6 +354,21 @@ export async function getOnboardingStatus(enrollments, username) {
   }
 }
 
+export async function getV2OnboardingStatus(username) {
+  const defaultResponse = {
+    verified_in: null,
+    current_status: null,
+  };
+  try {
+    const { data } = await getAuthenticatedHttpClient().get(
+      AppUrls.getV2OnboardingStatusUrl(username),
+    );
+    return data;
+  } catch (error) {
+    return defaultResponse;
+  }
+}
+
 export async function getAllUserData(userIdentifier) {
   const errors = [];
   let user = null;

--- a/src/users/data/api.test.js
+++ b/src/users/data/api.test.js
@@ -5,6 +5,7 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { enrollmentsData } from './test/enrollments';
 import { downloadableCertificate } from './test/certificates';
 import verifiedNameHistoryData from './test/verifiedNameHistory';
+import { v2OnboardingStatusData } from './test/onboardingStatus';
 import * as api from './api';
 import * as urls from './urls';
 
@@ -103,6 +104,26 @@ describe('API', () => {
     it('Unexpected error fetching enrollments', async () => {
       const response = await api.getOnboardingStatus(enrollmentErrors, testUsername);
       expect(response).toEqual({ ...expectedSuccessResponse, onboardingStatus: 'Error while fetching data' });
+    });
+  });
+
+  describe('V2 Onboarding Status Fetch', () => {
+    const expectedSuccessResponse = v2OnboardingStatusData;
+    const url = urls.getV2OnboardingStatusUrl(testUsername);
+    it('Successful Fetch ', async () => {
+      mockAdapter.onGet(url).reply(200, expectedSuccessResponse);
+
+      const response = await api.getV2OnboardingStatus(testUsername);
+      expect(response).toEqual(expectedSuccessResponse);
+    });
+
+    it('No Active Paid Enrollment ', async () => {
+      const defaultResponse = {
+        verified_in: null,
+        current_status: null,
+      };
+      const response = await api.getV2OnboardingStatus(testUsername);
+      expect(response).toEqual(defaultResponse);
     });
   });
 

--- a/src/users/data/api.test.js
+++ b/src/users/data/api.test.js
@@ -118,10 +118,23 @@ describe('API', () => {
     });
 
     it('No Active Paid Enrollment ', async () => {
+      mockAdapter.onGet(url).reply(() => throwError(404, 'Missing Records'));
       const defaultResponse = {
         verified_in: null,
         current_status: null,
+        error: 'Missing Records',
       };
+      const response = await api.getV2OnboardingStatus(testUsername);
+      expect(response).toEqual(defaultResponse);
+    });
+
+    it('returns a server error with default message', async () => {
+      const defaultResponse = {
+        verified_in: null,
+        current_status: null,
+        error: 'Error while fetching data',
+      };
+      mockAdapter.onGet(url).reply(() => throwError(500));
       const response = await api.getV2OnboardingStatus(testUsername);
       expect(response).toEqual(defaultResponse);
     });

--- a/src/users/data/test/onboardingStatus.js
+++ b/src/users/data/test/onboardingStatus.js
@@ -7,4 +7,29 @@ const onboardingStatusData = {
   reviewRequirementsUrl: null,
 };
 
-export default onboardingStatusData;
+const v2OnboardingStatusData = {
+  verifiedIn: {
+    onboardingStatus: 'verified',
+    onboardingLink: '/courses/course-v1:test-course/jump_to/block-v1:test-course+type@sequential+block@12345678',
+    expirationDate: '2022-09-07T23:59:59+00:00',
+    onboardingPastDue: false,
+    onboardingReleaseDate: '2020-09-03T20:00:00+00:00',
+    reviewRequirementsUrl: 'https://support.edx.org/hc/en-us/sections/12345678-Proctortrack',
+    courseId: 'course-v1:test-course',
+    enrollmentDate: '2020-07-03T08:57:50Z',
+    instructorDashboardLink: '/courses/course-v1:test-course/instructor#view-special_exams',
+  },
+  currentStatus: {
+    onboardingStatus: 'verified',
+    onboardingLink: '/courses/course-v1:test-course/jump_to/block-v1:test-course+type@sequential+block@12345678',
+    expirationDate: '2022-09-07T23:59:59+00:00',
+    onboardingPastDue: false,
+    onboardingReleaseDate: '2020-09-03T20:00:00+00:00',
+    reviewRequirementsUrl: 'https://support.edx.org/hc/en-us/sections/12345678-Proctortrack',
+    courseId: 'course-v1:test-course',
+    enrollmentDate: '2020-07-03T08:57:50Z',
+    instructorDashboardLink: '/courses/course-v1:test-course/instructor#view-special_exams',
+  },
+};
+
+export { onboardingStatusData, v2OnboardingStatusData };

--- a/src/users/data/urls.js
+++ b/src/users/data/urls.js
@@ -83,6 +83,10 @@ export const getOnboardingStatusUrl = (courseId, username) => `${
   LMS_BASE_URL
 }/api/edx_proctoring/v1/user_onboarding/status?course_id=${encodeURIComponent(courseId)}&username=${encodeURIComponent(username)}`;
 
+export const getV2OnboardingStatusUrl = (username) => `${
+  LMS_BASE_URL
+}/support/onboarding_status/${encodeURIComponent(username)}`;
+
 export const getCertificateUrl = (username, courseKey) => `${
   LMS_BASE_URL
 }/certificates/search?user=${username}&course_id=${courseKey}`;

--- a/src/users/entitlements/v2/Entitlements.test.jsx
+++ b/src/users/entitlements/v2/Entitlements.test.jsx
@@ -29,7 +29,7 @@ describe('Entitlements V2 Listing', () => {
   });
 
   afterEach(() => {
-    apiMock.mockRestore();
+    apiMock.mockReset();
     wrapper.unmount();
   });
 
@@ -109,20 +109,22 @@ describe('Entitlements V2 Listing', () => {
   });
 
   describe('Expire Entitlement button', () => {
-    it('Disabled Expire entitlement button', () => {
+    it('Disabled Expire entitlement button', async () => {
       // We're only checking row 0 of the table since it has the button Expire Button disabled
       let dataRow = wrapper.find('table tbody tr').at(0);
       dataRow.find('.dropdown button').simulate('click');
+      await waitForComponentToPaint(wrapper);
       dataRow = wrapper.find('table tbody tr').at(0);
       const expireOption = dataRow.find('.dropdown-menu.show a').at(1);
       expect(expireOption.text()).toEqual('Expire');
       expect(expireOption.html()).toEqual(expect.stringContaining('disabled'));
     });
 
-    it('Enabled Expire entitlement button', () => {
+    it('Enabled Expire entitlement button', async () => {
       // We're only checking row 1 of the table since the expire button is not disabled
       let dataRow = wrapper.find('table tbody tr').at(1);
       dataRow.find('.dropdown button').simulate('click');
+      await waitForComponentToPaint(wrapper);
       dataRow = wrapper.find('table tbody tr').at(1);
       const expireOption = dataRow.find('.dropdown-menu.show a').at(1);
       expect(expireOption.text()).toEqual('Expire');
@@ -143,6 +145,7 @@ describe('Entitlements V2 Listing', () => {
       // We're only checking row 0 of the table since the Reissue button is not disabled
       let dataRow = wrapper.find('table tbody tr').at(0);
       dataRow.find('.dropdown button').simulate('click');
+      await waitForComponentToPaint(wrapper);
       dataRow = wrapper.find('table tbody tr').at(0);
       const expireOption = dataRow.find('.dropdown-menu.show a').at(0);
       expect(expireOption.text()).toEqual('Reissue');
@@ -157,10 +160,11 @@ describe('Entitlements V2 Listing', () => {
       expect(reissueFormModal.prop('open')).toEqual(false);
     });
 
-    it('Disabled Reissue entitlement button', () => {
+    it('Disabled Reissue entitlement button', async () => {
       // We're only checking row 1 of the table since it has the button Reissue Button disabled
       let dataRow = wrapper.find('table tbody tr').at(1);
       dataRow.find('.dropdown button').simulate('click');
+      await waitForComponentToPaint(wrapper);
       dataRow = wrapper.find('table tbody tr').at(1);
       const expireOption = dataRow.find('.dropdown-menu.show a').at(0);
       expect(expireOption.text()).toEqual('Reissue');
@@ -185,7 +189,6 @@ describe('Entitlements V2 Listing', () => {
       courseSummary.find('button.btn-link').simulate('click');
       courseSummary = wrapper.find('CourseSummary');
       expect(courseSummary).toEqual({});
-      apiMock.mockReset();
     });
 
     it('Unsuccessful course summary fetch', async () => {
@@ -210,7 +213,6 @@ describe('Entitlements V2 Listing', () => {
 
       const alert = wrapper.find('CourseSummary').find('.alert');
       expect(alert.text()).toEqual("We couldn't find summary data for this Course.");
-      apiMock.mockReset();
     });
   });
 });

--- a/src/users/v2/OnboardingStatus.jsx
+++ b/src/users/v2/OnboardingStatus.jsx
@@ -3,7 +3,7 @@ import { camelCaseObject, getConfig } from '@edx/frontend-platform';
 import PropTypes from 'prop-types';
 import TableV2 from '../../components/Table';
 import { formatDate, titleCase } from '../../utils';
-import { getOnboardingStatus, getEnrollments } from '../data/api';
+import { getV2OnboardingStatus } from '../data/api';
 import PageLoading from '../../components/common/PageLoading';
 
 export default function OnboardingStatus({
@@ -12,15 +12,17 @@ export default function OnboardingStatus({
   const [onboardingData, setOnboardingData] = useState(null);
 
   useEffect(() => {
-    getEnrollments(username).then((enrollments) => {
-      getOnboardingStatus(enrollments, username).then((data) => {
-        const camelCaseData = camelCaseObject(data);
-        setOnboardingData(camelCaseData);
-      });
+    getV2OnboardingStatus(username).then((data) => {
+      const camelCaseData = camelCaseObject(data);
+      setOnboardingData(camelCaseData);
     });
   }, [username]);
 
   const proctoringColumns = useMemo(() => [
+    {
+      Header: 'Course ID',
+      accessor: 'courseId',
+    },
     {
       Header: 'Onboarding Status',
       accessor: 'status',
@@ -30,33 +32,45 @@ export default function OnboardingStatus({
       accessor: 'expirationDate',
     },
     {
-      Header: 'Onboarding Link',
-      accessor: 'onboardingLink',
+      Header: 'Instructor Dashboard',
+      accessor: 'instructorDashboardLink',
     },
   ], []);
 
-  const proctoringData = useMemo(() => {
-    if (onboardingData === null || onboardingData.length === 0) {
-      return [];
-    }
-    return [onboardingData].map(result => ({
-      status: result.onboardingStatus ? titleCase(result.onboardingStatus) : 'Not Started',
+  function formatData(data) {
+    return [data].map(result => ({
+      courseId: result.courseId || 'No Course',
+      status: result.onboardingStatus ? titleCase(result.onboardingStatus) : 'See Dashboard',
       expirationDate: formatDate(result.expirationDate),
-      onboardingLink: result.onboardingLink ? <a href={`${getConfig().LMS_BASE_URL}${result.onboardingLink}`} rel="noopener noreferrer" target="_blank" className="word_break">Link</a>
+      instructorDashboardLink: result.instructorDashboardLink ? <a href={`${getConfig().LMS_BASE_URL}${result.instructorDashboardLink}`} rel="noopener noreferrer" target="_blank" className="word_break" label="dashboard link">Link</a>
         : 'N/A',
     }));
-  }, [onboardingData]);
+  }
 
   return (
     <div className="flex-column p-4 m-3 card">
       <h3>Proctoring Information</h3>
-      {onboardingData ? (
-        <TableV2
-          id="proctoring-data"
-          data={proctoringData}
-          columns={proctoringColumns}
-          styleName="idv-table"
-        />
+      { onboardingData ? (
+        <div>
+          <h4>Verified In</h4>
+          { onboardingData.verifiedIn ? (
+            <TableV2
+              id="verified-in-data"
+              data={formatData(onboardingData.verifiedIn)}
+              columns={proctoringColumns}
+              styleName="idv-table"
+            />
+          ) : <div className="no-record-text" id="verified-in-no-data">No Record Found</div>}
+          <h4>Current Status</h4>
+          { onboardingData.currentStatus ? (
+            <TableV2
+              id="current-status-data"
+              data={formatData(onboardingData.currentStatus)}
+              columns={proctoringColumns}
+              styleName="idv-table"
+            />
+          ) : <div className="no-record-text" id="current-status-no-data">No Record Found</div>}
+        </div>
       ) : <PageLoading srMessage="Loading.." /> }
     </div>
   );

--- a/src/users/v2/OnboardingStatus.jsx
+++ b/src/users/v2/OnboardingStatus.jsx
@@ -40,7 +40,9 @@ export default function OnboardingStatus({
   function formatData(data) {
     return [data].map(result => ({
       courseId: result.courseId || 'No Course',
-      status: result.onboardingStatus ? titleCase(result.onboardingStatus) : 'See Dashboard',
+      // The default value of `See Dashboard` if there is no status returned in API is because
+      // there are certain status in db for which the api gives null they are visible on instructor dashboard.
+      status: result.onboardingStatus ? titleCase(result.onboardingStatus) : 'See Instructor Dashboard',
       expirationDate: formatDate(result.expirationDate),
       instructorDashboardLink: result.instructorDashboardLink ? <a href={`${getConfig().LMS_BASE_URL}${result.instructorDashboardLink}`} rel="noopener noreferrer" target="_blank" className="word_break" label="dashboard link">Link</a>
         : 'N/A',
@@ -52,7 +54,7 @@ export default function OnboardingStatus({
       <h3>Proctoring Information</h3>
       { onboardingData ? (
         <div>
-          <h4>Verified In</h4>
+          <h3>Verified In</h3>
           { onboardingData.verifiedIn ? (
             <TableV2
               id="verified-in-data"
@@ -60,7 +62,7 @@ export default function OnboardingStatus({
               columns={proctoringColumns}
               styleName="idv-table"
             />
-          ) : <div className="no-record-text" id="verified-in-no-data">No Record Found</div>}
+          ) : <div className="no-record-text" id="verified-in-no-data">{ onboardingData.error ? onboardingData.error : 'No Record Found' }</div> }
           <h4>Current Status</h4>
           { onboardingData.currentStatus ? (
             <TableV2
@@ -69,7 +71,7 @@ export default function OnboardingStatus({
               columns={proctoringColumns}
               styleName="idv-table"
             />
-          ) : <div className="no-record-text" id="current-status-no-data">No Record Found</div>}
+          ) : <div className="no-record-text" id="current-status-no-data">{ onboardingData.error ? onboardingData.error : 'No Record Found' }</div>}
         </div>
       ) : <PageLoading srMessage="Loading.." /> }
     </div>

--- a/src/users/v2/OnboardingStatus.test.jsx
+++ b/src/users/v2/OnboardingStatus.test.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { waitForComponentToPaint } from '../../setupTest';
 import OnboardingStatus from './OnboardingStatus';
 import UserMessagesProvider from '../../userMessages/UserMessagesProvider';
-import onboardingStatusData from '../data/test/onboardingStatus';
+import { v2OnboardingStatusData as onboardingStatusData } from '../data/test/onboardingStatus';
 import enrollmentsData from '../data/test/enrollments';
 import { titleCase, formatDate } from '../../utils';
 
@@ -23,7 +23,7 @@ describe('Onboarding Status', () => {
 
   beforeEach(async () => {
     jest.spyOn(api, 'getEnrollments').mockImplementationOnce(() => Promise.resolve(enrollmentsData));
-    jest.spyOn(api, 'getOnboardingStatus').mockImplementationOnce(() => Promise.resolve(onboardingStatusData));
+    jest.spyOn(api, 'getV2OnboardingStatus').mockImplementationOnce(() => Promise.resolve(onboardingStatusData));
     wrapper = mount(<OnboardingStatusWrapper {...props} />);
     await waitForComponentToPaint(wrapper);
   });
@@ -33,27 +33,94 @@ describe('Onboarding Status', () => {
 
     expect(username).toEqual(props.username);
   });
+
   it('Onboarding Status', () => {
-    const dataTable = wrapper.find('Table#proctoring-data');
-    const dataBody = dataTable.find('tbody tr td');
-    expect(dataBody).toHaveLength(3);
-    expect(dataBody.at(0).text()).toEqual(titleCase(onboardingStatusData.onboardingStatus));
-    expect(dataBody.at(1).text()).toEqual(formatDate(onboardingStatusData.expirationDate));
-    expect(dataBody.at(2).text()).toEqual('Link');
+    const verifiedInData = wrapper.find('Table#verified-in-data');
+    const verifiedInDataBody = verifiedInData.find('tbody tr td');
+    expect(verifiedInDataBody).toHaveLength(4);
+    expect(verifiedInDataBody.at(0).text()).toEqual(onboardingStatusData.verifiedIn.courseId);
+    expect(verifiedInDataBody.at(1).text()).toEqual(titleCase(onboardingStatusData.verifiedIn.onboardingStatus));
+    expect(verifiedInDataBody.at(2).text()).toEqual(formatDate(onboardingStatusData.verifiedIn.expirationDate));
+    expect(verifiedInDataBody.at(3).text()).toEqual('Link');
+
+    const currentStatusData = wrapper.find('Table#current-status-data');
+    const currentStatusDataBody = currentStatusData.find('tbody tr td');
+    expect(currentStatusDataBody).toHaveLength(4);
+    expect(currentStatusDataBody.at(0).text()).toEqual(onboardingStatusData.currentStatus.courseId);
+    expect(currentStatusDataBody.at(1).text()).toEqual(titleCase(onboardingStatusData.currentStatus.onboardingStatus));
+    expect(currentStatusDataBody.at(2).text()).toEqual(formatDate(onboardingStatusData.currentStatus.expirationDate));
+    expect(currentStatusDataBody.at(3).text()).toEqual('Link');
   });
+
   it('No Onboarding Status Data', async () => {
-    const onboardingData = { ...onboardingStatusData, onboardingStatus: null, onboardingLink: null };
+    const onboardingData = { verifiedIn: null, currentStatus: null };
 
     jest.spyOn(api, 'getEnrollments').mockImplementationOnce(() => Promise.resolve(enrollmentsData));
-    jest.spyOn(api, 'getOnboardingStatus').mockImplementationOnce(() => Promise.resolve(onboardingData));
+    jest.spyOn(api, 'getV2OnboardingStatus').mockImplementationOnce(() => Promise.resolve(onboardingData));
     wrapper = mount(<OnboardingStatusWrapper {...props} />);
     await waitForComponentToPaint(wrapper);
 
-    const dataTable = wrapper.find('Table#proctoring-data');
-    const dataBody = dataTable.find('tbody tr td');
-    expect(dataBody).toHaveLength(3);
-    expect(dataBody.at(0).text()).toEqual('Not Started');
-    expect(dataBody.at(1).text()).toEqual(formatDate(onboardingStatusData.expirationDate));
-    expect(dataBody.at(2).text()).toEqual('N/A');
+    const verifiedInDataTable = wrapper.find('div#verified-in-no-data');
+    expect(verifiedInDataTable.text()).toEqual('No Record Found');
+    const currentStatusDataTable = wrapper.find('div#current-status-no-data');
+    expect(currentStatusDataTable.text()).toEqual('No Record Found');
+  });
+
+  it('No Onboarding Status Data with current status data only', async () => {
+    const onboardingData = { ...onboardingStatusData, verifiedIn: null };
+
+    jest.spyOn(api, 'getEnrollments').mockImplementationOnce(() => Promise.resolve(enrollmentsData));
+    jest.spyOn(api, 'getV2OnboardingStatus').mockImplementationOnce(() => Promise.resolve(onboardingData));
+    wrapper = mount(<OnboardingStatusWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+
+    const verifiedInDataTable = wrapper.find('div#verified-in-no-data');
+    expect(verifiedInDataTable.text()).toEqual('No Record Found');
+
+    const currentStatusData = wrapper.find('Table#current-status-data');
+    const currentStatusDataBody = currentStatusData.find('tbody tr td');
+    expect(currentStatusDataBody).toHaveLength(4);
+    expect(currentStatusDataBody.at(0).text()).toEqual(onboardingStatusData.currentStatus.courseId);
+    expect(currentStatusDataBody.at(1).text()).toEqual(titleCase(onboardingStatusData.currentStatus.onboardingStatus));
+    expect(currentStatusDataBody.at(2).text()).toEqual(formatDate(onboardingStatusData.currentStatus.expirationDate));
+    expect(currentStatusDataBody.at(3).text()).toEqual('Link');
+  });
+
+  it('Onboarding Status Data with null values', async () => {
+    const nullData = {
+      onboardingStatus: null,
+      onboardingLink: null,
+      expirationDate: null,
+      onboardingPastDue: null,
+      onboardingReleaseDate: null,
+      reviewRequirementsUrl: null,
+      courseId: null,
+      enrollmentDate: null,
+      instructorDashboardLink: null,
+    };
+    const onboardingData = { ...onboardingStatusData, verifiedIn: nullData };
+
+    jest.spyOn(api, 'getEnrollments').mockImplementationOnce(() => Promise.resolve(enrollmentsData));
+    jest.spyOn(api, 'getV2OnboardingStatus').mockImplementationOnce(() => Promise.resolve(onboardingData));
+    wrapper = mount(<OnboardingStatusWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+
+    const verifiedInData = wrapper.find('Table#verified-in-data');
+    const verifiedInDataBody = verifiedInData.find('tbody tr td');
+    expect(verifiedInDataBody).toHaveLength(4);
+    expect(verifiedInDataBody.at(0).text()).toEqual('No Course');
+    expect(verifiedInDataBody.at(1).text()).toEqual('See Dashboard');
+    expect(verifiedInDataBody.at(2).text()).toEqual('N/A');
+    expect(verifiedInDataBody.at(3).text()).toEqual('N/A');
+  });
+
+  it('Onboarding Status Data is loading', async () => {
+    const onboardingData = null;
+
+    jest.spyOn(api, 'getEnrollments').mockImplementationOnce(() => Promise.resolve(enrollmentsData));
+    jest.spyOn(api, 'getV2OnboardingStatus').mockImplementationOnce(() => Promise.resolve(onboardingData));
+    wrapper = mount(<OnboardingStatusWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find('.sr-only').text()).toEqual('Loading..');
   });
 });

--- a/src/users/v2/OnboardingStatus.test.jsx
+++ b/src/users/v2/OnboardingStatus.test.jsx
@@ -22,7 +22,6 @@ describe('Onboarding Status', () => {
   };
 
   beforeEach(async () => {
-    jest.spyOn(api, 'getEnrollments').mockImplementationOnce(() => Promise.resolve(enrollmentsData));
     jest.spyOn(api, 'getV2OnboardingStatus').mockImplementationOnce(() => Promise.resolve(onboardingStatusData));
     wrapper = mount(<OnboardingStatusWrapper {...props} />);
     await waitForComponentToPaint(wrapper);
@@ -55,7 +54,6 @@ describe('Onboarding Status', () => {
   it('No Onboarding Status Data', async () => {
     const onboardingData = { verifiedIn: null, currentStatus: null };
 
-    jest.spyOn(api, 'getEnrollments').mockImplementationOnce(() => Promise.resolve(enrollmentsData));
     jest.spyOn(api, 'getV2OnboardingStatus').mockImplementationOnce(() => Promise.resolve(onboardingData));
     wrapper = mount(<OnboardingStatusWrapper {...props} />);
     await waitForComponentToPaint(wrapper);
@@ -64,6 +62,19 @@ describe('Onboarding Status', () => {
     expect(verifiedInDataTable.text()).toEqual('No Record Found');
     const currentStatusDataTable = wrapper.find('div#current-status-no-data');
     expect(currentStatusDataTable.text()).toEqual('No Record Found');
+  });
+
+  it('No Onboarding Status Data with error message', async () => {
+    const onboardingData = { verifiedIn: null, currentStatus: null, error: 'Server fetched failed' };
+
+    jest.spyOn(api, 'getV2OnboardingStatus').mockImplementationOnce(() => Promise.resolve(onboardingData));
+    wrapper = mount(<OnboardingStatusWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+
+    const verifiedInDataTable = wrapper.find('div#verified-in-no-data');
+    expect(verifiedInDataTable.text()).toEqual('Server fetched failed');
+    const currentStatusDataTable = wrapper.find('div#current-status-no-data');
+    expect(currentStatusDataTable.text()).toEqual('Server fetched failed');
   });
 
   it('No Onboarding Status Data with current status data only', async () => {
@@ -100,7 +111,6 @@ describe('Onboarding Status', () => {
     };
     const onboardingData = { ...onboardingStatusData, verifiedIn: nullData };
 
-    jest.spyOn(api, 'getEnrollments').mockImplementationOnce(() => Promise.resolve(enrollmentsData));
     jest.spyOn(api, 'getV2OnboardingStatus').mockImplementationOnce(() => Promise.resolve(onboardingData));
     wrapper = mount(<OnboardingStatusWrapper {...props} />);
     await waitForComponentToPaint(wrapper);
@@ -109,7 +119,7 @@ describe('Onboarding Status', () => {
     const verifiedInDataBody = verifiedInData.find('tbody tr td');
     expect(verifiedInDataBody).toHaveLength(4);
     expect(verifiedInDataBody.at(0).text()).toEqual('No Course');
-    expect(verifiedInDataBody.at(1).text()).toEqual('See Dashboard');
+    expect(verifiedInDataBody.at(1).text()).toEqual('See Instructor Dashboard');
     expect(verifiedInDataBody.at(2).text()).toEqual('N/A');
     expect(verifiedInDataBody.at(3).text()).toEqual('N/A');
   });
@@ -117,7 +127,6 @@ describe('Onboarding Status', () => {
   it('Onboarding Status Data is loading', async () => {
     const onboardingData = null;
 
-    jest.spyOn(api, 'getEnrollments').mockImplementationOnce(() => Promise.resolve(enrollmentsData));
     jest.spyOn(api, 'getV2OnboardingStatus').mockImplementationOnce(() => Promise.resolve(onboardingData));
     wrapper = mount(<OnboardingStatusWrapper {...props} />);
     await waitForComponentToPaint(wrapper);

--- a/src/users/v2/UserSummary.test.jsx
+++ b/src/users/v2/UserSummary.test.jsx
@@ -7,7 +7,7 @@ import UserSummary from './UserSummary';
 import UserSummaryData from '../data/test/userSummary';
 import UserMessagesProvider from '../../userMessages/UserMessagesProvider';
 import enrollmentsData from '../data/test/enrollments';
-import onboardingStatusData from '../data/test/onboardingStatus';
+import { v2OnboardingStatusData as onboardingStatusData } from '../data/test/onboardingStatus';
 import enterpriseCustomerUsersData from '../data/test/enterpriseCustomerUsers';
 import verifiedNameHistoryData from '../data/test/verifiedNameHistory';
 import { waitForComponentToPaint } from '../../setupTest';
@@ -26,7 +26,7 @@ describe('User Summary Component Tests', () => {
   const mountUserSummaryWrapper = async (data) => {
     jest.spyOn(api, 'getVerifiedNameHistory').mockImplementationOnce(() => Promise.resolve(verifiedNameHistoryData));
     jest.spyOn(api, 'getEnrollments').mockImplementationOnce(() => Promise.resolve(enrollmentsData));
-    jest.spyOn(api, 'getOnboardingStatus').mockImplementationOnce(() => Promise.resolve(onboardingStatusData));
+    jest.spyOn(api, 'getV2OnboardingStatus').mockImplementationOnce(() => Promise.resolve(onboardingStatusData));
     jest.spyOn(api, 'getEnterpriseCustomerUsers').mockImplementationOnce(() => Promise.resolve(enterpriseCustomerUsersData));
     wrapper = mount(<UserSummaryWrapper {...data} />);
     await waitForComponentToPaint(wrapper);


### PR DESCRIPTION
[PROD-2584](https://openedx.atlassian.net/browse/PROD-2584)

### Description

- Show the current Onboarding status and the actual verified-in course status details on v2 user summary
- Update some failing tests due to async updates after the test completion

<img width="1437" alt="Screen Shot 2022-02-09 at 2 53 34 PM" src="https://user-images.githubusercontent.com/15185149/153171901-1c4a1930-e43a-4d66-9ac6-8836dece207a.png">

