### PR TITLE
feat: implement cancel button and modal

### DIFF
--- a/src/Configuration/Provisioning/ProvisioningContext.jsx
+++ b/src/Configuration/Provisioning/ProvisioningContext.jsx
@@ -22,6 +22,7 @@ const ProvisioningContextProvider = ({ children }) => {
     },
     isEditMode: false,
     isLoading: true,
+    hasEdits: false,
   });
 
   return (

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormCatalog.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormCatalog.jsx
@@ -11,7 +11,12 @@ import { ProvisioningContext } from '../../ProvisioningContext';
 
 // TODO: Replace URL for hyperlink to somewhere to display catalog content information
 const ProvisioningFormCatalog = ({ index }) => {
-  const { setCustomCatalog, setCatalogQueryCategory, setInvalidPolicyFields } = useProvisioningContext();
+  const {
+    setCustomCatalog,
+    setCatalogQueryCategory,
+    setInvalidPolicyFields,
+    setHasEdits,
+  } = useProvisioningContext();
   const { CATALOG } = PROVISIONING_PAGE_TEXT.FORM;
   const contextData = useContextSelector(ProvisioningContext, v => v[0]);
   const {
@@ -20,6 +25,7 @@ const ProvisioningFormCatalog = ({ index }) => {
     multipleFunds,
     formData,
     showInvalidField: { policies },
+    hasEdits,
   } = contextData;
   const isCatalogQueryMetadataDefinedAndFalse = policies[index]?.catalogQueryMetadata === false;
   const camelCasedQueries = getCamelCasedConfigAttribute('PREDEFINED_CATALOG_QUERIES');
@@ -42,6 +48,9 @@ const ProvisioningFormCatalog = ({ index }) => {
   const handleChange = (e) => {
     const newTabValue = e.target.value;
     const newCatalogQuery = e.target.dataset.catalogqueryid;
+    if (isEditMode && !hasEdits) {
+      setHasEdits(true);
+    }
     if (newTabValue === CATALOG.OPTIONS.custom) {
       setCustomCatalog(true);
       setCatalogQueryCategory({

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormDescription.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormDescription.jsx
@@ -8,8 +8,8 @@ import useProvisioningContext from '../../data/hooks';
 
 const ProvisioningFormDescription = ({ index }) => {
   const { ACCOUNT_DESCRIPTION } = PROVISIONING_PAGE_TEXT.FORM;
-  const [formData, isEditMode] = selectProvisioningContext('formData', 'isEditMode');
-  const { setAccountDescription } = useProvisioningContext();
+  const [formData, isEditMode, hasEdits] = selectProvisioningContext('formData', 'isEditMode', 'hasEdits');
+  const { setAccountDescription, setHasEdits } = useProvisioningContext();
 
   let submittedFormAccountDescription;
   if (isEditMode) {
@@ -25,6 +25,9 @@ const ProvisioningFormDescription = ({ index }) => {
   const handleChange = (e) => {
     const newEvent = e.target;
     const { value } = newEvent;
+    if (isEditMode && !hasEdits) {
+      setHasEdits(true);
+    }
     if (value.length > ACCOUNT_DESCRIPTION.MAX_LENGTH) {
       return;
     }

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormPerLearnerCap.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormPerLearnerCap.jsx
@@ -8,9 +8,9 @@ import useProvisioningContext from '../../data/hooks';
 import { indexOnlyPropType, selectProvisioningContext } from '../../data/utils';
 
 const ProvisioningFormPerLearnerCap = ({ index }) => {
-  const { perLearnerCap, setInvalidPolicyFields } = useProvisioningContext();
+  const { perLearnerCap, setInvalidPolicyFields, setHasEdits } = useProvisioningContext();
   const { LEARNER_CAP } = PROVISIONING_PAGE_TEXT.FORM;
-  const [formData, showInvalidField, isEditMode] = selectProvisioningContext('formData', 'showInvalidField', 'isEditMode');
+  const [formData, showInvalidField, isEditMode, hasEdits] = selectProvisioningContext('formData', 'showInvalidField', 'isEditMode', 'hasEdits');
   const { policies } = showInvalidField;
   const isPerLearnerCapDefinedAndFalse = policies[index]?.perLearnerCap === false;
 
@@ -22,6 +22,9 @@ const ProvisioningFormPerLearnerCap = ({ index }) => {
 
   const handleChange = (e) => {
     const newTabValue = e.target.value;
+    if (isEditMode && !hasEdits) {
+      setHasEdits(true);
+    }
     if (newTabValue === LEARNER_CAP.OPTIONS.yes) {
       perLearnerCap({
         perLearnerCap: true,

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormPerLearnerCapAmount.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormPerLearnerCapAmount.jsx
@@ -9,8 +9,8 @@ import { isWholeDollarAmount } from '../../../../utils';
 
 const ProvisioningFormPerLearnerCapAmount = ({ index }) => {
   const { LEARNER_CAP_DETAIL } = PROVISIONING_PAGE_TEXT.FORM;
-  const { setPerLearnerCap, setInvalidPolicyFields } = useProvisioningContext();
-  const [formData, showInvalidField, isEditMode] = selectProvisioningContext('formData', 'showInvalidField', 'isEditMode');
+  const { setPerLearnerCap, setInvalidPolicyFields, setHasEdits } = useProvisioningContext();
+  const [formData, showInvalidField, isEditMode, hasEdits] = selectProvisioningContext('formData', 'showInvalidField', 'isEditMode', 'hasEdits');
   const { policies } = showInvalidField;
   const isPerLearnerCapAmountDefinedAndFalse = policies[index]?.perLearnerCapAmount === false;
   const [isWholeDollar, setIsWholeDollar] = useState(true);
@@ -22,6 +22,9 @@ const ProvisioningFormPerLearnerCapAmount = ({ index }) => {
 
   const [perLearnerCapValue, setPerLearnerCapValue] = useState(submittedFormPerLearnerCapAmount || '');
   const handleChange = (e) => {
+    if (isEditMode && hasEdits) {
+      setHasEdits(true);
+    }
     const newEventValue = e.target.value;
     if (newEventValue !== '' && !isWholeDollarAmount(newEventValue)) {
       setIsWholeDollar(false);

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormPerLearnerCapAmount.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormPerLearnerCapAmount.jsx
@@ -22,7 +22,7 @@ const ProvisioningFormPerLearnerCapAmount = ({ index }) => {
 
   const [perLearnerCapValue, setPerLearnerCapValue] = useState(submittedFormPerLearnerCapAmount || '');
   const handleChange = (e) => {
-    if (isEditMode && hasEdits) {
+    if (isEditMode && !hasEdits) {
       setHasEdits(true);
     }
     const newEventValue = e.target.value;

--- a/src/Configuration/Provisioning/ProvisioningForm/ProvisioningFormInternalOnly.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/ProvisioningFormInternalOnly.jsx
@@ -7,9 +7,9 @@ import useProvisioningContext from '../data/hooks';
 import { selectProvisioningContext } from '../data/utils';
 
 const ProvisioningFormInternalOnly = () => {
-  const { setInternalOnly } = useProvisioningContext();
+  const { setInternalOnly, setHasEdits } = useProvisioningContext();
   const { INTERNAL_ONLY } = PROVISIONING_PAGE_TEXT.FORM;
-  const [formData, isEditMode] = selectProvisioningContext('formData', 'isEditMode');
+  const [formData, isEditMode, hasEdits] = selectProvisioningContext('formData', 'isEditMode', 'hasEdits');
 
   let submittedFormInternalOnly;
   if (isEditMode) {
@@ -19,6 +19,9 @@ const ProvisioningFormInternalOnly = () => {
 
   const handleChange = async (e) => {
     const checkedState = e.target.checked;
+    if (isEditMode && !hasEdits) {
+      setHasEdits(true);
+    }
     setInternalOnly(checkedState);
     setValue(checkedState);
   };

--- a/src/Configuration/Provisioning/ProvisioningForm/ProvisioningFormSubsidy.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/ProvisioningFormSubsidy.jsx
@@ -8,9 +8,9 @@ import useProvisioningContext from '../data/hooks';
 import { selectProvisioningContext } from '../data/utils';
 
 const ProvisioningFormSubsidy = () => {
-  const { setSubsidyRevReq, setInvalidSubsidyFields } = useProvisioningContext();
+  const { setSubsidyRevReq, setInvalidSubsidyFields, setHasEdits } = useProvisioningContext();
   const { SUBSIDY_TYPE } = PROVISIONING_PAGE_TEXT.FORM;
-  const [isEditMode, formData, showInvalidField] = selectProvisioningContext('isEditMode', 'formData', 'showInvalidField');
+  const [isEditMode, formData, showInvalidField, hasEdits] = selectProvisioningContext('isEditMode', 'formData', 'showInvalidField', 'hasEdits');
   const { subsidy } = showInvalidField;
   const isSubsidyRevReqDefinedAndFalse = subsidy?.subsidyRevReq === false;
 
@@ -22,6 +22,9 @@ const ProvisioningFormSubsidy = () => {
 
   const handleChange = async (e) => {
     const newTabValue = e.target.value;
+    if (isEditMode && !hasEdits) {
+      setHasEdits(true);
+    }
     setSubsidyRevReq(newTabValue);
     setValue(newTabValue);
     setInvalidSubsidyFields({ ...subsidy, subsidyRevReq: true });

--- a/src/Configuration/Provisioning/ProvisioningForm/ProvisioningFormTerm.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/ProvisioningFormTerm.jsx
@@ -13,7 +13,12 @@ import { isValidDateString } from '../../../utils';
 
 const ProvisioningFormTerm = () => {
   const { TERM } = PROVISIONING_PAGE_TEXT.FORM;
-  const [formData, showInvalidField, isEditMode, hasEdits] = selectProvisioningContext('formData', 'showInvalidField', 'hasEdits');
+  const [
+    formData,
+    showInvalidField,
+    isEditMode,
+    hasEdits,
+  ] = selectProvisioningContext('formData', 'showInvalidField', 'isEditMode', 'hasEdits');
   const { subsidy } = showInvalidField;
   const areDatesDefinedAndFalse = subsidy?.startDate === false || subsidy?.endDate === false;
   const {

--- a/src/Configuration/Provisioning/ProvisioningForm/ProvisioningFormTerm.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/ProvisioningFormTerm.jsx
@@ -13,14 +13,22 @@ import { isValidDateString } from '../../../utils';
 
 const ProvisioningFormTerm = () => {
   const { TERM } = PROVISIONING_PAGE_TEXT.FORM;
-  const [formData, showInvalidField] = selectProvisioningContext('formData', 'showInvalidField');
+  const [formData, showInvalidField, isEditMode, hasEdits] = selectProvisioningContext('formData', 'showInvalidField', 'hasEdits');
   const { subsidy } = showInvalidField;
   const areDatesDefinedAndFalse = subsidy?.startDate === false || subsidy?.endDate === false;
-  const { setStartDate, setEndDate, setInvalidSubsidyFields } = useProvisioningContext();
+  const {
+    setStartDate,
+    setEndDate,
+    setInvalidSubsidyFields,
+    setHasEdits,
+  } = useProvisioningContext();
   const [hasInvalidEndDate, setHasInvalidEndDate] = useState(false);
   const handleDateChange = (e) => {
     const eventTarget = e.target;
     const isStartDate = eventTarget.dataset.testid.includes('start');
+    if (isEditMode && !hasEdits) {
+      setHasEdits(true);
+    }
     if (isValidDateString(eventTarget.value)) {
       setInvalidSubsidyFields(isStartDate ? { ...subsidy, startDate: true } : { ...subsidy, endDate: true });
       if (isStartDate) {

--- a/src/Configuration/Provisioning/ProvisioningForm/ProvisioningFormTitle.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/ProvisioningFormTitle.jsx
@@ -7,9 +7,9 @@ import useProvisioningContext from '../data/hooks';
 import { selectProvisioningContext } from '../data/utils';
 
 const ProvisioningFormTitle = () => {
-  const { setSubsidyTitle } = useProvisioningContext();
+  const { setSubsidyTitle, setHasEdits } = useProvisioningContext();
   const { FORM: { PLAN_TITLE } } = PROVISIONING_PAGE_TEXT;
-  const [formData, showInvalidField, isEditMode] = selectProvisioningContext('formData', 'showInvalidField', 'isEditMode');
+  const [formData, showInvalidField, isEditMode, hasEdits] = selectProvisioningContext('formData', 'showInvalidField', 'isEditMode', 'hasEdits');
 
   let submittedFormSubsidyTitle;
   if (isEditMode) {
@@ -23,6 +23,9 @@ const ProvisioningFormTitle = () => {
 
   const handleChange = (e) => {
     const newEventValue = e.target.value;
+    if (isEditMode && !hasEdits) {
+      setHasEdits(true);
+    }
     if (newEventValue === '') {
       setInvalidSubsidyFields({ ...subsidy, subsidyTitle: false });
       setSubsidyTitle('');

--- a/src/Configuration/Provisioning/SubsidyEditView/CancelButton.jsx
+++ b/src/Configuration/Provisioning/SubsidyEditView/CancelButton.jsx
@@ -1,10 +1,79 @@
-import { Button } from '@edx/paragon';
+import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { useHistory } from 'react-router';
+import {
+  ActionRow,
+  Button,
+  ModalDialog,
+  useToggle,
+} from '@edx/paragon';
+import PROVISIONING_PAGE_TEXT from '../data/constants';
+import { selectProvisioningContext } from '../data/utils';
 
 // TODO: Implementation of button in ticket ENT-7506
-const CancelButton = () => (
-  <Button variant="outline-primary">
-    Cancel
-  </Button>
-);
+const CancelButton = () => {
+  const { FORM: { CANCEL } } = PROVISIONING_PAGE_TEXT;
+  const [isOpen, open, close] = useToggle(false);
+  const [hasEdits] = selectProvisioningContext('hasEdits');
+  const params = useParams();
+  const history = useHistory();
+  const subsidyUuid = params.id;
+  const viewRoute = `/enterprise-configuration/learner-credit/${subsidyUuid}/view`;
+
+  const handleOnClick = () => {
+    if (hasEdits) {
+      history.push(viewRoute);
+    }
+    return open();
+  };
+
+  useEffect(() => {
+    const handleTabClose = (event) => {
+      event.preventDefault();
+      return (event.returnValue = true);
+    };
+    window.addEventListener('beforeunload', handleTabClose);
+    return () => {
+      window.removeEventListener('beforeunload', handleTabClose);
+    };
+  }, []);
+
+  return (
+    <div>
+      <Button variant="outline-primary" onClick={handleOnClick}>
+        Cancel
+      </Button>
+      <ModalDialog
+        closeLabel="Cancel"
+        title="Cancel Dialog"
+        isOpen={isOpen}
+        onClose={close}
+        hasCloseButton
+        variant="default"
+      >
+        <ModalDialog.Header>
+          <ModalDialog.Title>
+            {CANCEL.MODAL.TITLE}
+          </ModalDialog.Title>
+        </ModalDialog.Header>
+
+        <ModalDialog.Body>
+          <p>
+            {CANCEL.MODAL.BODY}
+          </p>
+        </ModalDialog.Body>
+
+        <ModalDialog.Footer>
+          <ActionRow>
+            <Button variant="tertiary">{CANCEL.MODAL.FOOTER.options.leave}</Button>
+            <ModalDialog.CloseButton>
+              {CANCEL.MODAL.FOOTER.options.stay}
+            </ModalDialog.CloseButton>
+          </ActionRow>
+        </ModalDialog.Footer>
+      </ModalDialog>
+    </div>
+  );
+};
 
 export default CancelButton;

--- a/src/Configuration/Provisioning/SubsidyEditView/CancelButton.jsx
+++ b/src/Configuration/Provisioning/SubsidyEditView/CancelButton.jsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useHistory } from 'react-router';
 import {
@@ -10,7 +9,6 @@ import {
 import PROVISIONING_PAGE_TEXT from '../data/constants';
 import { selectProvisioningContext } from '../data/utils';
 
-// TODO: Implementation of button in ticket ENT-7506
 const CancelButton = () => {
   const { FORM: { CANCEL } } = PROVISIONING_PAGE_TEXT;
   const [isOpen, open, close] = useToggle(false);
@@ -21,27 +19,16 @@ const CancelButton = () => {
   const viewRoute = `/enterprise-configuration/learner-credit/${subsidyUuid}/view`;
 
   const handleOnClick = () => {
-    if (hasEdits) {
+    if (!hasEdits) {
       history.push(viewRoute);
     }
     return open();
   };
 
-  useEffect(() => {
-    const handleTabClose = (event) => {
-      event.preventDefault();
-      return (event.returnValue = true);
-    };
-    window.addEventListener('beforeunload', handleTabClose);
-    return () => {
-      window.removeEventListener('beforeunload', handleTabClose);
-    };
-  }, []);
-
   return (
     <div>
       <Button variant="outline-primary" onClick={handleOnClick}>
-        Cancel
+        { CANCEL.description }
       </Button>
       <ModalDialog
         closeLabel="Cancel"
@@ -65,7 +52,7 @@ const CancelButton = () => {
 
         <ModalDialog.Footer>
           <ActionRow>
-            <Button variant="tertiary">{CANCEL.MODAL.FOOTER.options.leave}</Button>
+            <Button onClick={() => history.push(viewRoute)} variant="tertiary">{CANCEL.MODAL.FOOTER.options.leave}</Button>
             <ModalDialog.CloseButton>
               {CANCEL.MODAL.FOOTER.options.stay}
             </ModalDialog.CloseButton>

--- a/src/Configuration/Provisioning/SubsidyEditView/SubsidyEditView.jsx
+++ b/src/Configuration/Provisioning/SubsidyEditView/SubsidyEditView.jsx
@@ -36,6 +36,19 @@ const SubsidyEditView = () => {
   };
 
   useEffect(() => {
+    const handleTabClose = (event) => {
+      event.preventDefault();
+      const copyEvent = event;
+      copyEvent.returnValue = true;
+      return copyEvent.returnValue;
+    };
+    window.addEventListener('beforeunload', handleTabClose);
+    return () => {
+      window.removeEventListener('beforeunload', handleTabClose);
+    };
+  }, []);
+
+  useEffect(() => {
     try {
       hydrateEnterpriseSubsidiesData(subsidyUuid);
     } catch (error) {
@@ -71,7 +84,7 @@ const SubsidyEditView = () => {
             />
           ))}
         </div>
-        <div className="mt-5">
+        <div className="d-flex mt-5">
           <SaveEditsButton />
           <CancelButton />
         </div>

--- a/src/Configuration/Provisioning/SubsidyEditView/SubsidyEditView.jsx
+++ b/src/Configuration/Provisioning/SubsidyEditView/SubsidyEditView.jsx
@@ -38,6 +38,9 @@ const SubsidyEditView = () => {
   useEffect(() => {
     const handleTabClose = (event) => {
       event.preventDefault();
+      // Creating a copy to bypass lint rule: no-param-reassign when setting a property on a DOM object.
+      // TODO: Investigate why event.preventDefault does. not open dialog.
+      // refer to docs: https://developer.mozilla.org/en-US/docs/Web/API/BeforeUnloadEvent
       const copyEvent = event;
       copyEvent.returnValue = true;
       return copyEvent.returnValue;

--- a/src/Configuration/Provisioning/SubsidyEditView/tests/CancelButton.test.jsx
+++ b/src/Configuration/Provisioning/SubsidyEditView/tests/CancelButton.test.jsx
@@ -1,0 +1,73 @@
+import '@testing-library/jest-dom/extend-expect';
+import PropTypes from 'prop-types';
+import { act, screen, waitFor } from '@testing-library/react';
+import Router, { Router as BrowserRouter } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import CancelButton from '../CancelButton';
+import PROVISIONING_PAGE_TEXT from '../../data/constants';
+import { hydratedInitialState, ProvisioningContext } from '../../../testData/Provisioning/ProvisioningContextWrapper';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+}));
+
+const mockHistoryPush = jest.fn();
+const historyMock = {
+  push: mockHistoryPush,
+  location: jest.fn(),
+  listen: jest.fn(),
+  replace: jest.fn(),
+};
+
+const CancelButtonWrapper = ({
+  value = hydratedInitialState,
+}) => (
+  <BrowserRouter history={historyMock}>
+    <ProvisioningContext value={value}>
+      <CancelButton />
+    </ProvisioningContext>
+  </BrowserRouter>
+);
+
+describe('Cancel button', () => {
+  it('renders the button and opens modal when hasEdits is true ', async () => {
+    const { FORM: { CANCEL } } = PROVISIONING_PAGE_TEXT;
+    jest.spyOn(Router, 'useParams').mockReturnValue({ id: '0196e5c3-ba08-4798-8bf1-019d747c27bf' });
+    await act(async () => renderWithRouter(
+      <CancelButtonWrapper value={{ ...hydratedInitialState, hasEdits: false }} />,
+    ));
+
+    const button = screen.getByRole('button', {
+      name: CANCEL.description,
+    });
+    expect(button).toBeInTheDocument();
+    userEvent.click(button);
+    await waitFor(() => expect(screen.getByText(CANCEL.MODAL.TITLE)).toBeInTheDocument());
+    expect(button).toBeInTheDocument();
+    expect(screen.getByText(CANCEL.MODAL.BODY)).toBeInTheDocument();
+    expect(screen.getByRole('button', {
+      name: CANCEL.MODAL.FOOTER.options.leave,
+    })).toBeInTheDocument();
+    expect(screen.getByRole('button', {
+      name: CANCEL.MODAL.FOOTER.options.stay,
+    })).toBeInTheDocument();
+  });
+  it('renders the button and navigates to view screen when hasEdits is false ', async () => {
+    const { FORM: { CANCEL } } = PROVISIONING_PAGE_TEXT;
+    jest.spyOn(Router, 'useParams').mockReturnValue({ id: '0196e5c3-ba08-4798-8bf1-019d747c27bf' });
+    await act(async () => renderWithRouter(<CancelButtonWrapper value={hydratedInitialState} />));
+    const button = screen.getByRole('button', {
+      name: CANCEL.description,
+    });
+    expect(button).toBeInTheDocument();
+    userEvent.click(button);
+    await waitFor(() => expect(mockHistoryPush).toBeCalledTimes(1));
+    expect(mockHistoryPush).toHaveBeenCalledWith('/enterprise-configuration/learner-credit/0196e5c3-ba08-4798-8bf1-019d747c27bf/view');
+  });
+});
+
+CancelButtonWrapper.propTypes = {
+  value: PropTypes.shape().isRequired,
+};

--- a/src/Configuration/Provisioning/SubsidyEditView/tests/SubsidyEditView.test.jsx
+++ b/src/Configuration/Provisioning/SubsidyEditView/tests/SubsidyEditView.test.jsx
@@ -168,42 +168,4 @@ describe('SubsidyEditView', () => {
     window.dispatchEvent(new Event('beforeunload'));
     expect(window.addEventListener).toHaveBeenCalledWith('beforeunload', enableBeforeUnload);
   });
-  it('tests for plan title updates and cancel modal should appear', async () => {
-    const { FORM: { CANCEL } } = PROVISIONING_PAGE_TEXT;
-
-    const updatedStateValue = {
-      ...hydratedInitialState,
-      hasEdits: false,
-      isEditMode: true,
-    };
-    jest.spyOn(Router, 'useParams').mockReturnValue({ id: '0196e5c3-ba08-4798-8bf1-019d747c27bf' });
-    await act(async () => renderWithRouter(<SubsidyEditViewWrapper value={updatedStateValue} />));
-    const input = screen.getByTestId('customer-plan-title');
-    fireEvent.change(input, { target: { value: 'test' } });
-    const button = screen.getByRole('button', {
-      name: CANCEL.description,
-    });
-    expect(button).toBeInTheDocument();
-    userEvent.click(button);
-    await waitFor(() => expect(screen.getByText(CANCEL.MODAL.TITLE)).toBeInTheDocument());
-  });
-  it('tests for term updates and cancel modal should appear', async () => {
-    const { FORM: { CANCEL } } = PROVISIONING_PAGE_TEXT;
-
-    const updatedStateValue = {
-      ...hydratedInitialState,
-      hasEdits: false,
-      isEditMode: true,
-    };
-    jest.spyOn(Router, 'useParams').mockReturnValue({ id: '0196e5c3-ba08-4798-8bf1-019d747c27bf' });
-    await act(async () => renderWithRouter(<SubsidyEditViewWrapper value={updatedStateValue} />));
-    const startDateInput = screen.getByTestId('start-date');
-    fireEvent.change(startDateInput, { target: { value: '2021-01-01' } });
-    const button = screen.getByRole('button', {
-      name: CANCEL.description,
-    });
-    expect(button).toBeInTheDocument();
-    userEvent.click(button);
-    await waitFor(() => expect(screen.getByText(CANCEL.MODAL.TITLE)).toBeInTheDocument());
-  });
 });

--- a/src/Configuration/Provisioning/SubsidyEditView/tests/SubsidyEditView.test.jsx
+++ b/src/Configuration/Provisioning/SubsidyEditView/tests/SubsidyEditView.test.jsx
@@ -150,4 +150,16 @@ describe('SubsidyEditView', () => {
     expect(screen.getByText('Save Edits')).toBeInTheDocument();
     expect(screen.getByText('Cancel')).toBeInTheDocument();
   });
+  it('should call beforeunload of window and show alert to user', async () => {
+    jest.spyOn(Router, 'useParams').mockReturnValue({ id: '0196e5c3-ba08-4798-8bf1-019d747c27bf' });
+    jest.spyOn(window, 'addEventListener');
+    await act(async () => renderWithRouter(<SubsidyEditViewWrapper value={{ ...hydratedInitialState }} />));
+    const enableBeforeUnload = jest.fn();
+    function setupEventListener() {
+      window.addEventListener('beforeunload', enableBeforeUnload);
+    }
+    setupEventListener();
+    window.dispatchEvent(new Event('beforeunload'));
+    expect(window.addEventListener).toHaveBeenCalledWith('beforeunload', enableBeforeUnload);
+  });
 });

--- a/src/Configuration/Provisioning/SubsidyEditView/tests/SubsidyEditView.test.jsx
+++ b/src/Configuration/Provisioning/SubsidyEditView/tests/SubsidyEditView.test.jsx
@@ -1,7 +1,13 @@
 /* eslint-disable react/prop-types */
 import Router from 'react-router-dom';
 import { renderWithRouter } from '@edx/frontend-enterprise-utils';
-import { act, screen } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ProvisioningContext, hydratedInitialState } from '../../../testData/Provisioning/ProvisioningContextWrapper';
 import PROVISIONING_PAGE_TEXT from '../../data/constants';
 import SubsidyEditView from '../SubsidyEditView';
@@ -161,5 +167,45 @@ describe('SubsidyEditView', () => {
     setupEventListener();
     window.dispatchEvent(new Event('beforeunload'));
     expect(window.addEventListener).toHaveBeenCalledWith('beforeunload', enableBeforeUnload);
+  });
+  it('tests for plan title updates and cancel modal should appear', async () => {
+    const { FORM: { CANCEL } } = PROVISIONING_PAGE_TEXT;
+
+    const updatedStateValue = {
+      ...hydratedInitialState,
+      hasEdits: false,
+      isEditMode: true,
+    };
+    jest.spyOn(Router, 'useParams').mockReturnValue({ id: '0196e5c3-ba08-4798-8bf1-019d747c27bf' });
+    await act(async () => renderWithRouter(<SubsidyEditViewWrapper value={updatedStateValue} />));
+    const input = screen.getByTestId('customer-plan-title');
+    fireEvent.change(input, { target: { value: 'test' } });
+    const button = screen.getByRole('button', {
+      name: CANCEL.description,
+    });
+    expect(button).toBeInTheDocument();
+    userEvent.click(button);
+    await waitFor(() => expect(screen.getByText(CANCEL.MODAL.TITLE)).toBeInTheDocument());
+  });
+  it('tests for term updates and cancel modal should appear', async () => {
+    const { FORM: { CANCEL } } = PROVISIONING_PAGE_TEXT;
+
+    const updatedStateValue = {
+      ...hydratedInitialState,
+      isEditMode: true,
+      hasEdits: false,
+    };
+    jest.spyOn(Router, 'useParams').mockReturnValue({ id: '0196e5c3-ba08-4798-8bf1-019d747c27bf' });
+    await act(async () => renderWithRouter(<SubsidyEditViewWrapper value={updatedStateValue} />));
+    const startDateInput = screen.getByTestId('start-date');
+    expect(startDateInput.value).toBe('2023-06-20');
+    fireEvent.change(startDateInput, { target: { value: '2021-01-01' } });
+    expect(startDateInput.value).toBe('2021-01-01');
+    const button = screen.getByRole('button', {
+      name: CANCEL.description,
+    });
+    expect(button).toBeInTheDocument();
+    userEvent.click(button);
+    await waitFor(() => expect(screen.getByText(CANCEL.MODAL.TITLE)).toBeInTheDocument());
   });
 });

--- a/src/Configuration/Provisioning/SubsidyEditView/tests/SubsidyEditView.test.jsx
+++ b/src/Configuration/Provisioning/SubsidyEditView/tests/SubsidyEditView.test.jsx
@@ -15,6 +15,20 @@ import '@testing-library/jest-dom/extend-expect';
 
 const { FORM } = PROVISIONING_PAGE_TEXT;
 
+const mockConfig = () => ({
+  FEATURE_CONFIGURATION_EDIT_ENTERPRISE_PROVISION: 'true',
+  PREDEFINED_CATALOG_QUERIES: {
+    everything: 1,
+    open_courses: 2,
+    executive_education: 3,
+  },
+});
+
+jest.mock('@edx/frontend-platform', () => ({
+  ...jest.requireActual('@edx/frontend-platform'),
+  getConfig: () => mockConfig(),
+}));
+
 const mockData = {
   data: {
     results: [
@@ -114,6 +128,13 @@ const SubsidyEditViewWrapper = ({
 );
 
 describe('SubsidyEditView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
   it('renders on true multiple funds', async () => {
     jest.spyOn(Router, 'useParams').mockReturnValue({ id: '0196e5c3-ba08-4798-8bf1-019d747c27bf' });
     await act(async () => renderWithRouter(<SubsidyEditViewWrapper value={{ ...hydratedInitialState }} />));
@@ -168,44 +189,59 @@ describe('SubsidyEditView', () => {
     window.dispatchEvent(new Event('beforeunload'));
     expect(window.addEventListener).toHaveBeenCalledWith('beforeunload', enableBeforeUnload);
   });
-  it('tests for plan title updates and cancel modal should appear', async () => {
-    const { FORM: { CANCEL } } = PROVISIONING_PAGE_TEXT;
 
-    const updatedStateValue = {
-      ...hydratedInitialState,
-      hasEdits: false,
-      isEditMode: true,
-    };
-    jest.spyOn(Router, 'useParams').mockReturnValue({ id: '0196e5c3-ba08-4798-8bf1-019d747c27bf' });
-    await act(async () => renderWithRouter(<SubsidyEditViewWrapper value={updatedStateValue} />));
-    const input = screen.getByTestId('customer-plan-title');
-    fireEvent.change(input, { target: { value: 'test' } });
-    const button = screen.getByRole('button', {
-      name: CANCEL.description,
+  describe('updating form', () => {
+    beforeEach(() => {
+      const updatedStateValue = {
+        ...hydratedInitialState,
+        isEditMode: true,
+      };
+      jest.spyOn(Router, 'useParams').mockReturnValue({ id: '0196e5c3-ba08-4798-8bf1-019d747c27bf' });
+      renderWithRouter(<SubsidyEditViewWrapper value={updatedStateValue} />);
     });
-    expect(button).toBeInTheDocument();
-    userEvent.click(button);
-    await waitFor(() => expect(screen.getByText(CANCEL.MODAL.TITLE)).toBeInTheDocument());
-  });
-  it('tests for term updates and cancel modal should appear', async () => {
-    const { FORM: { CANCEL } } = PROVISIONING_PAGE_TEXT;
-
-    const updatedStateValue = {
-      ...hydratedInitialState,
-      isEditMode: true,
-      hasEdits: false,
+    const checksForCancelConfirmation = async () => {
+      const button = screen.getByRole('button', {
+        name: FORM.CANCEL.description,
+      });
+      expect(button).toBeInTheDocument();
+      userEvent.click(button);
+      await waitFor(() => expect(screen.getByText(FORM.CANCEL.MODAL.TITLE)).toBeInTheDocument());
     };
-    jest.spyOn(Router, 'useParams').mockReturnValue({ id: '0196e5c3-ba08-4798-8bf1-019d747c27bf' });
-    await act(async () => renderWithRouter(<SubsidyEditViewWrapper value={updatedStateValue} />));
-    const startDateInput = screen.getByTestId('start-date');
-    expect(startDateInput.value).toBe('2023-06-20');
-    fireEvent.change(startDateInput, { target: { value: '2021-01-01' } });
-    expect(startDateInput.value).toBe('2021-01-01');
-    const button = screen.getByRole('button', {
-      name: CANCEL.description,
+    it('shows confirmation modal when there are edits to date input', async () => {
+      const startDateInput = screen.getByTestId('start-date');
+      expect(startDateInput.value).toBe('2023-10-01');
+      fireEvent.change(startDateInput, { target: { value: '2021-01-01' } });
+      expect(startDateInput.value).toBe('2021-01-01');
+      await checksForCancelConfirmation();
     });
-    expect(button).toBeInTheDocument();
-    userEvent.click(button);
-    await waitFor(() => expect(screen.getByText(CANCEL.MODAL.TITLE)).toBeInTheDocument());
+    it('shows confirmation modal when there are edits subsidy type selection', async () => {
+      const yesButton = screen.getByTestId(FORM.SUBSIDY_TYPE.OPTIONS.yes);
+      expect(yesButton.checked).toBeTruthy();
+      const noButton = screen.getByTestId(FORM.SUBSIDY_TYPE.OPTIONS.no);
+      fireEvent.click(noButton);
+      await checksForCancelConfirmation();
+    });
+    it('shows confirmation modal when there are edits to the description', async () => {
+      const input = screen.getByTestId('account-description');
+      fireEvent.change(input, { target: { value: 'test' } });
+      await checksForCancelConfirmation();
+    });
+    it('shows confirmation modal when there are edits to the learner cap selection', async () => {
+      const yesButton = screen.getByTestId(FORM.LEARNER_CAP.OPTIONS.yes);
+      expect(yesButton.checked).toBeTruthy();
+      const noButton = screen.getByTestId(FORM.LEARNER_CAP.OPTIONS.no);
+      fireEvent.click(noButton);
+      await checksForCancelConfirmation();
+    });
+    it('shows confirmation modal when there are edits to learner cap amount', async () => {
+      const input = screen.getByTestId('per-learner-spend-cap-amount');
+      fireEvent.change(input, { target: { value: '100.50' } });
+      await checksForCancelConfirmation();
+    });
+    it('shows confirmation modal when there are edits checkbox is selected/unselected', async () => {
+      const checkbox = screen.getByTestId('internal-only-checkbox');
+      fireEvent.click(checkbox);
+      await checksForCancelConfirmation();
+    });
   });
 });

--- a/src/Configuration/Provisioning/SubsidyEditView/tests/SubsidyEditView.test.jsx
+++ b/src/Configuration/Provisioning/SubsidyEditView/tests/SubsidyEditView.test.jsx
@@ -2,7 +2,6 @@
 import Router from 'react-router-dom';
 import { renderWithRouter } from '@edx/frontend-enterprise-utils';
 import { act, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { ProvisioningContext, hydratedInitialState } from '../../../testData/Provisioning/ProvisioningContextWrapper';
 import PROVISIONING_PAGE_TEXT from '../../data/constants';
 import SubsidyEditView from '../SubsidyEditView';

--- a/src/Configuration/Provisioning/SubsidyEditView/tests/SubsidyEditView.test.jsx
+++ b/src/Configuration/Provisioning/SubsidyEditView/tests/SubsidyEditView.test.jsx
@@ -1,7 +1,13 @@
 /* eslint-disable react/prop-types */
 import Router from 'react-router-dom';
 import { renderWithRouter } from '@edx/frontend-enterprise-utils';
-import { act, screen } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ProvisioningContext, hydratedInitialState } from '../../../testData/Provisioning/ProvisioningContextWrapper';
 import PROVISIONING_PAGE_TEXT from '../../data/constants';
 import SubsidyEditView from '../SubsidyEditView';
@@ -161,5 +167,43 @@ describe('SubsidyEditView', () => {
     setupEventListener();
     window.dispatchEvent(new Event('beforeunload'));
     expect(window.addEventListener).toHaveBeenCalledWith('beforeunload', enableBeforeUnload);
+  });
+  it('tests for plan title updates and cancel modal should appear', async () => {
+    const { FORM: { CANCEL } } = PROVISIONING_PAGE_TEXT;
+
+    const updatedStateValue = {
+      ...hydratedInitialState,
+      hasEdits: false,
+      isEditMode: true,
+    };
+    jest.spyOn(Router, 'useParams').mockReturnValue({ id: '0196e5c3-ba08-4798-8bf1-019d747c27bf' });
+    await act(async () => renderWithRouter(<SubsidyEditViewWrapper value={updatedStateValue} />));
+    const input = screen.getByTestId('customer-plan-title');
+    fireEvent.change(input, { target: { value: 'test' } });
+    const button = screen.getByRole('button', {
+      name: CANCEL.description,
+    });
+    expect(button).toBeInTheDocument();
+    userEvent.click(button);
+    await waitFor(() => expect(screen.getByText(CANCEL.MODAL.TITLE)).toBeInTheDocument());
+  });
+  it('tests for term updates and cancel modal should appear', async () => {
+    const { FORM: { CANCEL } } = PROVISIONING_PAGE_TEXT;
+
+    const updatedStateValue = {
+      ...hydratedInitialState,
+      hasEdits: false,
+      isEditMode: true,
+    };
+    jest.spyOn(Router, 'useParams').mockReturnValue({ id: '0196e5c3-ba08-4798-8bf1-019d747c27bf' });
+    await act(async () => renderWithRouter(<SubsidyEditViewWrapper value={updatedStateValue} />));
+    const startDateInput = screen.getByTestId('start-date');
+    fireEvent.change(startDateInput, { target: { value: '2021-01-01' } });
+    const button = screen.getByRole('button', {
+      name: CANCEL.description,
+    });
+    expect(button).toBeInTheDocument();
+    userEvent.click(button);
+    await waitFor(() => expect(screen.getByText(CANCEL.MODAL.TITLE)).toBeInTheDocument());
   });
 });

--- a/src/Configuration/Provisioning/SubsidyEditView/tests/SubsidyEditView.test.jsx
+++ b/src/Configuration/Provisioning/SubsidyEditView/tests/SubsidyEditView.test.jsx
@@ -1,12 +1,7 @@
 /* eslint-disable react/prop-types */
 import Router from 'react-router-dom';
 import { renderWithRouter } from '@edx/frontend-enterprise-utils';
-import {
-  act,
-  fireEvent,
-  screen,
-  waitFor,
-} from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ProvisioningContext, hydratedInitialState } from '../../../testData/Provisioning/ProvisioningContextWrapper';
 import PROVISIONING_PAGE_TEXT from '../../data/constants';

--- a/src/Configuration/Provisioning/data/constants.js
+++ b/src/Configuration/Provisioning/data/constants.js
@@ -215,6 +215,19 @@ const PROVISIONING_PAGE_TEXT = {
     EDIT_BUTTON: {
       description: 'Edit plan',
     },
+    CANCEL: {
+      description: 'Cancel',
+      MODAL: {
+        TITLE: 'Leave page without saving?',
+        BODY: 'The edits you made will not be saved.',
+        FOOTER: {
+          options: {
+            leave: 'Leave without saving',
+            stay: 'Keep editing',
+          },
+        },
+      },
+    },
   },
 };
 

--- a/src/Configuration/Provisioning/data/hooks.js
+++ b/src/Configuration/Provisioning/data/hooks.js
@@ -191,6 +191,8 @@ export default function useProvisioningContext() {
 
   const setPerLearnerCap = (perLearnerCapAmount, index) => updateFormDataState(perLearnerCapAmount, true, index);
 
+  const setHasEdits = (hasEditsBoolean) => updateRootDataState({ hasEdits: hasEditsBoolean });
+
   const hydrateCatalogQueryData = useCallback(async () => {
     const { data } = await LmsApiService.fetchEnterpriseCatalogQueries();
     const learnerCreditPrefix = '[DO NOT ALTER][LEARNER CREDIT]';
@@ -369,5 +371,6 @@ export default function useProvisioningContext() {
     setInvalidSubsidyFields,
     setInvalidPolicyFields,
     resetInvalidFields,
+    setHasEdits,
   };
 }

--- a/src/Configuration/testData/Provisioning/ProvisioningContextWrapper.jsx
+++ b/src/Configuration/testData/Provisioning/ProvisioningContextWrapper.jsx
@@ -67,6 +67,7 @@ export const hydratedInitialState = {
     subsidy: [],
     policies: [],
   },
+  hasEdits: true,
 };
 
 export const ProvisioningContext = ({

--- a/src/Configuration/testData/Provisioning/ProvisioningContextWrapper.jsx
+++ b/src/Configuration/testData/Provisioning/ProvisioningContextWrapper.jsx
@@ -67,7 +67,7 @@ export const hydratedInitialState = {
     subsidy: [],
     policies: [],
   },
-  hasEdits: true,
+  hasEdits: false,
 };
 
 export const ProvisioningContext = ({


### PR DESCRIPTION
# Description
As part of enhancing the user experience in the provisioning tool for LC2, we need to implement the ability to cancel changes made in the edit form. 

# Solution
The "Cancel" button is added to the top and bottom of the form in edit view. Additionally, a confirmation modal appears if the user leaves the edit mode with unsaved edits, allowing them to confirm their decision before discarding the changes.

https://github.com/openedx/frontend-app-support-tools/assets/71999631/c812dbbe-91ef-40d2-bdfd-4a84c0d981e2

[JIRA](https://2u-internal.atlassian.net/browse/ENT-7506)

