### PR TITLE
fix: Responsiveness of Enrollment and Entitlement V2 table

### DIFF
--- a/src/overrides.scss
+++ b/src/overrides.scss
@@ -164,3 +164,7 @@ $darkCyan: #00262b;
 .background-light-gray {
   background: lightgrey;
 }
+
+.mb-60 {
+  margin-bottom: 60px;
+}

--- a/src/users/enrollments/v2/Enrollments.jsx
+++ b/src/users/enrollments/v2/Enrollments.jsx
@@ -281,7 +281,7 @@ export default function Enrollments({
             columns={columns}
             data={tableData}
             renderRowSubComponent={renderRowSubComponent}
-            styleName="custom-table"
+            styleName={tableData.length === 1 ? 'custom-table mb-60' : 'custom-table'}
             defaultSortColumn={defaultSortColumn}
           />
         )

--- a/src/users/entitlements/v2/Entitlements.jsx
+++ b/src/users/entitlements/v2/Entitlements.jsx
@@ -268,7 +268,7 @@ export default function Entitlements({
             columns={columns}
             data={tableData}
             renderRowSubComponent={renderRowSubComponent}
-            styleName="custom-table"
+            styleName={tableData.length === 1 ? 'custom-table mb-60' : 'custom-table'}
           />
         )}
 


### PR DESCRIPTION
[entitlement action hiding behind enrollment button for a single entitlement](https://openedx.atlassian.net/browse/PROD-2571)


Description: In case of single row drop down was hiding behind its below component because our table is responsive and add scroll if table content exceed. We need this responsive behavior so we have handled this edge case of single row manually by increasing size of table div, so drop can properly visible

<img width="1440" alt="Screen Shot 2022-02-17 at 7 51 27 PM" src="https://user-images.githubusercontent.com/15185149/154506832-ccec4686-9f2c-433b-bb21-2382f5109667.png">

