### PR TITLE
feat: alert for private record

### DIFF
--- a/src/users/LearnerRecords.jsx
+++ b/src/users/LearnerRecords.jsx
@@ -63,13 +63,17 @@ function LearnerRecords({ username, intl }) {
                   <p>{renderStatus(record.program)}</p>
                   <p>{renderDate(record.program.last_updated)}</p>
                 </div>
-                {record.shared_program_record_uuid && (
+                {record.shared_program_record_uuid ? (
                   <Button
                     variant="primary"
                     onClick={() => handleCopyButton(record.shared_program_record_uuid.replaceAll('-', ''))}
                   >
                     {intl.formatMessage(messages.copyPublicRecordLinkButton)}
                   </Button>
+                ) : (
+                  <Alert variant="warning" className="no-public-link">
+                    {intl.formatMessage(messages.noPublicLink)}
+                  </Alert>
                 )}
               </div>
               <Table

--- a/src/users/LearnerRecords.test.jsx
+++ b/src/users/LearnerRecords.test.jsx
@@ -108,6 +108,20 @@ describe('Learner Records Tests', () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
   });
 
+  it('renders an alert when there is no public instance of a record', async () => {
+    const privateRecords = [...records];
+    privateRecords[0].record.shared_program_record_uuid = '';
+    apiMock = jest
+      .spyOn(api, 'getLearnerRecords')
+      .mockImplementationOnce(() => Promise.resolve(privateRecords));
+
+    wrapper = mount(<LearnerRecordsWrapper username={data.username} />);
+
+    await waitForComponentToPaint(wrapper);
+
+    expect(wrapper.find('div.no-public-link').text()).toEqual('There is no public instance for this record. Learners must create a public link on their own.');
+  });
+
   it('renders a table for a program record', async () => {
     apiMock = jest
       .spyOn(api, 'getLearnerRecords')

--- a/src/users/index.scss
+++ b/src/users/index.scss
@@ -9,3 +9,7 @@ button.neg-margin-top {
 a.word_break {
   word-break: break-word;
 }
+
+div.no-public-link {
+  max-width: 464px;
+}

--- a/src/users/messages.js
+++ b/src/users/messages.js
@@ -57,6 +57,10 @@ const messages = defineMessages({
     id: 'record.table.header.status',
     defaultMessage: 'Status',
   },
+  noPublicLink: {
+    id: 'no.public.record.link',
+    defaultMessage: 'There is no public instance for this record. Learners must create a public link on their own.',
+  },
   noRecordsFound: {
     id: 'no.records.found',
     defaultMessage: 'No results found for username',


### PR DESCRIPTION
This will add behavior that renders an alert when a record does not have a public link. This is in place of the "Copy public record link" button that would render if a public link exists for that record.

![public_record_alert](https://user-images.githubusercontent.com/92897870/196498665-b44c8701-9b64-4b27-9bfb-5de31913b19c.png)

![Screen Shot 2022-10-18 at 1 10 36 PM](https://user-images.githubusercontent.com/92897870/196498969-684ea40a-5358-4caf-beaa-bbaa28d30ac9.png)

