### PR TITLE
fix: fix SSO Records in Program Inspector Production

### DIFF
--- a/src/ProgramEnrollments/ProgramInspector/ProgramInspector.jsx
+++ b/src/ProgramEnrollments/ProgramInspector/ProgramInspector.jsx
@@ -21,7 +21,7 @@ export default function ProgramInspector({ location }) {
       .map((queryParams) => queryParams.split('=')),
   );
 
-  const [ssoRecord, setSsoRecord] = useState(undefined);
+  const [ssoRecords, setSsoRecords] = useState([]);
   const [error, setError] = useState(undefined);
   const [learnerProgramEnrollment, setLearnerProgramEnrollment] = useState(undefined);
   const [username, setUsername] = useState(params.get('edx_user'));
@@ -42,7 +42,7 @@ export default function ProgramInspector({ location }) {
       setUsername(undefined);
       setExternalUserKey(undefined);
       setLearnerProgramEnrollment(undefined);
-      setSsoRecord(undefined);
+      setSsoRecords([]);
       history.push('/v2/programs');
     } else {
       const newLink = `/v2/programs?edx_user=${
@@ -90,12 +90,20 @@ export default function ProgramInspector({ location }) {
   }, []);
 
   useEffect(() => {
-    setSsoRecord(null);
-    if (learnerProgramEnrollment && learnerProgramEnrollment.user) {
+    setSsoRecords([]);
+    if (
+      learnerProgramEnrollment
+      && learnerProgramEnrollment.user
+      && learnerProgramEnrollment.user.sso_list
+    ) {
       getSsoRecords(learnerProgramEnrollment.user.username).then((response) => {
         response.map((data) => {
-          if (data.provider === activeOrgKey) {
-            setSsoRecord(data);
+          if (
+            learnerProgramEnrollment.user.sso_list.length
+            && learnerProgramEnrollment.user.sso_list.some(
+              (sso) => sso.uid === data.uid,
+            )) {
+            setSsoRecords((arr) => [...arr, data]);
           }
           return data;
         });
@@ -188,16 +196,16 @@ export default function ProgramInspector({ location }) {
                 </div>
               )}
             </div>
-            {ssoRecord ? (
-              <div className="col-sm-6 ml-1">
-                <h4>SSO Records</h4>
-                <SingleSignOnRecordCard ssoRecord={ssoRecord} />
-              </div>
-            ) : (
-              <div className="col-sm-6 ml-1">
+            <div className="col-sm-6 sso-records ml-1">
+              <h4>SSO Records</h4>
+              {ssoRecords && ssoRecords.length ? (
+                ssoRecords.map((ssoRecord) => (
+                  <SingleSignOnRecordCard ssoRecord={ssoRecord} />
+                ))
+              ) : (
                 <Alert variant="danger">SSO Record Not Found</Alert>
-              </div>
-            )}
+              )}
+            </div>
           </div>
           <div className="mt-2">
             {learnerProgramEnrollment

--- a/src/ProgramEnrollments/ProgramInspector/ProgramInspector.test.jsx
+++ b/src/ProgramEnrollments/ProgramInspector/ProgramInspector.test.jsx
@@ -144,4 +144,53 @@ describe('Program Inspector', () => {
 
     history.push.mockReset();
   });
+
+  it('render nothing when no username or external_user_key', async () => {
+    history.push = jest.fn();
+    apiMock = jest
+      .spyOn(api, 'getProgramEnrollmentsInspector')
+      .mockImplementationOnce(() => Promise.resolve(programInspectorSuccessResponse));
+    wrapper = mount(<ProgramEnrollmentsWrapper location={location} />);
+
+    await waitForComponentToPaint(wrapper);
+
+    wrapper.find("input[name='username']").simulate('change',
+      { target: { value: undefined } });
+    wrapper.find("input[name='externalKey']").simulate('change',
+      { target: { value: undefined } });
+    wrapper.find("select[name='orgKey']").simulate('change',
+      { target: { value: data.orgKey } });
+    wrapper.find('button.btn-primary').simulate('click');
+
+    expect(history.push).toHaveBeenCalledWith(
+      '/v2/programs',
+    );
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find('.inspector-name-row').exists()).toBeFalsy();
+    history.push.mockReset();
+  });
+
+  it('check if SSO is present', async () => {
+    history.push = jest.fn();
+    apiMock = jest
+      .spyOn(api, 'getProgramEnrollmentsInspector')
+      .mockImplementationOnce(() => Promise.resolve(programInspectorSuccessResponse));
+    wrapper = mount(<ProgramEnrollmentsWrapper location={location} />);
+
+    await waitForComponentToPaint(wrapper);
+
+    wrapper.find("input[name='username']").simulate('change',
+      { target: { value: data.username } });
+    wrapper.find("select[name='orgKey']").simulate('change',
+      { target: { value: data.orgKey } });
+    wrapper.find('button.btn-primary').simulate('click');
+
+    await waitForComponentToPaint(wrapper);
+    const ssoRecords = wrapper.find('.sso-records');
+    expect(ssoRecords.find('h4').at(0).text()).toEqual('SSO Records');
+    expect(ssoRecords.find('h3').text()).toEqual(
+      'tpa-saml (Provider)',
+    );
+    history.push.mockReset();
+  });
 });

--- a/src/ProgramEnrollments/ProgramInspector/data/test/programInspector.js
+++ b/src/ProgramEnrollments/ProgramInspector/data/test/programInspector.js
@@ -47,6 +47,11 @@ export const programInspectorSuccessResponse = {
     user: {
       email: 'verified@example.com',
       username: 'verified',
+      sso_list: [
+        {
+          uid: 'edx-inc:test@edx.org',
+        },
+      ],
     },
   },
   org_keys: 'testX',


### PR DESCRIPTION
This is a fix of SSO records in Inspectors. Previously, they were connected to saml provider type but now they are connected to program uids. 

Ticket-link: [PROD-2737](https://openedx.atlassian.net/browse/PROD-2737)