### PR TITLE
feat: add learner credentials

### DIFF
--- a/src/users/LearnerCredentials.jsx
+++ b/src/users/LearnerCredentials.jsx
@@ -1,0 +1,133 @@
+import PropTypes from 'prop-types';
+import {
+  Hyperlink, TransitionReplace, Button, Alert,
+} from '@edx/paragon';
+import React, { useEffect, useState } from 'react';
+import Table from '../components/Table';
+import { getUserProgramCredentials } from './data/api';
+
+export default function LearnerCredentials({ username }) {
+  const [credentials, setCredentials] = useState(null);
+  const [error, setError] = useState(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const Attributes = ({ attributes }) => (
+    <>
+      <TransitionReplace>
+        {isOpen ? (
+          <>
+            <Button
+              variant="link"
+              size="inline"
+              onClick={() => setIsOpen(false)}
+            >
+              Hide
+            </Button>
+            <Table
+              columns={[
+                {
+                  Header: 'Name',
+                  accessor: 'name',
+                },
+                {
+                  Header: 'Value',
+                  accessor: 'value',
+                },
+              ]}
+              data={attributes.map((attribute) => ({
+                name: attribute.name,
+                value: attribute.value,
+              }))}
+              styleName="custom-table"
+            />
+          </>
+        ) : (
+          <Button variant="link" size="inline" onClick={() => setIsOpen(true)}>
+            Show
+          </Button>
+        )}
+      </TransitionReplace>
+    </>
+  );
+
+  Attributes.propTypes = {
+    attributes: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        value: PropTypes.string.isRequired,
+      }),
+    ).isRequired,
+  };
+
+  useEffect(() => {
+    if (username) {
+      getUserProgramCredentials(username).then((response) => {
+        if (response.count > 0) {
+          setCredentials(response.results);
+        } else if (response.errors) {
+          setError(response.errors[0]);
+        }
+      });
+    }
+  }, [username]);
+
+  return (
+    <>
+      <section className="mb-3">
+        <h3>Learner Credentials</h3>
+        {credentials ? (
+          <Table
+            columns={[
+              {
+                Header: 'Credential Type',
+                accessor: 'credentialType',
+              },
+              {
+                Header: 'Program ID',
+                accessor: 'programID',
+              },
+              {
+                Header: 'Status',
+                accessor: 'status',
+              },
+              {
+                Header: 'Certificate Link',
+                accessor: 'certificateUrl',
+              },
+              {
+                Header: 'Attributes',
+                accessor: 'attributes',
+              },
+            ]}
+            data={credentials.map((credential) => ({
+              credentialType: credential.credential.type,
+              programID: credential.credential.program_uuid,
+              status: credential.status,
+              certificateUrl: (
+                <Hyperlink destination={credential.certificate_url}>
+                  {credential.uuid}
+                </Hyperlink>
+              ),
+              attributes: <Attributes attributes={credential.attributes} />,
+            }))}
+            styleName="custom-table"
+          />
+        ) : (
+          <>
+            {error ? (
+              <>
+                <Alert variant="danger">{error.text}</Alert>
+              </>
+            ) : (
+              <p className="ml-4">No Credentials were Found.</p>
+            )}
+          </>
+        )}
+      </section>
+    </>
+  );
+}
+
+LearnerCredentials.propTypes = {
+  username: PropTypes.string.isRequired,
+};

