### PR TITLE
feat: show user message on retired email search

### DIFF
--- a/src/userMessages/messages.js
+++ b/src/userMessages/messages.js
@@ -1,5 +1,6 @@
 export const USER_IDENTIFIER_INVALID_ERROR = 'The searched username, email or lms user id is invalid. Please correct the username, email or lms user id and try again.';
 export const USERNAME_IDENTIFIER_NOT_FOUND_ERROR = 'We couldn\'t find a user with the username "{identifier}".';
 export const USER_EMAIL_IDENTIFIER_NOT_FOUND_ERROR = 'We couldn\'t find a user with the email "{identifier}".';
+export const USER_RETIRED_EMAIL_IDENTIFIER_ERROR = 'This email is associated to a retired account.';
 export const LMS_USER_ID_IDENTIFIER_NOT_FOUND_ERROR = 'We couldn\'t find a user with the LMS User ID "{identifier}".';
 export const UNKNOWN_API_ERROR = "There was an error loading this user's data. Check the JavaScript console for detailed errors.";

--- a/src/users/data/api.js
+++ b/src/users/data/api.js
@@ -108,7 +108,9 @@ export async function getUser(userIdentifier) {
     console.log(JSON.parse(error.customAttributes.httpErrorResponseData));
 
     let notFoundErrorText = null;
-    if (isEmail(userIdentifier)) {
+    if (JSON.parse(error.customAttributes?.httpErrorResponseData)) {
+      notFoundErrorText = JSON.parse(error.customAttributes.httpErrorResponseData).error_msg;
+    } else if (isEmail(userIdentifier)) {
       notFoundErrorText = messages.USER_EMAIL_IDENTIFIER_NOT_FOUND_ERROR;
     } else if (isValidLMSUserID(userIdentifier)) {
       notFoundErrorText = messages.LMS_USER_ID_IDENTIFIER_NOT_FOUND_ERROR;

--- a/src/users/data/api.test.js
+++ b/src/users/data/api.test.js
@@ -8,6 +8,7 @@ import verifiedNameHistoryData from './test/verifiedNameHistory';
 import { v2OnboardingStatusData } from './test/onboardingStatus';
 import * as api from './api';
 import * as urls from './urls';
+import * as messages from '../../userMessages/messages';
 
 describe('API', () => {
   const testUsername = 'username';
@@ -446,6 +447,25 @@ describe('API', () => {
       mockAdapter.onGet(`${userAccountApiBaseUrl}/${testUsername}`).reply(() => throwError(404, ''));
       try {
         await api.getUser(testUsername);
+      } catch (error) {
+        expect(error.userError).toEqual(expectedUserError);
+      }
+    });
+
+    it('Retired Email retrieval 404 failure', async () => {
+      const expectedUserError = {
+        code: null,
+        dismissible: true,
+        text: messages.USER_RETIRED_EMAIL_IDENTIFIER_ERROR,
+        type: 'error',
+        topic: 'general',
+      };
+      // The retired email does not fetch an account hence we're showing the error message that the account is retired
+      mockAdapter.onGet(`${userAccountApiBaseUrl}?email=${encodeURIComponent(testEmail)}`).reply(
+        () => throwError(404, { error_msg: messages.USER_RETIRED_EMAIL_IDENTIFIER_ERROR }),
+      );
+      try {
+        await api.getUser(testEmail);
       } catch (error) {
         expect(error.userError).toEqual(expectedUserError);
       }


### PR DESCRIPTION
[PROD-2521](https://openedx.atlassian.net/browse/PROD-2521)
<img width="1072" alt="Screenshot 2022-03-10 at 2 18 37 AM" src="https://user-images.githubusercontent.com/52413434/157543228-adc26e1e-8bf9-46d2-ace3-9bc3fff9d401.png">

For the retired email, we weren't able to get anything from Support Tools hence we changed the message here so that it explains why the account info associated to the email cannot be received.