### PR TITLE
Migrate off Paragon Modal deprecation

### DIFF
--- a/src/overrides.scss
+++ b/src/overrides.scss
@@ -171,3 +171,6 @@ $darkCyan: #00262b;
 .inspector-name-row{
   border-bottom: 1px solid black;
 }
+.modal-title{
+  font-size: 1.9rem !important;
+  }

--- a/src/users/SingleSignOnRecordCard.jsx
+++ b/src/users/SingleSignOnRecordCard.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Card, Row, Col, Modal, Button,
+  Card, Row, Col, Button, ModalDialog, ActionRow,
 } from '@edx/paragon';
 import Table from '../components/Table';
 import { formatDate, formatUnixTimestamp } from '../utils';
@@ -61,22 +61,35 @@ export default function SingleSignOnRecordCard({ ssoRecord }) {
 
   return ssoRecord ? (
     <span>
-      <Modal
-        dialogClassName="modal-xl modal-dialog-centered"
-        open={showHistory}
-        title="SSO History"
-        body={(
-          <div>
-            <Table
-              styleName="sso-table"
-              id="sso-history-data-new"
-              data={ssoHistoryTableData}
-              columns={historyColumns}
-            />
-          </div>
-        )}
+      <ModalDialog
+        isOpen={showHistory}
         onClose={() => setShowHistory(false)}
-      />
+        hasCloseButton
+        dialogClassName="modal-xl modal-dialog-centered"
+      >
+        <ModalDialog.Header className="mb-3">
+          <ModalDialog.Title className="modal-title">
+            SSO History
+          </ModalDialog.Title>
+        </ModalDialog.Header>
+        <ModalDialog.Body>
+          <Table
+            styleName="sso-table"
+            id="sso-history-data-new"
+            data={ssoHistoryTableData}
+            columns={historyColumns}
+          />
+        </ModalDialog.Body>
+        <ModalDialog.Footer>
+          <ActionRow>
+            <ModalDialog.CloseButton
+              variant="link"
+            >
+              Close
+            </ModalDialog.CloseButton>
+          </ActionRow>
+        </ModalDialog.Footer>
+      </ModalDialog>
       <Card className="pt-2 px-3 mb-1 w-100">
         <Card.Body className="p-0">
           <Card.Title as="h3" className="btn-header mt-4">

--- a/src/users/SingleSignOnRecordCard.test.jsx
+++ b/src/users/SingleSignOnRecordCard.test.jsx
@@ -56,11 +56,10 @@ describe.each(ssoRecordsData)('Single Sign On Record Card', (ssoRecordData) => {
     expect(historyRow.text()).toEqual('History');
 
     historyRow.simulate('click');
-
-    let modal = wrapper.find('.modal-content');
+    let modal = wrapper.find('.pgn__modal-content-container');
     expect(modal.exists()).toBeTruthy();
-    expect(modal.find('.modal-title').text()).toEqual('SSO History');
-    expect(modal.find('.modal-footer button').text()).toEqual('Close');
+    expect(modal.find('.pgn__modal-title').text()).toEqual('SSO History');
+    expect(modal.find('.pgn__modal-footer button').text()).toEqual('Close');
 
     const dataHeader = modal.find('thead tr th');
     const { history } = ssoRecordProp;
@@ -81,9 +80,9 @@ describe.each(ssoRecordsData)('Single Sign On Record Card', (ssoRecordData) => {
         }
       });
     });
-    modal.find('.modal-footer button').simulate('click');
-    modal = wrapper.find('.modal-content');
-    expect(modal.prop('open')).not.toBeTruthy();
+    modal.find('.pgn__modal-footer button').simulate('click');
+    modal = wrapper.find('.pgn__modal-content-container');
+    expect(modal.exists()).not.toBeTruthy();
   });
 
   it('SSO Record Additional Data', () => {

--- a/src/users/VerifiedName.jsx
+++ b/src/users/VerifiedName.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { camelCaseObject } from '@edx/frontend-platform';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import {
-  Button, Modal, Hyperlink, OverlayTrigger, Popover,
+  Button, Hyperlink, OverlayTrigger, Popover, ModalDialog, ActionRow,
 } from '@edx/paragon';
 
 import PageLoading from '../components/common/PageLoading';
@@ -143,24 +143,39 @@ export default function VerifiedName({ username }) {
       </Hyperlink>
     ) : 'N/A',
   }], [verifiedNameData]);
