### PR TITLE
chore: Update to the new version of brand-openedx in the new scope.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
+        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
         "@edx/frontend-enterprise-utils": "4.0.0",
         "@edx/frontend-platform": "^5.6.1",
         "@edx/paragon": "20.46.0",
@@ -2069,10 +2069,10 @@
       }
     },
     "node_modules/@edx/brand": {
-      "name": "@edx/brand-openedx",
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.2.0.tgz",
-      "integrity": "sha512-r4PDN3rCgDsLovW44ayxoNNHgG5I4Rvss6MG5CrQEX4oW8YhQVEod+jJtwR5vi0mFLN2GIaMlDpd7iIy03VqXg=="
+      "name": "@openedx/brand-openedx",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.2.tgz",
+      "integrity": "sha512-mBvxR7aB9290j9+h3d/9G8VkG1b8ecLSmlxc0vskfm7DL/fKUzFmHAj3PI7Z4kkwCQOL4QT5mJHJKC0ZFf7qvQ=="
     },
     "node_modules/@edx/browserslist-config": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/openedx/frontend-app-support-tools/issues"
   },
   "dependencies": {
-    "@edx/brand": "npm:@edx/brand-openedx@1.2.0",
+    "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/frontend-enterprise-utils": "4.0.0",
     "@edx/frontend-platform": "^5.6.1",
     "@edx/paragon": "20.46.0",


### PR DESCRIPTION
Part of https://github.com/openedx/axim-engineering/issues/23

This updates the `@edx/brand` alias to point to the `brand-openedx` package at
the `openedx` scope. This does not impact imports because this package is used
via an alias.
