### PR TITLE
fix: display error message returned from API on enrollment create

### DIFF
--- a/src/users/data/api.js
+++ b/src/users/data/api.js
@@ -527,17 +527,18 @@ export async function postEnrollment({
     );
     return data;
   } catch (error) {
+    let errorMessage;
     if (error.customAttributes.httpErrorStatus === 400) {
+      errorMessage = JSON.parse(error.customAttributes.httpErrorResponseData);
       // eslint-disable-next-line no-console
-      console.log(JSON.parse(error.customAttributes.httpErrorResponseData));
+      console.log(errorMessage);
     }
     return {
       errors: [
         {
           code: null,
           dismissible: true,
-          text:
-            'There was an error creating the enrollment. Check the JavaScript console for detailed errors.',
+          text: errorMessage || 'An unexpected error occurred',
           type: 'danger',
           topic: 'createEnrollments',
         },

--- a/src/users/data/api.test.js
+++ b/src/users/data/api.test.js
@@ -815,12 +815,25 @@ describe('API', () => {
         const expectedError = {
           code: null,
           dismissible: true,
-          text:
-          'There was an error creating the enrollment. Check the JavaScript console for detailed errors.',
+          text: 'An unexpected error occurred',
           type: 'danger',
           topic: 'enrollments',
         };
         mockAdapter.onPost(enrollmentsApiUrl, requestData).reply(() => throwError(400, ''));
+        const response = await api.postEnrollment({ ...apiCallData });
+        expect(...response.errors).toEqual({ ...expectedError, topic: 'createEnrollments' });
+      });
+
+      it('Unsuccessful enrollment create with error message', async () => {
+        const expectedError = {
+          code: null,
+          dismissible: true,
+          text:
+          'User already enrolled',
+          type: 'danger',
+          topic: 'enrollments',
+        };
+        mockAdapter.onPost(enrollmentsApiUrl, requestData).reply(() => throwError(400, 'User already enrolled'));
         const response = await api.postEnrollment({ ...apiCallData });
         expect(...response.errors).toEqual({ ...expectedError, topic: 'createEnrollments' });
       });


### PR DESCRIPTION
[Improving Feedback message for support using "Create New Enrollment" actions](https://openedx.atlassian.net/browse/PROD-2607)

Description: Before this we were not displaying exact error which is returned by API rather we were display error message to check console for details. But now we are displaying actual error which is returned by API



<img width="1437" alt="Screen Shot 2022-03-09 at 1 40 52 PM" src="https://user-images.githubusercontent.com/15185149/157404470-9f012738-b377-4ee8-9bb3-23c49d3b7d7a.png">