-
   return (
     <div>
-      <Modal
-        open={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-        title="Verified Name History"
+      <ModalDialog
+        isOpen={isModalOpen}
+        size="lg"
+        onClose={() => { setIsModalOpen(false); }}
+        hasCloseButton
         id="verified-name-history"
-        dialogClassName="modal-xl modal-dialog-centered justify-content-center"
-        body={(
+        data-testid="history-modal"
+
+      >
+        <ModalDialog.Header className="mb-3">
+          <ModalDialog.Title className="modal-title">
+            Verified Name History
+          </ModalDialog.Title>
+        </ModalDialog.Header>
+        <ModalDialog.Body>
           <Table
             data={VerifiedNameHistoryTableData}
             columns={verifiedNameHistoryColumns}
             styleName="idv-table"
           />
-        )}
-        data-testid="history-modal"
-      />
+        </ModalDialog.Body>
+        <ModalDialog.Footer>
+          <ActionRow>
+            <ModalDialog.CloseButton
+              variant="link"
+            >
+              Cancel
+            </ModalDialog.CloseButton>
+          </ActionRow>
+        </ModalDialog.Footer>
+      </ModalDialog>
       <div className="flex-column p-4 m-3 card">
         <FormattedMessage
           id="supportTools.learnerInformation.verifiedNameHeader"

--- a/src/users/VerifiedName.jsx
+++ b/src/users/VerifiedName.jsx
@@ -171,7 +171,7 @@ export default function VerifiedName({ username }) {
             <ModalDialog.CloseButton
               variant="link"
             >
-              Cancel
+              Close
             </ModalDialog.CloseButton>
           </ActionRow>
         </ModalDialog.Footer>

--- a/src/users/account-actions/CancelRetirement.jsx
+++ b/src/users/account-actions/CancelRetirement.jsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-import { Modal, Button, Alert } from '@edx/paragon';
+import {
+  Button, Alert, ModalDialog, ActionRow,
+} from '@edx/paragon';
 import { postCancelRetirement } from '../data/api';
 
 export default function CancelRetirement({
@@ -50,25 +52,42 @@ export default function CancelRetirement({
         className="mr-1 mb-2"
       >Cancel Retirement
       </Button>
-
-      <Modal
-        open={cancelRetirementModalIsOpen}
-        id="user-account-cancel-retirement"
-        buttons={[errorMessage ? (<></>)
-          : (
-            <Button
-              variant="danger"
-              onClick={cancelRetirement}
-            >
-              Confirm
-            </Button>
-          ),
-        ]}
+      <ModalDialog
+        isOpen={cancelRetirementModalIsOpen}
         onClose={closeCancelRetirementModal}
-        dialogClassName="modal-lg modal-dialog-centered justify-content-center"
-        title="Cancel Retirement"
-        body={modalBody}
-      />
+        hasCloseButton
+        id="user-account-cancel-retirement"
+        size="lg"
+      >
+        <ModalDialog.Header className="mb-3">
+          <ModalDialog.Title className="modal-title">
+            Cancel Retirement
+          </ModalDialog.Title>
+        </ModalDialog.Header>
+        <ModalDialog.Body className="mb-3">
+          {modalBody}
+        </ModalDialog.Body>
+        <ModalDialog.Footer>
+          <ActionRow>
+            <ModalDialog.CloseButton
+              variant="link"
+            >
+              Close
+            </ModalDialog.CloseButton>
+            {
+              errorMessage ? (<></>)
+                : (
+                  <Button
+                    variant="danger"
+                    onClick={cancelRetirement}
+                  >
+                    Confirm
+                  </Button>
+                )
+}
+          </ActionRow>
+        </ModalDialog.Footer>
+      </ModalDialog>
     </div>
   );
 }

--- a/src/users/account-actions/CancelRetirement.test.jsx
+++ b/src/users/account-actions/CancelRetirement.test.jsx
@@ -35,16 +35,16 @@ describe('Cancel Retirement Component Tests', () => {
   it('Cancel Retirement Modal', async () => {
     const mockApiCall = jest.spyOn(api, 'postCancelRetirement').mockImplementationOnce(() => Promise.resolve({}));
     const cancelRetirementButton = wrapper.find('#cancel-retirement').hostNodes();
-    let cancelRetirementModal = wrapper.find('Modal#user-account-cancel-retirement');
+    let cancelRetirementModal = wrapper.find('ModalDialog#user-account-cancel-retirement');
 
-    expect(cancelRetirementModal.prop('open')).toEqual(false);
+    expect(cancelRetirementModal.prop('isOpen')).toEqual(false);
     expect(cancelRetirementButton.text()).toEqual('Cancel Retirement');
 
     cancelRetirementButton.simulate('click');
-    cancelRetirementModal = wrapper.find('Modal#user-account-cancel-retirement');
+    cancelRetirementModal = wrapper.find('ModalDialog#user-account-cancel-retirement');
 
-    expect(cancelRetirementModal.prop('open')).toEqual(true);
-    expect(cancelRetirementModal.prop('title')).toEqual('Cancel Retirement');
+    expect(cancelRetirementModal.prop('isOpen')).toEqual(true);
+    expect(cancelRetirementModal.find('h2.pgn__modal-title').text()).toEqual('Cancel Retirement');
     const confirmAlert = cancelRetirementModal.find('.alert-warning');
     expect(confirmAlert.text()).toEqual('This will cancel retirement for the requested user. Do you wish to proceed?');
 
@@ -52,8 +52,8 @@ describe('Cancel Retirement Component Tests', () => {
     await waitForComponentToPaint(wrapper);
     expect(changeHandler).toHaveBeenCalled();
     cancelRetirementModal.find('button.btn-link').simulate('click');
-    cancelRetirementModal = wrapper.find('Modal#user-account-cancel-retirement');
-    expect(cancelRetirementModal.prop('open')).toEqual(false);
+    cancelRetirementModal = wrapper.find('ModalDialog#user-account-cancel-retirement');
+    expect(cancelRetirementModal.prop('isOpen')).toEqual(false);
 
     mockApiCall.mockRestore();
   });
@@ -73,8 +73,8 @@ describe('Cancel Retirement Component Tests', () => {
     const mockApiCall = jest.spyOn(api, 'postCancelRetirement').mockImplementationOnce(() => Promise.resolve(cancelRetirementErrors));
     const cancelRetirementButton = wrapper.find('#cancel-retirement').hostNodes();
     cancelRetirementButton.simulate('click');
-    let cancelRetirementModal = wrapper.find('Modal#user-account-cancel-retirement');
-    expect(cancelRetirementModal.prop('open')).toEqual(true);
+    let cancelRetirementModal = wrapper.find('ModalDialog#user-account-cancel-retirement');
+    expect(cancelRetirementModal.prop('isOpen')).toEqual(true);
     const confirmAlert = cancelRetirementModal.find('.alert-warning');
     expect(confirmAlert.text()).toEqual(
       'This will cancel retirement for the requested user. Do you wish to proceed?',
@@ -82,13 +82,13 @@ describe('Cancel Retirement Component Tests', () => {
 
     cancelRetirementModal.find('button.btn-danger').hostNodes().simulate('click');
     await waitForComponentToPaint(wrapper);
-    cancelRetirementModal = wrapper.find('Modal#user-account-cancel-retirement');
+    cancelRetirementModal = wrapper.find('ModalDialog#user-account-cancel-retirement');
     const errorAlert = cancelRetirementModal.find('.alert-danger');
     expect(errorAlert.text()).toEqual('Retirement does not exist!');
 
     cancelRetirementModal.find('button.btn-link').simulate('click');
-    cancelRetirementModal = wrapper.find('Modal#user-account-cancel-retirement');
-    expect(cancelRetirementModal.prop('open')).toEqual(false);
+    cancelRetirementModal = wrapper.find('ModalDialog#user-account-cancel-retirement');
+    expect(cancelRetirementModal.prop('isOpen')).toEqual(false);
     mockApiCall.mockRestore();
   });
 
@@ -107,10 +107,10 @@ describe('Cancel Retirement Component Tests', () => {
     const mockApiCall = jest.spyOn(api, 'postCancelRetirement').mockImplementationOnce(() => Promise.resolve(cancelRetirementErrors));
     const cancelRetirementButton = wrapper.find('#cancel-retirement').hostNodes();
     cancelRetirementButton.simulate('click');
-    let cancelRetirementModal = wrapper.find('Modal#user-account-cancel-retirement');
+    let cancelRetirementModal = wrapper.find('ModalDialog#user-account-cancel-retirement');
     cancelRetirementModal.find('button.btn-danger').hostNodes().simulate('click');
     await waitForComponentToPaint(wrapper);
-    cancelRetirementModal = wrapper.find('Modal#user-account-cancel-retirement');
+    cancelRetirementModal = wrapper.find('ModalDialog#user-account-cancel-retirement');
     const errorAlert = cancelRetirementModal.find('.alert-danger');
     expect(errorAlert.text()).toEqual(
       'Something went wrong. Please try again later!',

--- a/src/users/account-actions/PasswordHistory.jsx
+++ b/src/users/account-actions/PasswordHistory.jsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Modal, Button, DataTable } from '@edx/paragon';
+import {
+  Button, DataTable, ModalDialog, ActionRow,
+} from '@edx/paragon';
 import { formatDate } from '../../utils';
 
 export default function PasswordHistory({
@@ -43,30 +45,45 @@ export default function PasswordHistory({
     <div>
 
       {passwordStatus.passwordToggleHistory.length > 0 && (
-      <Button
-        id="toggle-password-history"
-        variant="outline-primary"
-        onClick={() => openHistoryModal()}
-        className="mr-1 mb-2"
-      >
-        Show History
-      </Button>
+        <Button
+          id="toggle-password-history"
+          variant="outline-primary"
+          onClick={() => openHistoryModal()}
+          className="mr-1 mb-2"
+        >
+          Show History
+        </Button>
       )}
 
-      <Modal
-        open={passwordHistoryModalIsOpen}
+      <ModalDialog
+        isOpen={passwordHistoryModalIsOpen}
         onClose={() => setPasswordHistoryModalIsOpen(false)}
-        title="Enable/Disable History"
+        hasCloseButton
         id="password-history"
-        dialogClassName="modal-xl"
-        body={(
+        size="xl"
+      >
+        <ModalDialog.Header className="mb-3">
+          <ModalDialog.Title className="modal-title">
+            Enable/Disable History
+          </ModalDialog.Title>
+        </ModalDialog.Header>
+        <ModalDialog.Body className="mb-3">
           <DataTable
             data={passwordHistoryData}
             columns={userPasswordHistoryColumns}
             itemCount={passwordHistoryData.length}
           />
-          )}
-      />
+        </ModalDialog.Body>
+        <ModalDialog.Footer>
+          <ActionRow>
+            <ModalDialog.CloseButton
+              variant="link"
+            >
+              Close
+            </ModalDialog.CloseButton>
+          </ActionRow>
+        </ModalDialog.Footer>
+      </ModalDialog>
     </div>
   );
 }

--- a/src/users/account-actions/PasswordHistory.test.jsx
+++ b/src/users/account-actions/PasswordHistory.test.jsx
@@ -20,20 +20,20 @@ describe('Password History Component Tests', () => {
 
   it('Password History Modal', () => {
     const passwordHistoryButton = wrapper.find('button#toggle-password-history');
-    let historyModal = wrapper.find('Modal#password-history');
+    let historyModal = wrapper.find('ModalDialog#password-history');
 
-    expect(historyModal.prop('open')).toEqual(false);
+    expect(historyModal.prop('isOpen')).toEqual(false);
     expect(passwordHistoryButton.text()).toEqual('Show History');
     expect(passwordHistoryButton.disabled).toBeFalsy();
 
     passwordHistoryButton.simulate('click');
-    historyModal = wrapper.find('Modal#password-history');
+    historyModal = wrapper.find('ModalDialog#password-history');
 
-    expect(historyModal.prop('open')).toEqual(true);
+    expect(historyModal.prop('isOpen')).toEqual(true);
     expect(historyModal.find('table tbody tr')).toHaveLength(2);
 
     historyModal.find('button.btn-link').simulate('click');
-    historyModal = wrapper.find('Modal#password-history');
-    expect(historyModal.prop('open')).toEqual(false);
+    historyModal = wrapper.find('ModalDialog#password-history');
+    expect(historyModal.prop('isOpen')).toEqual(false);
   });
 });

--- a/src/users/account-actions/ResetPassword.jsx
+++ b/src/users/account-actions/ResetPassword.jsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-import { Modal, Button, Alert } from '@edx/paragon';
+import {
+  Button, Alert, ModalDialog, ActionRow,
+} from '@edx/paragon';
 import { postResetPassword } from '../data/api';
 
 export default function ResetPassword({
@@ -53,25 +55,40 @@ export default function ResetPassword({
         className="mr-1 mb-2"
       >Reset Password
       </Button>
-
-      <Modal
-        open={resetPasswordModalIsOpen}
-        id="user-account-reset-password"
-        buttons={[errorMessage ? (<></>)
-          : (
-            <Button
-              variant="danger"
-              onClick={resetPassword}
-            >
-              Confirm
-            </Button>
-          ),
-        ]}
+      <ModalDialog
+        isOpen={resetPasswordModalIsOpen}
         onClose={closeResetPasswordModal}
-        dialogClassName="modal-lg modal-dialog-centered justify-content-center"
-        title="Reset Password"
-        body={modalBody}
-      />
+        hasCloseButton
+        id="user-account-reset-password"
+        size="lg"
+      >
+        <ModalDialog.Header className="mb-3 mt-1">
+          <ModalDialog.Title className="modal-title">
+            Reset Password
+          </ModalDialog.Title>
+        </ModalDialog.Header>
+        <ModalDialog.Body className="mb-3">
+          {modalBody}
+        </ModalDialog.Body>
+        <ModalDialog.Footer>
+          <ActionRow>
+            <ModalDialog.CloseButton
+              variant="link"
+            >
+              Close
+            </ModalDialog.CloseButton>
+            {errorMessage ? (<></>)
+              : (
+                <Button
+                  variant="danger"
+                  onClick={resetPassword}
+                >
+                  Confirm
+                </Button>
+              )}
+          </ActionRow>
+        </ModalDialog.Footer>
+      </ModalDialog>
     </div>
   );
 }

--- a/src/users/account-actions/ResetPassword.test.jsx
+++ b/src/users/account-actions/ResetPassword.test.jsx
@@ -35,16 +35,16 @@ describe('Reset Password Component Tests', () => {
   it('Reset Password Modal', async () => {
     const mockApiCall = jest.spyOn(api, 'postResetPassword').mockImplementationOnce(() => Promise.resolve({}));
     const passwordResetButton = wrapper.find('#reset-password').hostNodes();
-    let resetPasswordModal = wrapper.find('Modal#user-account-reset-password');
+    let resetPasswordModal = wrapper.find('ModalDialog#user-account-reset-password');
 
-    expect(resetPasswordModal.prop('open')).toEqual(false);
+    expect(resetPasswordModal.prop('isOpen')).toEqual(false);
     expect(passwordResetButton.text()).toEqual('Reset Password');
 
     passwordResetButton.simulate('click');
-    resetPasswordModal = wrapper.find('Modal#user-account-reset-password');
+    resetPasswordModal = wrapper.find('ModalDialog#user-account-reset-password');
 
-    expect(resetPasswordModal.prop('open')).toEqual(true);
-    expect(resetPasswordModal.prop('title')).toEqual('Reset Password');
+    expect(resetPasswordModal.prop('isOpen')).toEqual(true);
+    expect(resetPasswordModal.find('h2.pgn__modal-title').text()).toEqual('Reset Password');
     const confirmAlert = resetPasswordModal.find('.alert-warning');
     expect(confirmAlert.text()).toEqual(
       'We will send a message with password recovery instructions to the email address edx@example.com. Do you wish to proceed?',
@@ -53,8 +53,8 @@ describe('Reset Password Component Tests', () => {
     await waitForComponentToPaint(wrapper);
     expect(UserSummaryData.changeHandler).toHaveBeenCalled();
     resetPasswordModal.find('button.btn-link').simulate('click');
-    resetPasswordModal = wrapper.find('Modal#user-account-reset-password');
-    expect(resetPasswordModal.prop('open')).toEqual(false);
+    resetPasswordModal = wrapper.find('ModalDialog#user-account-reset-password');
+    expect(resetPasswordModal.prop('isOpen')).toEqual(false);
 
     mockApiCall.mockRestore();
   });
@@ -74,8 +74,8 @@ describe('Reset Password Component Tests', () => {
     const mockApiCall = jest.spyOn(api, 'postResetPassword').mockImplementationOnce(() => Promise.resolve(resetPasswordErrors));
     const passwordResetButton = wrapper.find('#reset-password').hostNodes();
     passwordResetButton.simulate('click');
-    let resetPasswordModal = wrapper.find('Modal#user-account-reset-password');
-    expect(resetPasswordModal.prop('open')).toEqual(true);
+    let resetPasswordModal = wrapper.find('ModalDialog#user-account-reset-password');
+    expect(resetPasswordModal.prop('isOpen')).toEqual(true);
     const confirmAlert = resetPasswordModal.find('.alert-warning');
     expect(confirmAlert.text()).toEqual(
       'We will send a message with password recovery instructions to the email address edx@example.com. Do you wish to proceed?',
@@ -83,14 +83,14 @@ describe('Reset Password Component Tests', () => {
 
     resetPasswordModal.find('button.btn-danger').hostNodes().simulate('click');
     await waitForComponentToPaint(wrapper);
-    resetPasswordModal = wrapper.find('Modal#user-account-reset-password');
+    resetPasswordModal = wrapper.find('ModalDialog#user-account-reset-password');
     const errorAlert = resetPasswordModal.find('.alert-danger');
     expect(errorAlert.text()).toEqual(
       'Your previous request is in progress, please try again in a few moments',
     );
     resetPasswordModal.find('button.btn-link').simulate('click');
-    resetPasswordModal = wrapper.find('Modal#user-account-reset-password');
-    expect(resetPasswordModal.prop('open')).toEqual(false);
+    resetPasswordModal = wrapper.find('ModalDialog#user-account-reset-password');
+    expect(resetPasswordModal.prop('isOpen')).toEqual(false);
     mockApiCall.mockRestore();
   });
 
@@ -109,10 +109,10 @@ describe('Reset Password Component Tests', () => {
     const mockApiCall = jest.spyOn(api, 'postResetPassword').mockImplementationOnce(() => Promise.resolve(resetPasswordErrors));
     const passwordResetButton = wrapper.find('#reset-password').hostNodes();
     passwordResetButton.simulate('click');
-    let resetPasswordModal = wrapper.find('Modal#user-account-reset-password');
+    let resetPasswordModal = wrapper.find('ModalDialog#user-account-reset-password');
     resetPasswordModal.find('button.btn-danger').hostNodes().simulate('click');
     await waitForComponentToPaint(wrapper);
-    resetPasswordModal = wrapper.find('Modal#user-account-reset-password');
+    resetPasswordModal = wrapper.find('ModalDialog#user-account-reset-password');
     const errorAlert = resetPasswordModal.find('.alert-danger');
     expect(errorAlert.text()).toEqual(
       'Something went wrong. Please try again later!',

--- a/src/users/account-actions/TogglePasswordStatus.jsx
+++ b/src/users/account-actions/TogglePasswordStatus.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Modal, Button, Input, Alert,
+  Button, Input, Alert, ModalDialog, ActionRow,
 } from '@edx/paragon';
 import { postTogglePasswordStatus } from '../data/api';
 
@@ -33,21 +33,18 @@ export default function TogglePasswordStatus({
       >
         {passwordStatus.status === PASSWORD_STATUS.USABLE ? DISABLE_USER : ENABLE_USER}
       </Button>
-      <Modal
-        open={disableUserModalIsOpen}
-        id="user-account-status-toggle"
-        dialogClassName="modal-lg modal-dialog-centered justify-content-center"
-        buttons={[
-          <Button
-            variant="danger"
-            onClick={togglePasswordStatus}
-          >
-            Confirm
-          </Button>,
-        ]}
+      <ModalDialog
+        isOpen={disableUserModalIsOpen}
         onClose={() => setDisableUserModalIsOpen(false)}
-        title={`${passwordStatus.status === PASSWORD_STATUS.USABLE ? DISABLE_USER_CONFIRMATION : ENABLE_USER_CONFIRMATION}`}
-        body={(
+        hasCloseButton
+        id="user-account-status-toggle"
+      >
+        <ModalDialog.Header className="mb-3 mt-1 ">
+          <ModalDialog.Title className="modal-title">
+            {`${passwordStatus.status === PASSWORD_STATUS.USABLE ? DISABLE_USER_CONFIRMATION : ENABLE_USER_CONFIRMATION}`}
+          </ModalDialog.Title>
+        </ModalDialog.Header>
+        <ModalDialog.Body className="mb-3">
           <div>
             <Alert variant="warning">
               <p>
@@ -62,8 +59,23 @@ export default function TogglePasswordStatus({
               onChange={(event) => setComment(event.target.value)}
             />
           </div>
-          )}
-      />
+        </ModalDialog.Body>
+        <ModalDialog.Footer>
+          <ActionRow>
+            <ModalDialog.CloseButton
+              variant="link"
+            >
+              Close
+            </ModalDialog.CloseButton>
+            <Button
+              variant="danger"
+              onClick={togglePasswordStatus}
+            >
+              Confirm
+            </Button>
+          </ActionRow>
+        </ModalDialog.Footer>
+      </ModalDialog>
     </div>
   );
 }

--- a/src/users/account-actions/TogglePasswordStatus.test.jsx
+++ b/src/users/account-actions/TogglePasswordStatus.test.jsx
@@ -31,17 +31,17 @@ describe('Toggle Password Status Component Tests', () => {
     it('Disable User Modal', async () => {
       const mockApiCall = jest.spyOn(api, 'postTogglePasswordStatus').mockImplementationOnce(() => Promise.resolve());
       const passwordActionButton = wrapper.find('#toggle-password').hostNodes();
-      let disableDialogModal = wrapper.find('Modal#user-account-status-toggle');
+      let disableDialogModal = wrapper.find('ModalDialog#user-account-status-toggle');
 
-      expect(disableDialogModal.prop('open')).toEqual(false);
+      expect(disableDialogModal.prop('isOpen')).toEqual(false);
       expect(passwordActionButton.text()).toEqual('Disable User');
       expect(passwordActionButton.disabled).toBeFalsy();
 
       passwordActionButton.simulate('click');
-      disableDialogModal = wrapper.find('Modal#user-account-status-toggle');
+      disableDialogModal = wrapper.find('ModalDialog#user-account-status-toggle');
 
-      expect(disableDialogModal.prop('open')).toEqual(true);
-      expect(disableDialogModal.prop('title')).toEqual('Disable user confirmation');
+      expect(disableDialogModal.prop('isOpen')).toEqual(true);
+      expect(disableDialogModal.find('h2.pgn__modal-title').text()).toEqual('Disable user confirmation');
       expect(disableDialogModal.find('.alert-warning').text()).toEqual(
         'Please provide the reason for disabling the user edx.',
       );
@@ -50,8 +50,8 @@ describe('Toggle Password Status Component Tests', () => {
 
       await waitFor(() => expect(UserSummaryData.changeHandler).toHaveBeenCalledTimes(1));
       disableDialogModal.find('button.btn-link').simulate('click');
-      disableDialogModal = wrapper.find('Modal#user-account-status-toggle');
-      expect(disableDialogModal.prop('open')).toEqual(false);
+      disableDialogModal = wrapper.find('ModalDialog#user-account-status-toggle');
+      expect(disableDialogModal.prop('isOpen')).toEqual(false);
       mockApiCall.mockRestore();
     });
   });
@@ -76,17 +76,17 @@ describe('Toggle Password Status Component Tests', () => {
     it('Enable User Modal', async () => {
       const mockApiCall = jest.spyOn(api, 'postTogglePasswordStatus').mockImplementationOnce(() => Promise.resolve());
       const passwordActionButton = wrapper.find('#toggle-password').hostNodes();
-      let enableUserModal = wrapper.find('Modal#user-account-status-toggle');
+      let enableUserModal = wrapper.find('ModalDialog#user-account-status-toggle');
 
-      expect(enableUserModal.prop('open')).toEqual(false);
+      expect(enableUserModal.prop('isOpen')).toEqual(false);
       expect(passwordActionButton.text()).toEqual('Enable User');
       expect(passwordActionButton.disabled).toBeFalsy();
 
       passwordActionButton.simulate('click');
-      enableUserModal = wrapper.find('Modal#user-account-status-toggle');
+      enableUserModal = wrapper.find('ModalDialog#user-account-status-toggle');
 
-      expect(enableUserModal.prop('open')).toEqual(true);
-      expect(enableUserModal.prop('title')).toEqual('Enable user confirmation');
+      expect(enableUserModal.prop('isOpen')).toEqual(true);
+      expect(enableUserModal.find('h2.pgn__modal-title').text()).toEqual('Enable user confirmation');
       expect(enableUserModal.find('.alert-warning').text()).toEqual(
         'Please provide the reason for enabling the user edx.',
       );

--- a/src/users/courseSummary/CourseSummary.jsx
+++ b/src/users/courseSummary/CourseSummary.jsx
@@ -8,7 +8,7 @@ import React, {
 } from 'react';
 import { camelCaseObject } from '@edx/frontend-platform';
 import PropTypes from 'prop-types';
-import { Modal } from '@edx/paragon';
+import { ModalDialog, ActionRow } from '@edx/paragon';
 import PageLoading from '../../components/common/PageLoading';
 import { formatDate } from '../../utils';
 import UserMessagesContext from '../../userMessages/UserMessagesContext';
@@ -49,7 +49,7 @@ export default function CourseSummary({
     if (courseSummaryRef !== null) {
       courseSummaryRef.current.focus();
     }
-  });
+  }, []);
 
   const courseRunsColumn = useMemo(
     () => [
@@ -143,23 +143,39 @@ export default function CourseSummary({
   );
 
   return (
-    <Modal
-      open={modalIsOpen}
+    <ModalDialog
+      isOpen={modalIsOpen}
       onClose={() => {
         closeHandler();
         setModalIsOpen(false);
       }}
-      title={
-        courseSummaryData && !courseSummaryErrors
-          ? `Course Summary: ${courseSummaryData.title}`
-          : 'Course Summary'
-        }
+      hasCloseButton
       id="course-summary"
-      dialogClassName="modal-lg"
-      body={(
-        courseSummaryInfo
-      )}
-    />
+      size="lg"
+    >
+      <ModalDialog.Header className="mb-3">
+        <ModalDialog.Title className="mb-3">
+          {
+            courseSummaryData && !courseSummaryErrors
+              ? `Course Summary: ${courseSummaryData.title}`
+              : 'Course Summary'
+          }
+        </ModalDialog.Title>
+      </ModalDialog.Header>
+      <ModalDialog.Body ref={courseSummaryRef}>
+        {courseSummaryInfo}
+      </ModalDialog.Body>
+      <ModalDialog.Footer>
+        <ActionRow>
+          <ModalDialog.CloseButton
+            id="closeBtnTest"
+            variant="link"
+          >
+            Close
+          </ModalDialog.CloseButton>
+        </ActionRow>
+      </ModalDialog.Footer>
+    </ModalDialog>
   );
 }
 

--- a/src/users/courseSummary/CourseSummary.test.jsx
+++ b/src/users/courseSummary/CourseSummary.test.jsx
@@ -36,16 +36,16 @@ describe('Course Summary', () => {
     const dataRows = wrapper.find('table.course-summary-table tbody').first().children();
     expect(dataRows.length).toEqual(5);
 
-    let courseSummaryModal = wrapper.find('Modal#course-summary');
-    expect(courseSummaryModal.prop('open')).toEqual(true);
-    expect(courseSummaryModal.find('h2.modal-title').text()).toEqual('Course Summary: Test Course');
+    let courseSummaryModal = wrapper.find('ModalDialog#course-summary');
+    expect(courseSummaryModal.prop('isOpen')).toEqual(true);
+    expect(courseSummaryModal.find('h2.pgn__modal-title').text()).toEqual('Course Summary: Test Course');
 
     const courseRunsTable = wrapper.find('table.course-runs-table');
     expect(courseRunsTable.find('tbody tr').length).toEqual(2);
 
     wrapper.find('button.btn-link').simulate('click');
-    courseSummaryModal = wrapper.find('Modal#course-summary');
-    expect(courseSummaryModal.prop('open')).toEqual(false);
+    courseSummaryModal = wrapper.find('ModalDialog#course-summary');
+    expect(courseSummaryModal.prop('isOpen')).toEqual(false);
   });
 
   it('Missing Course Run Information', async () => {
@@ -79,8 +79,8 @@ describe('Course Summary', () => {
     wrapper = mount(<CourseSummaryWrapper {...props} />);
     await waitForComponentToPaint(wrapper);
 
-    const courseSummaryModal = wrapper.find('Modal#course-summary');
-    expect(courseSummaryModal.find('h2.modal-title').text()).toEqual('Course Summary');
+    const courseSummaryModal = wrapper.find('ModalDialog#course-summary');
+    expect(courseSummaryModal.find('h2.pgn__modal-title').text()).toEqual('Course Summary');
     const alert = wrapper.find('.alert');
     expect(alert.text()).toEqual('No Course Summary Data found');
   });

--- a/src/users/enrollments/Certificates.jsx
+++ b/src/users/enrollments/Certificates.jsx
@@ -7,7 +7,9 @@ import React, {
 } from 'react';
 import { camelCaseObject, getConfig } from '@edx/frontend-platform';
 import PropTypes from 'prop-types';
-import { Alert, Button, Modal } from '@edx/paragon';
+import {
+  ActionRow, Alert, Button, ModalDialog,
+} from '@edx/paragon';
 import PageLoading from '../../components/common/PageLoading';
 import { formatDate } from '../../utils';
 import { getCertificate, generateCertificate, regenerateCertificate } from '../data/api';
@@ -51,7 +53,7 @@ export default function Certificates({
     if (certificateRef != null) {
       certificateRef.current.focus();
     }
-  });
+  }, []);
 
   function usePrevious(value) {
     const ref = useRef();
@@ -186,19 +188,34 @@ export default function Certificates({
   );
 
   return (
-    <Modal
-      open={modalIsOpen}
+    <ModalDialog
+      isOpen={modalIsOpen}
       onClose={() => {
         closeHandler();
         setModalIsOpen(false);
       }}
-      title="Certificate"
+      hasCloseButton
       id="certificate"
-      dialogClassName="modal-lg"
-      body={(
-        certificateInfo
-    )}
-    />
+      size="lg"
+    >
+      <ModalDialog.Header className="mb-3">
+        <ModalDialog.Title className="modal-title">
+          Certificate
+        </ModalDialog.Title>
+      </ModalDialog.Header>
+      <ModalDialog.Body>
+        { certificateInfo}
+      </ModalDialog.Body>
+      <ModalDialog.Footer>
+        <ActionRow>
+          <ModalDialog.CloseButton
+            variant="link"
+          >
+            Close
+          </ModalDialog.CloseButton>
+        </ActionRow>
+      </ModalDialog.Footer>
+    </ModalDialog>
   );
 }
 

--- a/src/users/enrollments/Certificates.test.jsx
+++ b/src/users/enrollments/Certificates.test.jsx
@@ -22,7 +22,7 @@ describe('Certificate component', () => {
   const props = {
     username: testUser,
     courseId: testCourseId,
-    closeHandler: jest.fn(() => {}),
+    closeHandler: jest.fn(() => { }),
   };
 
   afterEach(() => {
@@ -37,12 +37,11 @@ describe('Certificate component', () => {
     const dataRows = wrapper.find('table.certificate-info-table tbody tr');
     expect(dataRows.length).toEqual(7);
 
-    let certificateModal = wrapper.find('Modal#certificate');
-    expect(certificateModal.prop('open')).toEqual(true);
-
+    let certificateModal = wrapper.find('ModalDialog#certificate');
+    expect(certificateModal.prop('isOpen')).toEqual(true);
     wrapper.find('button.btn-link').simulate('click');
-    certificateModal = wrapper.find('Modal#certificate');
-    expect(certificateModal.prop('open')).toEqual(false);
+    certificateModal = wrapper.find('ModalDialog#certificate');
+    expect(certificateModal.prop('isOpen')).toEqual(false);
   });
 
   it('Downloadable Certificate', async () => {

--- a/src/users/enrollments/ChangeEnrollmentForm.jsx
+++ b/src/users/enrollments/ChangeEnrollmentForm.jsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Button, Input, InputSelect, Modal,
+  ActionRow,
+  Button, Input, InputSelect, ModalDialog,
 } from '@edx/paragon';
 import AlertList from '../../userMessages/AlertList';
 import { patchEnrollment } from '../data/api';
@@ -133,35 +134,48 @@ export default function ChangeEnrollmentForm({
   );
 
   return (
-    <Modal
-      open={modalIsOpen}
+    <ModalDialog
+      isOpen={modalIsOpen}
       onClose={() => {
         setModalIsOpen(false);
         closeHandler(false);
         clear('changeEnrollments');
       }}
-      title="Change Enrollment"
+      hasCloseButton
       id="change-enrollment"
-      dialogClassName="modal-lg"
-      body={(
-        changeEnrollmentForm
-      )}
-      buttons={[
-        showLoader
-          ? (<div className="spinner-border text-primary" role="status" />)
-          : (
-            <Button
-              variant="primary"
-              disabled={!(mode && reason)}
-              className="mr-3"
-              onClick={submit}
-              hidden={hideOnSubmit}
-            >
-              Submit
-            </Button>
-          ),
-      ]}
-    />
+      size="lg"
+    >
+      <ModalDialog.Header className="mb-2">
+        <ModalDialog.Title className="modal-title">
+          Change Enrollment
+        </ModalDialog.Title>
+      </ModalDialog.Header>
+      <ModalDialog.Body>
+        {changeEnrollmentForm}
+      </ModalDialog.Body>
+      <ModalDialog.Footer>
+        <ActionRow>
+          <ModalDialog.CloseButton
+            variant="link"
+          >
+            Close
+          </ModalDialog.CloseButton>
+          {showLoader
+            ? (<div className="spinner-border text-primary" role="status" />)
+            : (
+              <Button
+                variant="primary"
+                disabled={!(mode && reason)}
+                className="mr-3"
+                onClick={submit}
+                hidden={hideOnSubmit}
+              >
+                Submit
+              </Button>
+            )},
+        </ActionRow>
+      </ModalDialog.Footer>
+    </ModalDialog>
   );
 }
 

--- a/src/users/enrollments/ChangeEnrollmentForm.test.jsx
+++ b/src/users/enrollments/ChangeEnrollmentForm.test.jsx
@@ -25,8 +25,8 @@ describe('Enrollment Change form', () => {
   });
 
   it('Default form rendering', () => {
-    let changeFormModal = wrapper.find('Modal#change-enrollment');
-    expect(changeFormModal.prop('open')).toEqual(true);
+    let changeFormModal = wrapper.find('ModalDialog#change-enrollment');
+    expect(changeFormModal.prop('isOpen')).toEqual(true);
     const modeSelectionDropdown = wrapper.find('select#mode');
     const modeChangeReasonDropdown = wrapper.find('select#reason');
     const commentsTextarea = wrapper.find('textarea#comments');
@@ -35,8 +35,8 @@ describe('Enrollment Change form', () => {
     expect(commentsTextarea.text()).toEqual('');
 
     wrapper.find('button.btn-link').simulate('click');
-    changeFormModal = wrapper.find('Modal#change-enrollment');
-    expect(changeFormModal.prop('open')).toEqual(false);
+    changeFormModal = wrapper.find('ModalDialog#change-enrollment');
+    expect(changeFormModal.prop('isOpen')).toEqual(false);
   });
 
   describe('Form submission', () => {

--- a/src/users/enrollments/CreateEnrollmentForm.jsx
+++ b/src/users/enrollments/CreateEnrollmentForm.jsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Button, Input, InputSelect, Modal,
+  ActionRow,
+  Button, Input, InputSelect, ModalDialog,
 } from '@edx/paragon';
 
 import AlertList from '../../userMessages/AlertList';
@@ -93,34 +94,47 @@ export default function CreateEnrollmentForm({
   );
 
   return (
-    <Modal
-      open={modalIsOpen}
+    <ModalDialog
+      isOpen={modalIsOpen}
       onClose={() => {
         closeHandler(false);
         setModalIsOpen(false);
         clear('createEnrollments');
       }}
-      title="Create New Enrollment"
+      hasCloseButton
       id="create-enrollment"
-      dialogClassName="modal-lg"
-      body={(
-        createEnrollmentForm
-      )}
-      buttons={[
-        showLoader
-          ? (<div className="spinner-border text-primary" role="status" />)
-          : (
-            <Button
-              variant="primary"
-              disabled={!(courseID && reason)}
-              className="mr-3"
-              onClick={submit}
-            >
-              Submit
-            </Button>
-          ),
-      ]}
-    />
+      size="lg"
+    >
+      <ModalDialog.Header className="mb-3">
+        <ModalDialog.Title className="modal-title">
+          Create New Enrollment
+        </ModalDialog.Title>
+      </ModalDialog.Header>
+      <ModalDialog.Body>
+        {createEnrollmentForm}
+      </ModalDialog.Body>
+      <ModalDialog.Footer>
+        <ActionRow>
+          <ModalDialog.CloseButton
+            variant="link"
+          >
+            Close
+          </ModalDialog.CloseButton>
+          {showLoader
+            ? (<div className="spinner-border text-primary" role="status" />)
+            : (
+              <Button
+                variant="primary"
+                disabled={!(courseID && reason)}
+                className="mr-3"
+                onClick={submit}
+              >
+                Submit
+              </Button>
+            )}
+        </ActionRow>
+      </ModalDialog.Footer>
+    </ModalDialog>
   );
 }
 

--- a/src/users/enrollments/CreateEnrollmentForm.test.jsx
+++ b/src/users/enrollments/CreateEnrollmentForm.test.jsx
@@ -25,8 +25,8 @@ describe('Enrollment Create form', () => {
   });
 
   it('Default form rendering', () => {
-    let createFormModal = wrapper.find('Modal#create-enrollment');
-    expect(createFormModal.prop('open')).toEqual(true);
+    let createFormModal = wrapper.find('ModalDialog#create-enrollment');
+    expect(createFormModal.prop('isOpen')).toEqual(true);
     const modeSelectionDropdown = wrapper.find('select#mode');
     const modeChangeReasonDropdown = wrapper.find('select#reason');
     const commentsTextarea = wrapper.find('textarea#comments');
@@ -35,8 +35,8 @@ describe('Enrollment Create form', () => {
     expect(commentsTextarea.text()).toEqual('');
 
     wrapper.find('button.btn-link').simulate('click');
-    createFormModal = wrapper.find('Modal#create-enrollment');
-    expect(createFormModal.prop('open')).toEqual(false);
+    createFormModal = wrapper.find('ModalDialog#create-enrollment');
+    expect(createFormModal.prop('isOpen')).toEqual(false);
   });
 
   describe('Form submission', () => {

--- a/src/users/enrollments/Enrollments.test.jsx
+++ b/src/users/enrollments/Enrollments.test.jsx
@@ -65,9 +65,9 @@ describe('Course Enrollments Listing', () => {
   it('Enrollment create form is rendered', () => {
     const createEnrollmentButton = wrapper.find('button#create-enrollment-button');
     createEnrollmentButton.simulate('click');
-    const createFormModal = wrapper.find('Modal#create-enrollment');
+    const createFormModal = wrapper.find('ModalDialog#create-enrollment');
     expect(createFormModal.html()).toEqual(expect.stringContaining('Create New Enrollment'));
-    expect(createFormModal.prop('open')).toEqual(true);
+    expect(createFormModal.prop('isOpen')).toEqual(true);
 
     createFormModal.find('button.btn-link').simulate('click');
     expect(wrapper.find('CreateEnrollmentForm')).toEqual({});
@@ -80,9 +80,9 @@ describe('Course Enrollments Listing', () => {
     dataRow = wrapper.find('table tbody tr').at(0);
     dataRow.find('.dropdown-menu.show a').at(0).simulate('click');
 
-    const changeFormModal = wrapper.find('Modal#change-enrollment');
+    const changeFormModal = wrapper.find('ModalDialog#change-enrollment');
     expect(changeFormModal.html()).toEqual(expect.stringContaining(courseId));
-    expect(changeFormModal.prop('open')).toEqual(true);
+    expect(changeFormModal.prop('isOpen')).toEqual(true);
 
     changeFormModal.find('button.btn-link').simulate('click');
     expect(wrapper.find('changeEnrollmentForm')).toEqual({});

--- a/src/users/entitlements/CreateEntitlementForm.jsx
+++ b/src/users/entitlements/CreateEntitlementForm.jsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Button, Input, Modal,
+  ActionRow,
+  Button, Input, ModalDialog,
 } from '@edx/paragon';
 
 import UserMessagesContext from '../../userMessages/UserMessagesContext';
@@ -95,34 +96,47 @@ export default function CreateEntitlementForm({
   );
 
   return (
-    <Modal
-      open={modalIsOpen}
+    <ModalDialog
+      isOpen={modalIsOpen}
       onClose={() => {
         closeHandler(false);
         setModalIsOpen(false);
         clear('createEntitlement');
       }}
-      title="Create New Entitlement"
+      hasCloseButton
       id="create-entitlement"
-      dialogClassName="modal-lg"
-      body={(
-        createEntitlementForm
-      )}
-      buttons={[
-        showLoader
-          ? (<div className="spinner-border text-primary" role="status" />)
-          : (
-            <Button
-              variant="primary"
-              disabled={!(courseUuid && mode && comments)}
-              className="mr-3"
-              onClick={submit}
-            >
-              Submit
-            </Button>
-          ),
-      ]}
-    />
+      size="lg"
+    >
+      <ModalDialog.Header className="mb-3">
+        <ModalDialog.Title className="modal-title">
+          Create New Entitlement
+        </ModalDialog.Title>
+      </ModalDialog.Header>
+      <ModalDialog.Body>
+        { createEntitlementForm}
+      </ModalDialog.Body>
+      <ModalDialog.Footer>
+        <ActionRow>
+          <ModalDialog.CloseButton
+            variant="link"
+          >
+            Close
+          </ModalDialog.CloseButton>
+          { showLoader
+            ? (<div className="spinner-border text-primary" role="status" />)
+            : (
+              <Button
+                variant="primary"
+                disabled={!(courseUuid && mode && comments)}
+                className="mr-3"
+                onClick={submit}
+              >
+                Submit
+              </Button>
+            )}
+        </ActionRow>
+      </ModalDialog.Footer>
+    </ModalDialog>
   );
 }
 

--- a/src/users/entitlements/CreateEntitlementForm.test.jsx
+++ b/src/users/entitlements/CreateEntitlementForm.test.jsx
@@ -25,8 +25,8 @@ describe('Create Entitlement Form', () => {
   });
 
   it('Default form render', () => {
-    let createFormModal = wrapper.find('Modal#create-entitlement');
-    expect(createFormModal.prop('open')).toEqual(true);
+    let createFormModal = wrapper.find('ModalDialog#create-entitlement');
+    expect(createFormModal.prop('isOpen')).toEqual(true);
     const courseUuidInput = wrapper.find('input#courseUuid');
     const modeSelectDropdown = wrapper.find('select#mode');
     const commentsTextArea = wrapper.find('textarea#comments');
@@ -35,8 +35,8 @@ describe('Create Entitlement Form', () => {
     expect(commentsTextArea.text()).toEqual('');
 
     wrapper.find('button.btn-link').simulate('click');
-    createFormModal = wrapper.find('Modal#create-entitlement');
-    expect(createFormModal.prop('open')).toEqual(false);
+    createFormModal = wrapper.find('ModalDialog#create-entitlement');
+    expect(createFormModal.prop('isOpen')).toEqual(false);
   });
 
   describe('Form Submission', () => {

--- a/src/users/entitlements/Entitlements.jsx
+++ b/src/users/entitlements/Entitlements.jsx
@@ -140,7 +140,7 @@ export default function Entitlements({
     if (formType != null) {
       formRef.current.focus();
     }
-  });
+  }, []);
 
   const expandAllRowsHandler = ({ getToggleAllRowsExpandedProps, isAllRowsExpanded }) => (
     <a {...getToggleAllRowsExpandedProps()} className="link-primary">

--- a/src/users/entitlements/Entitlements.test.jsx
+++ b/src/users/entitlements/Entitlements.test.jsx
@@ -39,12 +39,12 @@ describe('Entitlements Listing', () => {
     expect(entitlementButton.prop('disabled')).toBeFalsy();
     entitlementButton.simulate('click');
 
-    let createFormModal = wrapper.find('Modal#create-entitlement');
-    expect(createFormModal.prop('open')).toEqual(true);
+    let createFormModal = wrapper.find('ModalDialog#create-entitlement');
+    expect(createFormModal.prop('isOpen')).toEqual(true);
     expect(createFormModal.html()).toEqual(expect.stringContaining('Create New Entitlement'));
     wrapper.find('button.btn-link').simulate('click');
-    createFormModal = wrapper.find('Modal#create-entitlement');
-    expect(createFormModal.prop('open')).toEqual(false);
+    createFormModal = wrapper.find('ModalDialog#create-entitlement');
+    expect(createFormModal.prop('isOpen')).toEqual(false);
   });
 
   it('entitlements data', () => {
@@ -131,12 +131,12 @@ describe('Entitlements Listing', () => {
       expect(expireOption.html()).not.toEqual(expect.stringContaining('disabled'));
       expireOption.simulate('click');
 
-      let expireFormModal = wrapper.find('Modal#expire-entitlement');
-      expect(expireFormModal.prop('open')).toEqual(true);
+      let expireFormModal = wrapper.find('ModalDialog#expire-entitlement');
+      expect(expireFormModal.prop('isOpen')).toEqual(true);
       expect(expireFormModal.html()).toEqual(expect.stringContaining('Expire Entitlement'));
       wrapper.find('button.btn-link').simulate('click');
-      expireFormModal = wrapper.find('Modal#expire-entitlement');
-      expect(expireFormModal.prop('open')).toEqual(false);
+      expireFormModal = wrapper.find('ModalDialog#expire-entitlement');
+      expect(expireFormModal.prop('isOpen')).toEqual(false);
     });
   });
 
@@ -152,12 +152,12 @@ describe('Entitlements Listing', () => {
       expect(expireOption.html()).not.toEqual(expect.stringContaining('disabled'));
       expireOption.simulate('click');
 
-      let reissueFormModal = wrapper.find('Modal#reissue-entitlement');
-      expect(reissueFormModal.prop('open')).toEqual(true);
+      let reissueFormModal = wrapper.find('ModalDialog#reissue-entitlement');
+      expect(reissueFormModal.prop('isOpen')).toEqual(true);
       expect(reissueFormModal.html()).toEqual(expect.stringContaining('Reissue Entitlement'));
       wrapper.find('button.btn-link').simulate('click');
-      reissueFormModal = wrapper.find('Modal#reissue-entitlement');
-      expect(reissueFormModal.prop('open')).toEqual(false);
+      reissueFormModal = wrapper.find('ModalDialog#reissue-entitlement');
+      expect(reissueFormModal.prop('isOpen')).toEqual(false);
     });
 
     it('Disabled Reissue entitlement button', async () => {

--- a/src/users/entitlements/ExpireEntitlementForm.jsx
+++ b/src/users/entitlements/ExpireEntitlementForm.jsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Button, Input, Modal,
+  ActionRow,
+  Button, Input, ModalDialog,
 } from '@edx/paragon';
 
 import UserMessagesContext from '../../userMessages/UserMessagesContext';
@@ -90,35 +91,48 @@ export default function ExpireEntitlementForm({
   );
 
   return (
-    <Modal
-      open={modalIsOpen}
+    <ModalDialog
+      isOpen={modalIsOpen}
       onClose={() => {
         closeHandler(false);
         setModalIsOpen(false);
         clear('expireEntitlement');
       }}
-      title="Expire Entitlement"
+      hasCloseButton
       id="expire-entitlement"
-      dialogClassName="modal-lg"
-      body={(
-        expireEntitlementForm
-      )}
-      buttons={[
-        showLoader
-          ? (<div className="spinner-border text-primary" role="status" />)
-          : (
-            <Button
-              variant="primary"
-              className="mr-3"
-              disabled={!(entitlement.courseUuid && entitlement.mode && comments)}
-              hidden={hideSubmit}
-              onClick={submit}
-            >
-              Submit
-            </Button>
-          ),
-      ]}
-    />
+      size="lg"
+    >
+      <ModalDialog.Header className="mb-3">
+        <ModalDialog.Title className="modal-title">
+          Expire Entitlement
+        </ModalDialog.Title>
+      </ModalDialog.Header>
+      <ModalDialog.Body>
+        {expireEntitlementForm}
+      </ModalDialog.Body>
+      <ModalDialog.Footer>
+        <ActionRow>
+          <ModalDialog.CloseButton
+            variant="link"
+          >
+            Close
+          </ModalDialog.CloseButton>
+          { showLoader
+            ? (<div className="spinner-border text-primary" role="status" />)
+            : (
+              <Button
+                variant="primary"
+                className="mr-3"
+                disabled={!(entitlement.courseUuid && entitlement.mode && comments)}
+                hidden={hideSubmit}
+                onClick={submit}
+              >
+                Submit
+              </Button>
+            )}
+        </ActionRow>
+      </ModalDialog.Footer>
+    </ModalDialog>
   );
 }
 

--- a/src/users/entitlements/ExpireEntitlementForm.test.jsx
+++ b/src/users/entitlements/ExpireEntitlementForm.test.jsx
@@ -25,14 +25,14 @@ describe('Expire Entitlement Form', () => {
   });
 
   it('Default form render', () => {
-    let expireFormModal = wrapper.find('Modal#expire-entitlement');
-    expect(expireFormModal.prop('open')).toEqual(true);
+    let expireFormModal = wrapper.find('ModalDialog#expire-entitlement');
+    expect(expireFormModal.prop('isOpen')).toEqual(true);
     const commentsTextArea = wrapper.find('textarea#comments');
     expect(commentsTextArea.text()).toEqual('');
 
     wrapper.find('button.btn-link').simulate('click');
-    expireFormModal = wrapper.find('Modal#expire-entitlement');
-    expect(expireFormModal.prop('open')).toEqual(false);
+    expireFormModal = wrapper.find('ModalDialog#expire-entitlement');
+    expect(expireFormModal.prop('isOpen')).toEqual(false);
   });
 
   describe('Form Submission', () => {

--- a/src/users/entitlements/ReissueEntitlementForm.jsx
+++ b/src/users/entitlements/ReissueEntitlementForm.jsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Button, Input, Modal,
+  ActionRow,
+  Button, Input, ModalDialog,
 } from '@edx/paragon';
 
 import UserMessagesContext from '../../userMessages/UserMessagesContext';
@@ -88,35 +89,48 @@ export default function ReissueEntitlementForm({
   );
 
   return (
-    <Modal
-      open={modalIsOpen}
+    <ModalDialog
+      isOpen={modalIsOpen}
       onClose={() => {
         clear('reissueEntitlement');
         closeHandler(false);
         setModalIsOpen(false);
       }}
-      title="Reissue Entitlement"
+      hasCloseButton
       id="reissue-entitlement"
-      dialogClassName="modal-lg"
-      body={(
-        reissueEntitlementForm
-      )}
-      buttons={[
-        showLoader
-          ? (<div className="spinner-border text-primary" role="status" />)
-          : (
-            <Button
-              variant="primary"
-              className="mr-3"
-              disabled={!(entitlement.courseUuid && entitlement.mode && comments)}
-              hidden={hideSubmit}
-              onClick={submit}
-            >
-              Submit
-            </Button>
-          ),
-      ]}
-    />
+      size="lg"
+    >
+      <ModalDialog.Header className="mb-3">
+        <ModalDialog.Title className="modal-title">
+          Reissue Entitlement
+        </ModalDialog.Title>
+      </ModalDialog.Header>
+      <ModalDialog.Body>
+        {reissueEntitlementForm}
+      </ModalDialog.Body>
+      <ModalDialog.Footer>
+        <ActionRow>
+          <ModalDialog.CloseButton
+            variant="link"
+          >
+            Close
+          </ModalDialog.CloseButton>
+          { showLoader
+            ? (<div className="spinner-border text-primary" role="status" />)
+            : (
+              <Button
+                variant="primary"
+                className="mr-3"
+                disabled={!(entitlement.courseUuid && entitlement.mode && comments)}
+                hidden={hideSubmit}
+                onClick={submit}
+              >
+                Submit
+              </Button>
+            )}
+        </ActionRow>
+      </ModalDialog.Footer>
+    </ModalDialog>
   );
 }
 

--- a/src/users/entitlements/ReissueEntitlementForm.test.jsx
+++ b/src/users/entitlements/ReissueEntitlementForm.test.jsx
@@ -25,14 +25,14 @@ describe('Reissue Entitlement Form', () => {
   });
 
   it('Default form render', () => {
-    let reissueFormModal = wrapper.find('Modal#reissue-entitlement');
-    expect(reissueFormModal.prop('open')).toEqual(true);
+    let reissueFormModal = wrapper.find('ModalDialog#reissue-entitlement');
+    expect(reissueFormModal.prop('isOpen')).toEqual(true);
     const commentsTextArea = wrapper.find('textarea#comments');
     expect(commentsTextArea.text()).toEqual('');
 
     wrapper.find('button.btn-link').simulate('click');
-    reissueFormModal = wrapper.find('Modal#reissue-entitlement');
-    expect(reissueFormModal.prop('open')).toEqual(false);
+    reissueFormModal = wrapper.find('ModalDialog#reissue-entitlement');
+    expect(reissueFormModal.prop('isOpen')).toEqual(false);
   });
 
   describe('Form Submission', () => {


### PR DESCRIPTION
Migrate off paragon modal deprecated components.

**SSO History Before**
<img width="407" alt="SSO history before" src="https://user-images.githubusercontent.com/107556986/210728932-0e3b0bb9-d6e2-49bb-9d24-c7dd1b4f7350.png">

**SSO History After**
<img width="502" alt="SSO history after" src="https://user-images.githubusercontent.com/107556986/210729049-569f7a4c-2d08-4415-be51-48fa49d4b7fb.png">

**Password History Before**

<img width="1400" alt="pw history before" src="https://user-images.githubusercontent.com/107556986/210729121-521a9cb2-6c61-45ff-9888-044049656a98.png">

**Password history after**

<img width="1150" alt="pw history after" src="https://user-images.githubusercontent.com/107556986/210729207-1d83ea60-e58f-418b-9c49-6ad8f258c591.png">

**Reset password before**

<img width="797" alt="reset pw before" src="https://user-images.githubusercontent.com/107556986/210731393-f964df85-92a8-4968-81e3-2097e47f4664.png">


**Reset password after**

<img width="814" alt="reset passw after" src="https://user-images.githubusercontent.com/107556986/210729496-66995c42-d41f-4d99-9413-2983d5d1c766.png">

**Toggle password before**

<img width="500" alt="toggle pw before" src="https://user-images.githubusercontent.com/107556986/210732055-8ee0209f-0ca3-49b0-bd05-96aab041c731.png">

**Toggle password after**
<img width="517" alt="toggle pw after" src="https://user-images.githubusercontent.com/107556986/210729717-63c2a45f-5735-496f-be55-00c78c1c3b9b.png">

**Verified name before**

<img width="738" alt="Verified name before" src="https://user-images.githubusercontent.com/107556986/210729771-bc50284d-80fa-454b-a437-a755f243a6b0.png">

**Verified name after**

<img width="821" alt="verified namee before" src="https://user-images.githubusercontent.com/107556986/210733376-8e718a99-e968-45ab-bce2-f10b8add6674.png">


**Create enrollment before**

<img width="809" alt="Create enrollment before" src="https://user-images.githubusercontent.com/107556986/210734801-80b202d4-a1ac-4ac3-bb88-481fb4f19cb2.png">

**Create enrolment after**

<img width="829" alt="create enroll after" src="https://user-images.githubusercontent.com/107556986/210730033-1d34f2aa-e23f-4f74-a129-21dbde1eec53.png">

**Create entitlement before**

![create entitlement before](https://user-images.githubusercontent.com/107556986/210730233-353afb8d-1b29-4542-9c5e-ba7bd984561b.jpeg)

**Create entitlement after**
<img width="795" alt="create entilement after" src="https://user-images.githubusercontent.com/107556986/210730280-b65a404f-de66-4181-af57-6f33fcbac69d.png">

**Expire entitlement before**

<img width="1416" alt="Expire enrollment before" src="https://user-images.githubusercontent.com/107556986/210730302-e3233bb9-00a4-4ab5-915a-7706358a1c94.png">

**Expire entitlement after**
<img width="801" alt="expire after" src="https://user-images.githubusercontent.com/107556986/210730415-bbf9b5bf-cb5a-491e-a7b2-aa99241cc834.png">

**Reissue entitlement before**
<img width="894" alt="Reissue before" src="https://user-images.githubusercontent.com/107556986/210730539-6f5d9b86-7ab1-4ec5-ae45-f27c89072377.png">

**Reissue entitlement after**

<img width="830" alt="Reissue after" src="https://user-images.githubusercontent.com/107556986/210730635-55ec2bd8-5138-4cd0-9ab0-bcc84b82128c.png">



