### PR TITLE
fix: associated catalog selection bug in prod

### DIFF
--- a/src/Configuration/Provisioning/SubsidyEditView/tests/SubsidyEditView.test.jsx
+++ b/src/Configuration/Provisioning/SubsidyEditView/tests/SubsidyEditView.test.jsx
@@ -56,7 +56,7 @@ const mocks = {
         enterprise_customer: '4a67c952-8eb1-44ba-9ab3-2faa5d0905de',
         title: '4a67c952-8eb1-44ba-9ab3-2faa5d0905de - Open Courses budget',
         uuid: '69035754-fa48-4519-92d8-a723ae0f6e58',
-        enterprise_catalog_query: 29,
+        enterprise_catalog_query: 2,
       }],
     },
   },

--- a/src/Configuration/Provisioning/data/constants.js
+++ b/src/Configuration/Provisioning/data/constants.js
@@ -267,21 +267,6 @@ export const INITIAL_CATALOG_QUERIES = {
   ],
 };
 
-export const CATALOG_QUERIES = {
-  Everything: {
-    id: 28,
-    catalogQueryTitle: 'Everything',
-  },
-  'Executive Education budget': {
-    id: 29,
-    catalogQueryTitle: 'Executive Education budget',
-  },
-  'Open Courses budget': {
-    id: 30,
-    catalogQueryTitle: 'Open Courses budget',
-  },
-};
-
 export const MAX_PAGE_SIZE = 12;
 
 export default PROVISIONING_PAGE_TEXT;

--- a/src/Configuration/Provisioning/data/hooks.js
+++ b/src/Configuration/Provisioning/data/hooks.js
@@ -254,10 +254,11 @@ export default function useProvisioningContext() {
               title: catalogCategoryTitle,
               catalogUuid: catalog.uuid,
             };
-          } else if (catalog.enterprise_catalog_query === predefinedQueries.everything
-            || catalog.enterprise_catalog_query === predefinedQueries.executiveEducation
-            || catalog.enterprise_catalog_query === predefinedQueries.openCourses
-          ) {
+          } else if ([
+            predefinedQueries.everything,
+            predefinedQueries.executiveEducation,
+            predefinedQueries.openCourses,
+          ].includes(catalog.enterprise_catalog_query)) {
             catalogQuery = {
               id: catalog?.enterprise_catalog_query,
               title: catalogCategoryTitle.split(splitStringBudget)[0],

--- a/src/Configuration/Provisioning/data/hooks.js
+++ b/src/Configuration/Provisioning/data/hooks.js
@@ -6,7 +6,6 @@ import LmsApiService from '../../../data/services/EnterpriseApiService';
 import PROVISIONING_PAGE_TEXT, {
   INITIAL_CATALOG_QUERIES,
   MAX_PAGE_SIZE,
-  CATALOG_QUERIES,
   splitStringBudget,
 } from './constants';
 import { ProvisioningContext } from '../ProvisioningContext';
@@ -239,6 +238,7 @@ export default function useProvisioningContext() {
     const policiesData = policies.data.results.filter(policy => policy.subsidy_uuid === subsidyUuid).map(policy => {
       let catalogCategoryTitle;
       const formattedPolicies = [];
+      const predefinedQueries = getCamelCasedConfigAttribute('PREDEFINED_CATALOG_QUERIES');
 
       catalogs.forEach(catalog => {
         if (catalog.uuid === policy.catalog_uuid) {
@@ -254,9 +254,9 @@ export default function useProvisioningContext() {
               title: catalogCategoryTitle,
               catalogUuid: catalog.uuid,
             };
-          } else if (catalog.enterprise_catalog_query === CATALOG_QUERIES['Open Courses budget'].id
-            || catalog.enterprise_catalog_query === CATALOG_QUERIES.Everything.id
-            || catalog.enterprise_catalog_query === CATALOG_QUERIES['Executive Education budget'].id
+          } else if (catalog.enterprise_catalog_query === predefinedQueries.everything
+            || catalog.enterprise_catalog_query === predefinedQueries.executiveEducation
+            || catalog.enterprise_catalog_query === predefinedQueries.openCourses
           ) {
             catalogQuery = {
               id: catalog?.enterprise_catalog_query,


### PR DESCRIPTION
# Description 
The provisioning tool's edit view renders the associated catalog selection based on the `PREDEFINED_CATALOG_QUERIES`. However, currently in prod, the associated catalog isn't rendering correctly for single budget plans due to a code discrepancy. The code was originally matching the data returned from the enterprise catalogs service with the [staged](https://github.com/edx/edx-internal/blob/8ddec5706fcd00dc4a8bf0ccc80931dd2a9adeb9/edx-remote-config/stage/lms.yml#L1555) `PREDEFINED_CATALOG_QUERIES`, which differs from the [production](https://github.com/edx/edx-internal/blob/23a79984698ee18ccb48aeed35a931fe4b4bc829/edx-remote-config/prod/lms.yml#L1729) environment.

# Solution
To address this issue, update the matching logic to utilize the config attribute, which will correctly identify the `PREDEFINED_CATALOG_QUERIES` regardless of the environment.

https://2u-internal.atlassian.net/browse/ENT-7784 