--- a/src/users/LearnerCredentials.test.jsx
+++ b/src/users/LearnerCredentials.test.jsx
@@ -1,0 +1,148 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { waitForComponentToPaint } from '../setupTest';
+import UserMessagesProvider from '../userMessages/UserMessagesProvider';
+import * as api from './data/api';
+import { credentials, noCredentials } from './data/test/credentials';
+import LearnerCredentials from './LearnerCredentials';
+
+const LearnerCredentialsWrapper = (props) => (
+  <MemoryRouter>
+    <UserMessagesProvider>
+      <LearnerCredentials {...props} />
+    </UserMessagesProvider>
+  </MemoryRouter>
+);
+
+describe('Learner Credentials Tests', () => {
+  let wrapper;
+  let apiMock;
+  const data = {
+    username: 'edx',
+  };
+
+  beforeEach(() => {
+    if (apiMock) {
+      apiMock.mockReset();
+    }
+  });
+
+  it('default page render', async () => {
+    wrapper = mount(<LearnerCredentialsWrapper username={data.username} />);
+    apiMock = jest
+      .spyOn(api, 'getUserProgramCredentials')
+      .mockImplementationOnce(() => Promise.resolve(noCredentials));
+
+    await waitForComponentToPaint(wrapper);
+
+    expect(wrapper.find('h3').text()).toEqual('Learner Credentials');
+    expect(wrapper.find('p').text()).toEqual('No Credentials were Found.');
+    wrapper.unmount();
+  });
+
+  it('Error render', async () => {
+    const expectedError = {
+      errors: [
+        {
+          code: null,
+          dismissible: true,
+          text: 'There was an error retrieving credentials for the user',
+          type: 'danger',
+          topic: 'credentials',
+        },
+      ],
+    };
+    apiMock = jest
+      .spyOn(api, 'getUserProgramCredentials')
+      .mockImplementationOnce(() => Promise.resolve(expectedError));
+    wrapper = mount(<LearnerCredentialsWrapper username={data.username} />);
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.find('.alert').text()).toEqual(expectedError.errors[0].text);
+    wrapper.unmount();
+  });
+
+  it('Credentials Exist', async () => {
+    apiMock = jest
+      .spyOn(api, 'getUserProgramCredentials')
+      .mockImplementationOnce(() => Promise.resolve(credentials));
+
+    wrapper = mount(<LearnerCredentialsWrapper username={data.username} />);
+
+    await waitForComponentToPaint(wrapper);
+
+    const dataTable = wrapper.find('table.custom-table tr');
+    const headingRow = dataTable.at(0);
+    const dataRow = dataTable.at(1);
+
+    expect(headingRow.find('th').at(0).text()).toEqual('Credential Type');
+    expect(headingRow.find('th').at(1).text()).toEqual('Program ID');
+    expect(headingRow.find('th').at(2).text()).toEqual('Status');
+    expect(headingRow.find('th').at(3).text()).toEqual('Certificate Link');
+    expect(headingRow.find('th').at(4).text()).toEqual('Attributes');
+
+    const row = credentials.results[0];
+    expect(dataRow.find('td').at(0).text()).toEqual(row.credential.type);
+    expect(dataRow.find('td').at(1).text()).toEqual(
+      row.credential.program_uuid,
+    );
+    expect(dataRow.find('td').at(2).text()).toEqual(row.status);
+    expect(dataRow.find('td').at(3).find('a').text()).toEqual(row.uuid);
+    expect(dataRow.find('td').at(3).find('a').prop('href')).toEqual(
+      row.certificate_url,
+    );
+    expect(dataRow.find('td').at(4).find('button').text()).toEqual('Show');
+
+    wrapper.unmount();
+  });
+
+  it('Attributes Table', async () => {
+    apiMock = jest
+      .spyOn(api, 'getUserProgramCredentials')
+      .mockImplementationOnce(() => Promise.resolve(credentials));
+
+    wrapper = mount(<LearnerCredentialsWrapper username={data.username} />);
+
+    await waitForComponentToPaint(wrapper);
+
+    const attributeCell = wrapper
+      .find('table.custom-table tr')
+      .at(1)
+      .find('td')
+      .at(4);
+    const row = credentials.results[0];
+    expect(attributeCell.find('button').text()).toEqual('Show');
+    attributeCell.find('button').simulate('click');
+    attributeCell.update();
+
+    const updatedAttributeCell = wrapper
+      .find('table.custom-table tr')
+      .at(1)
+      .find('td')
+      .at(4);
+    expect(updatedAttributeCell.find('button').text()).toEqual('Hide');
+
+    const attributeTable = updatedAttributeCell.find('table.custom-table tr');
+    expect(attributeTable.at(0).find('th').at(0).text()).toEqual('Name');
+    expect(attributeTable.at(0).find('th').at(1).text()).toEqual('Value');
+    expect(attributeTable.at(1).find('td').at(0).text()).toEqual(
+      row.attributes[0].name,
+    );
+    expect(attributeTable.at(1).find('td').at(1).text()).toEqual(
+      row.attributes[0].value,
+    );
+
+    updatedAttributeCell.find('button').simulate('click');
+    updatedAttributeCell.update();
+    expect(
+      wrapper
+        .find('table.custom-table tr')
+        .at(1)
+        .find('td')
+        .at(4)
+        .find('button')
+        .text(),
+    ).toEqual('Show');
+    wrapper.unmount();
+  });
+});

--- a/src/users/LearnerInformation.jsx
+++ b/src/users/LearnerInformation.jsx
@@ -5,6 +5,7 @@ import UserSummary from './UserSummary';
 import SingleSignOnRecords from './SingleSignOnRecords';
 import Licenses from './licenses/Licenses';
 import EntitlementsAndEnrollmentsContainer from './EntitlementsAndEnrollmentsContainer';
