### PR TITLE
fix: fixed typos and added loading state

### DIFF
--- a/src/Configuration/Provisioning/SubsidyDetailView/PolicyDetailView/tests/AssociatedCatalogDetail.test.jsx
+++ b/src/Configuration/Provisioning/SubsidyDetailView/PolicyDetailView/tests/AssociatedCatalogDetail.test.jsx
@@ -13,7 +13,7 @@ describe('AssociatedCatalog', () => {
   it('renders the component with only the catalog type and does not include uuid or budget word', () => {
     render(<AssociatedCatalogDetail associatedCatalog={mockCatalogs[CATALOG.OPTIONS.openCourses]} />);
     expect(screen.getByText('Catalog')).toBeInTheDocument();
-    expect(screen.getByText('Associated Catalog')).toBeInTheDocument();
+    expect(screen.getByText('Associated catalog')).toBeInTheDocument();
     expect(screen.getByText('Open Courses')).toBeInTheDocument();
     expect(screen.queryByText('1234567890')).toBeNull();
     expect(screen.queryByText('Budget')).toBeNull();

--- a/src/Configuration/Provisioning/SubsidyDetailView/tests/SubsidyDetailView.test.jsx
+++ b/src/Configuration/Provisioning/SubsidyDetailView/tests/SubsidyDetailView.test.jsx
@@ -105,7 +105,7 @@ describe('SubsidyDetailView', () => {
     expect(screen.getByText('June 22, 2023')).toBeInTheDocument();
     expect(screen.getByText('Internal only')).toBeInTheDocument();
     expect(screen.getByText('Test Plan')).toBeInTheDocument();
-    expect(screen.getByText('Subsidy Type')).toBeInTheDocument();
+    expect(screen.getByText('Subsidy type')).toBeInTheDocument();
     expect(screen.getByText('Rev req through standard commercial process?')).toBeInTheDocument();
     expect(screen.getByText('No (partner no rev prepay)')).toBeInTheDocument();
     expect(screen.getByText('Budget by product')).toBeInTheDocument();

--- a/src/Configuration/Provisioning/SubsidyEditView/SubsidyEditView.jsx
+++ b/src/Configuration/Provisioning/SubsidyEditView/SubsidyEditView.jsx
@@ -13,6 +13,7 @@ import ROUTES from '../../../data/constants/routes';
 import AccountTypeDetail from '../SubsidyDetailView/AccountTypeDetail';
 import CancelButton from './CancelButton';
 import CustomerDetail from '../SubsidyDetailView/CustomerDetail';
+import PageLoading from '../../../components/common/PageLoading';
 import ProvisioningFormAlert from '../ProvisioningForm/ProvisioningFormAlert';
 import ProvisioningFormTerm from '../ProvisioningForm/ProvisioningFormTerm';
 import ProvisioningFormInternalOnly from '../ProvisioningForm/ProvisioningFormInternalOnly';
@@ -99,7 +100,7 @@ const SubsidyEditView = () => {
           <CancelButton />
         </div>
       </div>
-    ) : null
+    ) : <PageLoading srMessage="Loading" />
   );
 };
 

--- a/src/Configuration/Provisioning/SubsidyEditView/tests/SubsidyEditView.test.jsx
+++ b/src/Configuration/Provisioning/SubsidyEditView/tests/SubsidyEditView.test.jsx
@@ -173,7 +173,7 @@ describe('SubsidyEditView', () => {
     expect(screen.getByText('No, create one Learner Credit budget')).toBeInTheDocument();
     expect(screen.getByTestId('account-name').value).toBe('Paper company --- Open Courses');
     expect(screen.getByText(
-      'The maximum USD value a single learner may redeem from the budget. This value should be less then the budget starting balance.',
+      'The maximum USD value a single learner may redeem from the budget. This value should be less than the budget starting balance.',
     )).toBeInTheDocument();
     expect(screen.getByText('Save Edits')).toBeInTheDocument();
     expect(screen.getByText('Cancel')).toBeInTheDocument();

--- a/src/Configuration/Provisioning/data/constants.js
+++ b/src/Configuration/Provisioning/data/constants.js
@@ -66,7 +66,7 @@ const PROVISIONING_PAGE_TEXT = {
       },
     },
     SUBSIDY_TYPE: {
-      TITLE: 'Subsidy Type',
+      TITLE: 'Subsidy type',
       SUB_TITLE: 'Rev req through standard commercial process?',
       OPTIONS: {
         yes: 'Yes (bulk enrollment prepay)',
@@ -112,7 +112,7 @@ const PROVISIONING_PAGE_TEXT = {
     },
     CATALOG: {
       TITLE: 'Catalog',
-      SUB_TITLE: 'Associated Catalog',
+      SUB_TITLE: 'Associated catalog',
       OPTIONS: {
         everything: 'Everything',
         openCourses: 'Open Courses',
@@ -162,7 +162,7 @@ const PROVISIONING_PAGE_TEXT = {
       OPTIONS: {
         perLearnerSpendCap: {
           title: 'Per learner spend limit ($)',
-          subtitle: 'The maximum USD value a single learner may redeem from the budget. This value should be less then the budget starting balance.',
+          subtitle: 'The maximum USD value a single learner may redeem from the budget. This value should be less than the budget starting balance.',
         },
       },
       ERROR: {


### PR DESCRIPTION
# Description
Follow up ticket to fix errors from bug bash.

# Solution
|Description|UI Change|
| ------------- | ------------- |
|Added a loading state in Edit View|<img width="1485" alt="Screenshot 2023-09-25 at 10 58 40 AM" src="https://github.com/openedx/frontend-app-support-tools/assets/71999631/b48b87c6-12ef-4969-81b3-92dd25570b9d">|
|Fixed typo: "Subsidy Type" - the "T" should not be capitalized|<img width="422" alt="Screenshot 2023-09-25 at 10 50 43 AM" src="https://github.com/openedx/frontend-app-support-tools/assets/71999631/d5691faa-d590-4cef-b93b-b8346bcaa5c8">|
|Fixed typo: The maximum USD value a single learner may redeem from the budget. This value should be less then than the budget starting balance.|<img width="882" alt="Screenshot 2023-09-25 at 10 51 20 AM" src="https://github.com/openedx/frontend-app-support-tools/assets/71999631/d2953794-b85a-4f54-a150-cd5f83eb4c9e">|
|Fixed typo: "Associated Catalog" the "C" should not be capitalized|<img width="230" alt="Screenshot 2023-09-25 at 10 50 52 AM" src="https://github.com/openedx/frontend-app-support-tools/assets/71999631/bda1f69e-c436-4e77-bf6d-9750ef5fa66f">|

