### PR TITLE
feat: Removes perLearnerEnrollmentLimit field from api call

### DIFF
--- a/src/data/services/EnterpriseApiService.js
+++ b/src/data/services/EnterpriseApiService.js
@@ -28,6 +28,8 @@ class LmsApiService {
     title,
   });
 
+  // Did not include perLearnerEnrollmentLimit field because it is
+  // not used in the current implementation of the provisioning form
   static postSubsidyAccessPolicy = (
     description,
     enterpriseCustomerUuid,
@@ -37,7 +39,6 @@ class LmsApiService {
     spendLimit,
     accessMethod = 'direct',
     active = true,
-    perLearnerEnrollmentLimit = null,
     policyType = 'PerLearnerSpendCreditAccessPolicy',
   ) => LmsApiService.apiClient().post(
     `${getConfig().ENTERPRISE_ACCESS_BASE_URL}/api/v1/admin/policy/`,
@@ -50,7 +51,6 @@ class LmsApiService {
       subsidy_uuid: subsidyUuid,
       access_method: accessMethod,
       per_learner_spend_limit: perLearnerSpendLimit,
-      per_learner_enrollment_limit: perLearnerEnrollmentLimit,
       spend_limit: spendLimit,
     },
   );


### PR DESCRIPTION
Removes the perLearnerEnrollmentLimit field form the API call to correspond with this [PR](https://github.com/openedx/enterprise-access/pull/201)