+import LearnerCredentials from './LearnerCredentials';
 
 export default function LearnerInformation({
   user, changeHandler,
@@ -38,6 +39,11 @@ export default function LearnerInformation({
           <Licenses
             userEmail={user.email}
           />
+        </Tab>
+
+        <Tab eventKey="credentials" title="Learner Credentials">
+          <br />
+          <LearnerCredentials username={user.username} />
         </Tab>
 
       </Tabs>

--- a/src/users/LearnerInformation.test.jsx
+++ b/src/users/LearnerInformation.test.jsx
@@ -54,11 +54,12 @@ describe('Learners and Enrollments component', () => {
 
   it('renders correctly', () => {
     const tabs = wrapper.find('nav.nav-tabs a');
-    expect(tabs.length).toEqual(3);
+    expect(tabs.length).toEqual(4);
 
     expect(tabs.at(0).text()).toEqual('Account Information');
     expect(tabs.at(1).text()).toEqual('Enrollments/Entitlements');
     expect(tabs.at(2).text()).toEqual('SSO/License Info');
+    expect(tabs.at(3).text()).toEqual('Learner Credentials');
   });
 
   it('Account Information Tab', () => {
@@ -69,6 +70,7 @@ describe('Learners and Enrollments component', () => {
     expect(tabs.at(0).html()).toEqual(expect.stringContaining('active'));
     expect(tabs.at(1).html()).not.toEqual(expect.stringContaining('active'));
     expect(tabs.at(2).html()).not.toEqual(expect.stringContaining('active'));
+    expect(tabs.at(3).html()).not.toEqual(expect.stringContaining('active'));
 
     const accountInfo = wrapper.find('.tab-content div#learner-information-tabpane-account');
     expect(accountInfo.html()).toEqual(expect.stringContaining('active'));
@@ -83,6 +85,7 @@ describe('Learners and Enrollments component', () => {
     expect(tabs.at(0).html()).not.toEqual(expect.stringContaining('active'));
     expect(tabs.at(1).html()).toEqual(expect.stringContaining('active'));
     expect(tabs.at(2).html()).not.toEqual(expect.stringContaining('active'));
+    expect(tabs.at(3).html()).not.toEqual(expect.stringContaining('active'));
 
     const enrollmentsEntitlements = wrapper.find('.tab-content div#learner-information-tabpane-enrollments-entitlements');
     expect(enrollmentsEntitlements.html()).toEqual(expect.stringContaining('active'));
@@ -90,7 +93,7 @@ describe('Learners and Enrollments component', () => {
     expect(enrollmentsEntitlements.html()).toEqual(expect.stringContaining('Enrollments (2)'));
   });
 
-  it('Enrollments/Entitlements Tab', () => {
+  it('SSO Tab', () => {
     let tabs = wrapper.find('nav.nav-tabs a');
 
     tabs.at(2).simulate('click');
@@ -98,10 +101,34 @@ describe('Learners and Enrollments component', () => {
     expect(tabs.at(0).html()).not.toEqual(expect.stringContaining('active'));
     expect(tabs.at(1).html()).not.toEqual(expect.stringContaining('active'));
     expect(tabs.at(2).html()).toEqual(expect.stringContaining('active'));
+    expect(tabs.at(3).html()).not.toEqual(expect.stringContaining('active'));
 
-    const enrollmentsEntitlements = wrapper.find('.tab-content div#learner-information-tabpane-sso');
-    expect(enrollmentsEntitlements.html()).toEqual(expect.stringContaining('active'));
-    expect(enrollmentsEntitlements.html()).toEqual(expect.stringContaining('Single Sign-on Records'));
-    expect(enrollmentsEntitlements.html()).toEqual(expect.stringContaining('Licenses Subscription'));
+    const ssoRecords = wrapper.find('.tab-content div#learner-information-tabpane-sso');
+    expect(ssoRecords.html()).toEqual(expect.stringContaining('active'));
+    expect(ssoRecords.html()).toEqual(
+      expect.stringContaining('Single Sign-on Records'),
+    );
+    expect(ssoRecords.html()).toEqual(
+      expect.stringContaining('Licenses Subscription'),
+    );
+  });
+
+  it('Learner Credentials Tab', () => {
+    let tabs = wrapper.find('nav.nav-tabs a');
+
+    tabs.at(3).simulate('click');
+    tabs = wrapper.find('nav.nav-tabs a');
+    expect(tabs.at(0).html()).not.toEqual(expect.stringContaining('active'));
+    expect(tabs.at(1).html()).not.toEqual(expect.stringContaining('active'));
+    expect(tabs.at(2).html()).not.toEqual(expect.stringContaining('active'));
+    expect(tabs.at(3).html()).toEqual(expect.stringContaining('active'));
+
+    const credentials = wrapper.find(
+      '.tab-content div#learner-information-tabpane-credentials',
+    );
+    expect(credentials.html()).toEqual(expect.stringContaining('active'));
+    expect(credentials.html()).toEqual(
+      expect.stringContaining('Learner Credentials'),
+    );
   });
 });

--- a/src/users/data/api.js
+++ b/src/users/data/api.js
@@ -641,3 +641,29 @@ export async function regenerateCertificate(username, courseKey) {
     };
   }
 }
+
+export async function getUserProgramCredentials(username, page = 1) {
+  try {
+    const { data } = await getAuthenticatedHttpClient().get(
+      `${AppUrls.getUserCredentialsUrl()}?username=${username}&type=program&page=${page}`,
+    );
+    if (data.next !== null) {
+      const nextPageData = await getUserProgramCredentials(username, page + 1);
+      data.results = data.results.concat(nextPageData.results);
+      return data;
+    }
+    return data;
+  } catch (error) {
+    return {
+      errors: [
+        {
+          code: null,
+          dismissible: true,
+          text: error.text ? error.text : 'There was an error retrieving credentials for the user',
+          type: 'danger',
+          topic: 'credentials',
+        },
+      ],
+    };
+  }
+}

--- a/src/users/data/test/credentials.js
+++ b/src/users/data/test/credentials.js
@@ -1,0 +1,35 @@
+export const credentials = {
+  count: 1,
+  next: null,
+  previous: null,
+  results: [
+    {
+      attributes: [
+        {
+          name: 'test_name',
+          value: 'test_value',
+        },
+      ],
+      certificate_url: 'http://localhost:18150/credentials/94315574b2754dc0ba98f1051a4c5dc5/',
+      created: '2022-04-07T00:47:12Z',
+      credential: {
+        type: 'program',
+        credential_id: 1,
+        program_uuid: '887d1d24-bc9f-11ec-8422-0242ac120002',
+      },
+      date_override: null,
+      download_url: null,
+      modified: '2022-04-18T02:39:29Z',
+      status: 'awarded',
+      username: 'edx',
+      uuid: '94315574-b275-4dc0-ba98-f1051a4c5dc5',
+    },
+  ],
+};
+
+export const noCredentials = {
+  count: 0,
+  next: null,
+  previous: null,
+  results: [],
+};

--- a/src/users/data/urls.js
+++ b/src/users/data/urls.js
@@ -1,7 +1,7 @@
 import { getConfig } from '@edx/frontend-platform';
 import { isEmail, isValidLMSUserID, isValidUsername } from '../../utils/index';
 
-const { LMS_BASE_URL } = getConfig();
+const { LMS_BASE_URL, CREDENTIALS_BASE_URL } = getConfig();
 
 export const getEnrollmentsUrl = username => `${
   LMS_BASE_URL
@@ -98,3 +98,5 @@ export const generateCertificateUrl = () => `${
 export const regenerateCertificateUrl = () => `${
   LMS_BASE_URL
 }/certificates/regenerate`;
+
+export const getUserCredentialsUrl = () => `${CREDENTIALS_BASE_URL}/api/v2/credentials`;


### PR DESCRIPTION
This PR introduces user credentials inside support tools including links to the program certificate links, currently only available in the Django Admin of the Credentials app.

Link to the ticket: [PROD-2569](https://openedx.atlassian.net/browse/PROD-2569) 

Testing methodology:

- Go to the credentials app and create a [user credential](http://localhost:18150/admin/credentials/usercredential/ )
- Now you can view the newly created credentials inside the learner's tab within [support tools](http://localhost:18450/learner_information)

Screenshots:
<img width="1479" alt="Screenshot 2022-05-30 at 10 29 35 AM" src="https://user-images.githubusercontent.com/56605828/170923103-570cc0b7-e04f-46cf-b24a-465adf121314.png">
<img width="1425" alt="Screenshot 2022-05-30 at 10 29 42 AM" src="https://user-images.githubusercontent.com/56605828/170923118-45a4cdf2-dd7c-48b8-8cbc-c14c93553541.png">

