### PR TITLE
feat: adds user defined description field

### DIFF
--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormDescription.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormDescription.jsx
@@ -1,0 +1,53 @@
+import {
+  Form,
+} from '@edx/paragon';
+import { useState } from 'react';
+import PROVISIONING_PAGE_TEXT from '../../data/constants';
+import { indexOnlyPropType } from '../../data/utils';
+import useProvisioningContext from '../../data/hooks';
+
+const ProvisioningFormDescription = ({ index }) => {
+  const { ACCOUNT_DESCRIPTION } = PROVISIONING_PAGE_TEXT.FORM;
+  const { setAccountDescription } = useProvisioningContext();
+  const [accountDescriptionLength, setAccountDescriptionLength] = useState(0);
+  const [localAccountDescription, setLocalAccountDescription] = useState('');
+
+  const handleChange = (e) => {
+    const newEvent = e.target;
+    const { value } = newEvent;
+    if (value.length > ACCOUNT_DESCRIPTION.MAX_LENGTH) {
+      return;
+    }
+    setAccountDescriptionLength(value.length);
+    setLocalAccountDescription(value);
+    setAccountDescription({ accountDescription: value }, index);
+  };
+
+  return (
+    <article className="mt-4.5">
+      <div>
+        <h3>{ACCOUNT_DESCRIPTION.TITLE}</h3>
+      </div>
+      <Form.Group>
+        <Form.Label className="mb-2.5">{ACCOUNT_DESCRIPTION.SUB_TITLE}</Form.Label>
+        <Form.Control
+          className="mb-1"
+          as="textarea"
+          style={{ height: '100px' }}
+          value={localAccountDescription}
+          onChange={handleChange}
+          data-testid="account-description"
+        />
+        <Form.Control.Feedback>
+          {accountDescriptionLength}/{ACCOUNT_DESCRIPTION.MAX_LENGTH}
+        </Form.Control.Feedback>
+      </Form.Group>
+    </article>
+  );
+};
+
+ProvisioningFormDescription.propTypes = {
+  ...indexOnlyPropType,
+};
+
+export default ProvisioningFormDescription;

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormPolicyContainer.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormPolicyContainer.jsx
@@ -3,11 +3,13 @@ import ProvisioningFormCatalogContainer from './ProvisioningFormCatalogContainer
 import ProvisioningFormAccountDetails from './ProvisioningFormAccountDetails';
 import ProvisioningFormPerLearnerCapContainer from './ProvisioningFormPerLearnerCapContainer';
 import { indexOnlyPropType } from '../../data/utils';
+import ProvisioningFormDescription from './ProvisioningFormDescription';
 
 const ProvisioningFormPolicyContainer = ({ title, index }) => (
   <div className="mt-5">
     <h2>{title}</h2>
     <ProvisioningFormAccountDetails index={index} />
+    <ProvisioningFormDescription index={index} />
     <ProvisioningFormCatalogContainer index={index} />
     <ProvisioningFormPerLearnerCapContainer index={index} />
   </div>

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormDescription.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormDescription.test.jsx
@@ -1,0 +1,70 @@
+/* eslint-disable react/prop-types */
+import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { screen, fireEvent } from '@testing-library/react';
+import { ProvisioningContext, initialStateValue } from '../../../../testData';
+import PROVISIONING_PAGE_TEXT from '../../../data/constants';
+import ProvisioningFormDescription from '../ProvisioningFormDescription';
+
+const { ACCOUNT_DESCRIPTION } = PROVISIONING_PAGE_TEXT.FORM;
+
+const ProvisioningFormDescriptionWrapper = ({
+  value = initialStateValue,
+  index = 0,
+}) => (
+  <ProvisioningContext value={value}>
+    <ProvisioningFormDescription index={index} />
+  </ProvisioningContext>
+);
+
+// generate a string of length 256
+const generateString = () => {
+  let longString = '';
+  for (let i = 0; i < 256; i++) {
+    longString += 'a';
+  }
+  return longString;
+};
+
+describe('ProvisioningFormDescription', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+  it('renders single policy state', () => {
+    renderWithRouter(
+      <ProvisioningFormDescriptionWrapper
+        index={0}
+      />,
+    );
+    expect(screen.getByText(ACCOUNT_DESCRIPTION.TITLE)).toBeTruthy();
+    expect(screen.getByText(ACCOUNT_DESCRIPTION.SUB_TITLE)).toBeTruthy();
+  });
+  it('updates the form display name data on change', () => {
+    renderWithRouter(
+      <ProvisioningFormDescriptionWrapper
+        index={0}
+      />,
+    );
+
+    expect(screen.getByText(ACCOUNT_DESCRIPTION.SUB_TITLE)).toBeTruthy();
+    const input = screen.getByTestId('account-description');
+    fireEvent.change(input, { target: { value: 'test' } });
+    expect(input.value).toBe('test');
+    expect(screen.getByText(`${input.value.length}/${ACCOUNT_DESCRIPTION.MAX_LENGTH}`)).toBeTruthy();
+  });
+  it('does not allow more than 255 characters', () => {
+    renderWithRouter(
+      <ProvisioningFormDescriptionWrapper
+        index={0}
+      />,
+    );
+    const oversizedString = generateString();
+    expect(oversizedString.length).toBe(256);
+    const input = screen.getByTestId('account-description');
+    fireEvent.change(input, { target: { value: oversizedString } });
+    expect(screen.getByText(`0/${ACCOUNT_DESCRIPTION.MAX_LENGTH}`)).toBeTruthy();
+    // the last character should not be added
+    fireEvent.change(input, { target: { value: oversizedString.slice(0, -1) } });
+    expect(input.value).toBe(oversizedString.slice(0, -1));
+    expect(screen.getByText(`255/${ACCOUNT_DESCRIPTION.MAX_LENGTH}`)).toBeTruthy();
+  });
+});

