### PR TITLE
fix: pdf cert url behavior

### DIFF
--- a/src/users/data/test/certificates.js
+++ b/src/users/data/test/certificates.js
@@ -17,3 +17,14 @@ export const regeneratableCertificate = {
   downloadUrl: null,
   regenerate: true,
 };
+
+export const pdfCertificate = {
+  courseKey: 'course-v1:testX+test123+2030',
+  type: 'verified',
+  status: 'passing',
+  is_pdf_certificate: true,
+  grade: '60',
+  modified: new Date('2020/01/01').toLocaleString(),
+  downloadUrl: 'https://www.example.com',
+  regenerate: true,
+};

--- a/src/users/enrollments/Certificates.jsx
+++ b/src/users/enrollments/Certificates.jsx
@@ -95,6 +95,17 @@ export default function Certificates({
     });
   }
 
+  /**
+   * For a pdf certificate, the download url is already a valid and complete Url.
+   * LMS base is only attached for non-pdf certificates.
+   */
+  function certificateDownloadUrl(certificateInfo) {
+    if (certificateInfo.isPdfCertificate) {
+      return certificateInfo.downloadUrl;
+    }
+    return `${getConfig().LMS_BASE_URL}${certificateInfo.downloadUrl}`;
+  }
+
   const certificateInfo = (
     <section ref={certificateRef}>
       {!certificate && !displayCertErrors && <PageLoading srMessage="Loading" /> }
@@ -134,7 +145,7 @@ export default function Certificates({
 
             <tr>
               <th>Download URL</th>
-              <td>{certificate.downloadUrl ? <a href={`${getConfig().LMS_BASE_URL}${certificate.downloadUrl}`}>Download</a> : 'Not Available'}</td>
+              <td>{certificate.downloadUrl ? <a href={certificateDownloadUrl(certificate)}>Download</a> : 'Not Available'}</td>
             </tr>
 
             <tr>

--- a/src/users/enrollments/Certificates.test.jsx
+++ b/src/users/enrollments/Certificates.test.jsx
@@ -1,9 +1,10 @@
 import { mount } from 'enzyme';
 import React from 'react';
+import { getConfig } from '@edx/frontend-platform';
 
 import { waitForComponentToPaint } from '../../setupTest';
 import Certificates from './Certificates';
-import { downloadableCertificate, regeneratableCertificate } from '../data/test/certificates';
+import { downloadableCertificate, pdfCertificate, regeneratableCertificate } from '../data/test/certificates';
 import UserMessagesProvider from '../../userMessages/UserMessagesProvider';
 import * as api from '../data/api';
 
@@ -98,6 +99,26 @@ describe('Certificate component', () => {
     const actionButton = action.find('button#regenerate-certificate');
     expect(action.find('th').text()).toEqual('Actions');
     expect(actionButton.text()).toEqual('Regenerate');
+  });
+
+  it('Pdf Certificate', async () => {
+    apiMock = jest.spyOn(api, 'getCertificate').mockImplementationOnce(() => Promise.resolve(pdfCertificate));
+    wrapper = mount(<CertificateWrapper {...props} />);
+    await waitForComponentToPaint(wrapper);
+
+    const dataRows = wrapper.find('table.certificate-info-table tbody tr');
+    expect(dataRows.length).toEqual(7);
+
+    expect(dataRows.at(0).html()).toEqual(expect.stringContaining(pdfCertificate.courseKey));
+
+    const downloadUrl = dataRows.at(5);
+    expect(downloadUrl.find('th').text()).toEqual('Download URL');
+    expect(downloadUrl.find('td').text()).toEqual('Download');
+
+    // Pdf certificate's download link does not have LMS base url
+    const downloadLink = downloadUrl.find('td').find('a').prop('href');
+    expect(downloadLink).not.toEqual(expect.stringContaining(`${getConfig().LMS_BASE_URL}`));
+    expect(downloadLink).toEqual('https://www.example.com');
   });
 
   it('Missing Certificate Data', async () => {


### PR DESCRIPTION
### [PROD-2736](https://2u-internal.atlassian.net/browse/PROD-2736)

### Description
The certificate component is appending LMS base url against download_url field of certificate data. However, the field download_url contains a complete url if the field is_pdf_certificate is true. This caused PDF download url to form incorrectly on support tools. This PR is fixing that behavior. Reference: https://github.com/openedx/edx-platform/blob/master/lms/djangoapps/certificates/api.py#L61

