### PR TITLE
fix: Add tooltip popover for details on IDV attempts history

### DIFF
--- a/src/users/data/api.js
+++ b/src/users/data/api.js
@@ -259,6 +259,22 @@ export async function getVerifiedNameHistory(username) {
   }
 }
 
+export async function getVerificationAttemptDetailsById(attemptId) {
+  try {
+    const { data } = await getAuthenticatedHttpClient().get(
+      AppUrls.getVerificationAttemptDetailsByIdUrl(attemptId),
+    );
+    return data;
+  } catch (error) {
+    // We don't have good error handling in the app for any errors that may have come back
+    // from the API, so we log them to the console and tell the user to go look.  We would
+    // never do this in a customer-facing app.
+    // eslint-disable-next-line no-console
+    console.log(JSON.parse(error.customAttributes.httpErrorResponseData));
+    return {};
+  }
+}
+
 export async function getUserPasswordStatus(userIdentifier) {
   const { data } = await getAuthenticatedHttpClient().get(
     AppUrls.getUserPasswordStatusUrl(userIdentifier),

--- a/src/users/data/api.test.js
+++ b/src/users/data/api.test.js
@@ -14,6 +14,7 @@ describe('API', () => {
   const testEmail = 'email@example.com';
   const testLMSUserID = '22';
   const testCourseId = 'course-v1:testX+test123+2030';
+  const testAttemptId = 12334;
   const userAccountApiBaseUrl = `${getConfig().LMS_BASE_URL}/api/user/v1/accounts`;
   const ssoRecordsApiUrl = `${getConfig().LMS_BASE_URL}/support/sso_records/${testUsername}`;
   const enrollmentsApiUrl = `${getConfig().LMS_BASE_URL}/support/enrollment/${testUsername}`;
@@ -22,6 +23,7 @@ describe('API', () => {
   const verificationDetailsApiUrl = `${getConfig().LMS_BASE_URL}/api/user/v1/accounts/${testUsername}/verifications/`;
   const verificationStatusApiUrl = `${getConfig().LMS_BASE_URL}/api/user/v1/accounts/${testUsername}/verification_status/`;
   const verifiedNameHistoryUrl = `${getConfig().LMS_BASE_URL}/api/edx_name_affirmation/v1/verified_name/history?username=${testUsername}`;
+  const verificationAttemptDetailsByIdUrl = `${getConfig().LMS_BASE_URL}/api/user/v1/accounts/verifications/${testAttemptId}/`;
   const licensesApiUrl = `${getConfig().LICENSE_MANAGER_URL}/api/v1/staff_lookup_licenses/`;
   const certificatesUrl = urls.getCertificateUrl(testUsername, testCourseId);
   const generateCertificateUrl = urls.generateCertificateUrl();
@@ -366,6 +368,27 @@ describe('API', () => {
 
       const response = await api.getVerifiedNameHistory(testUsername);
       expect(response).toEqual(expectedData);
+    });
+  });
+
+  describe('Verification Attempt Details By Id', () => {
+    const mockResponse = {
+      message: '[{"generalReasons": ["Name mismatch"]}]',
+      status: 'denied',
+      verificationType: 'softwareSecure',
+    };
+
+    it('returns empty if request experience server error', async () => {
+      mockAdapter.onGet(verificationAttemptDetailsByIdUrl).reply(() => throwError(500, '{}'));
+      const response = await api.getVerificationAttemptDetailsById(testAttemptId);
+      expect(response).toEqual({});
+    });
+
+    it('successfully fetches data', async () => {
+      mockAdapter.onGet(verificationAttemptDetailsByIdUrl).reply(200, mockResponse);
+
+      const response = await api.getVerificationAttemptDetailsById(testAttemptId);
+      expect(response).toEqual(mockResponse);
     });
   });
 

--- a/src/users/data/urls.js
+++ b/src/users/data/urls.js
@@ -47,6 +47,10 @@ export const getVerifiedNameHistoryUrl = username => `${
   LMS_BASE_URL
 }/api/edx_name_affirmation/v1/verified_name/history?username=${username}`;
 
+export const getVerificationAttemptDetailsByIdUrl = attemptId => `${
+  LMS_BASE_URL
+}/api/user/v1/accounts/verifications/${attemptId}/`;
+
 export const getUserPasswordStatusUrl = userIdentifier => `${
   LMS_BASE_URL
 }/support/manage_user/${userIdentifier}`;


### PR DESCRIPTION
### Description
[MST-1383](https://openedx.atlassian.net/browse/MST-1383)

To help support team member to see more information about the IDV attempt associated with VerifiedName records, we are providing a pop over element to the VerifiedNameHistory Modal Dialog. See screenshot below. This is a minor enhancement.

![tooltipforVerifiedNameIDV](https://user-images.githubusercontent.com/16839373/156810049-fdb97e9d-30e5-463f-94fa-aa251a3565f6.png)