--- a/src/Configuration/Provisioning/ProvisioningForm/ProvisioningFormSubmissionButton.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/ProvisioningFormSubmissionButton.jsx
@@ -204,7 +204,6 @@ const ProvisioningFormSubmissionButton = () => {
     complete: BUTTON.success,
     error: BUTTON.error,
   };
-
   return (
     <ActionRow className="justify-content-start mt-5">
       <StatefulButton

--- a/src/Configuration/Provisioning/data/constants.js
+++ b/src/Configuration/Provisioning/data/constants.js
@@ -104,6 +104,11 @@ const PROVISIONING_PAGE_TEXT = {
         emptyField: 'Please enter a valid starting balance.',
       },
     },
+    ACCOUNT_DESCRIPTION: {
+      TITLE: 'Budget description',
+      SUB_TITLE: 'Provide a description for the budget product',
+      MAX_LENGTH: 255,
+    },
     CATALOG: {
       TITLE: 'Catalog',
       SUB_TITLE: 'Associated Catalog',

--- a/src/Configuration/Provisioning/data/hooks.js
+++ b/src/Configuration/Provisioning/data/hooks.js
@@ -133,6 +133,8 @@ export default function useProvisioningContext() {
 
   const setAccountValue = (accountValue, index) => updateFormDataState(accountValue, true, index);
 
+  const setAccountDescription = (accountDescription, index) => updateFormDataState(accountDescription, true, index);
+
   const setCustomerCatalog = (customerCatalogBoolean, index) => updateFormDataState(
     customerCatalogBoolean,
     true,
@@ -203,6 +205,7 @@ export default function useProvisioningContext() {
     setInternalOnly,
     setAccountName,
     setAccountValue,
+    setAccountDescription,
     setCatalogQueryCategory,
     perLearnerCap,
     setPerLearnerCap,

--- a/src/Configuration/Provisioning/data/utils.js
+++ b/src/Configuration/Provisioning/data/utils.js
@@ -404,7 +404,9 @@ export function transformPolicyData(formData, catalogCreationResponse, subsidyCr
     || subsidyCreationResponse.length === 0
   ) { return []; }
   const payloads = policies.map((policy, index) => ({
-    description: `${policy.accountName}, Initial Policy Value: $${policy.accountValue}, Initial Subsidy Value: $${policies.reduce((acc, { accountValue }) => acc + parseInt(accountValue, 10), 0)}`,
+    description: policy.accountDescription?.length > 0
+      ? policy.accountDescription
+      : `${policy.accountName}, Initial Policy Value: $${policy.accountValue}, Initial Subsidy Value: $${policies.reduce((acc, { accountValue }) => acc + parseInt(accountValue, 10), 0)}`,
     enterpriseCustomerUuid: enterpriseUUID,
     catalogUuid: catalogCreationResponse[0][index].uuid,
     subsidyUuid: subsidyCreationResponse[0].uuid,


### PR DESCRIPTION
Adds a field to the provisioning tool that allows a user defined description. Defaults to a sane value if no description is given.
![Screenshot 2023-06-08 at 10 29 30 AM](https://github.com/openedx/frontend-app-support-tools/assets/82611798/ac3ff934-3980-47d5-be93-6079c3f4427d)
