### PR TITLE
fix: make proctoringAttemptId show on VerifiedName panel

### DIFF
--- a/src/users/v2/VerifiedName.jsx
+++ b/src/users/v2/VerifiedName.jsx
@@ -38,7 +38,7 @@ export default function VerifiedName({ username }) {
       profileName: result.profileName,
       status: result.status,
       idvAttemptId: result.verificationAttemptId,
-      proctoringAttemptId: result.proctoringAttemptId,
+      proctoringAttemptId: result.proctoredExamAttemptId,
       createdAt: formatDate(result.created),
     }));
     setVerifiedNameHistoryData(tableData);


### PR DESCRIPTION
The proctoredExamAttemptId column values are not showing up.
This change fixes it.

Before:

![VerifiedPanelWithBug](https://user-images.githubusercontent.com/16839373/156254750-5ac96e4a-3fd8-4a2d-90df-442775b4cace.png)

 

After:
![GoodVerifiedNamePanel](https://user-images.githubusercontent.com/16839373/156254064-235c27af-b738-4a1a-a259-03976e92c9a3.png)

@openedx/masters-devs-cosmonauts Please help review