### PR TITLE
feat: update primary search field to customer name

### DIFF
--- a/src/Configuration/Provisioning/DashboardDataTable/DashboardDataTable.jsx
+++ b/src/Configuration/Provisioning/DashboardDataTable/DashboardDataTable.jsx
@@ -66,9 +66,10 @@ const DashboardDataTable = () => {
         FilterStatusComponent={FilterStatus}
         columns={[
           {
-            Header: 'Plan ID',
-            accessor: 'uuid',
-            Cell: PlanIdHyperlink,
+            Header: 'Customer name',
+            accessor: 'enterpriseCustomerName',
+            disableSortBy: true,
+            Cell: CustomerNameHyperlink,
           },
           {
             Header: 'Plan name',
@@ -76,16 +77,15 @@ const DashboardDataTable = () => {
             Cell: PlanTitleHyperlink,
           },
           {
+            Header: 'Plan ID',
+            accessor: 'uuid',
+            Cell: PlanIdHyperlink,
+          },
+          {
             Header: 'Plan Status',
             accessor: 'isActive',
             disableFilters: true,
             Cell: DashboardTableBadges,
-          },
-          {
-            Header: 'Customer name',
-            accessor: 'enterpriseCustomerName',
-            disableSortBy: true,
-            Cell: CustomerNameHyperlink,
           },
           {
             Header: 'Start date',


### PR DESCRIPTION
# Description
The current search feature requires user to search by plan id with the exact match. ECS has requested that this search field be updated to search by customer name.

# AC 
Update the primary to search field to customer name by swapping columns Plan ID with Customer Name.

https://github.com/openedx/frontend-app-support-tools/assets/71999631/01cb0ce2-dbaa-444b-a7ec-87502eb31b6e

