### PR TITLE
feat: adds budget distribution mode selection component in provisioning tool

### DIFF
--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormPerLearnerCapContainer.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormPerLearnerCapContainer.jsx
@@ -1,12 +1,15 @@
 import ProvisioningFormPerLearnerCap from './ProvisioningFormPerLearnerCap';
 import ProvisioningFormPerLearnerCapAmount from './ProvisioningFormPerLearnerCapAmount';
+import PROVISIONING_PAGE_TEXT from '../../data/constants';
 import { indexOnlyPropType, selectProvisioningContext } from '../../data/utils';
 
 const ProvisioningFormPerLearnerCapContainer = ({ index }) => {
   const [formData] = selectProvisioningContext('formData');
+  const { POLICY_TYPE: { OPTIONS } } = PROVISIONING_PAGE_TEXT.FORM;
   return (
     <>
-      <ProvisioningFormPerLearnerCap index={index} />
+      {formData.policies[index]?.policyType === OPTIONS.LEARNER_SELECTS.VALUE
+        && <ProvisioningFormPerLearnerCap index={index} />}
       {formData.policies[index]?.perLearnerCap && <ProvisioningFormPerLearnerCapAmount index={index} />}
     </>
   );

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormPolicyContainer.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormPolicyContainer.jsx
@@ -4,6 +4,7 @@ import ProvisioningFormAccountDetails from './ProvisioningFormAccountDetails';
 import ProvisioningFormPerLearnerCapContainer from './ProvisioningFormPerLearnerCapContainer';
 import { indexOnlyPropType } from '../../data/utils';
 import ProvisioningFormDescription from './ProvisioningFormDescription';
+import ProvisioningFormPolicyType from './ProvisioningFormPolicyType';
 
 const ProvisioningFormPolicyContainer = ({ title, index }) => (
   <div className="mt-5">
@@ -11,6 +12,7 @@ const ProvisioningFormPolicyContainer = ({ title, index }) => (
     <ProvisioningFormAccountDetails index={index} />
     <ProvisioningFormDescription index={index} />
     <ProvisioningFormCatalogContainer index={index} />
+    <ProvisioningFormPolicyType index={index} />
     <ProvisioningFormPerLearnerCapContainer index={index} />
   </div>
 );

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormPolicyType.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormPolicyType.jsx
@@ -1,0 +1,82 @@
+import {
+  Form,
+} from '@edx/paragon';
+import { v4 as uuidv4 } from 'uuid';
+import React, { useState } from 'react';
+import PROVISIONING_PAGE_TEXT from '../../data/constants';
+import useProvisioningContext from '../../data/hooks';
+import { indexOnlyPropType, selectProvisioningContext } from '../../data/utils';
+
+const ProvisioningFormPolicyType = ({ index }) => {
+  const { perLearnerCap, setPolicyType, setInvalidPolicyFields } = useProvisioningContext();
+  const { POLICY_TYPE } = PROVISIONING_PAGE_TEXT.FORM;
+  const [formData, showInvalidField] = selectProvisioningContext('formData', 'showInvalidField');
+  const { policies } = showInvalidField;
+  const isPolicyTypeDefinedAndFalse = policies[index]?.policyType === false;
+
+  const [value, setValue] = useState(null);
+
+  const handleChange = (e) => {
+    const policyTypeValue = e.target.value;
+    if (policyTypeValue === POLICY_TYPE.OPTIONS.LEARNER_SELECTS.DESCRIPTION) {
+      setPolicyType({
+        policyType: POLICY_TYPE.OPTIONS.LEARNER_SELECTS.VALUE,
+        accessMethod: POLICY_TYPE.OPTIONS.LEARNER_SELECTS.ACCESS_METHOD,
+      }, index);
+    } else if (policyTypeValue === POLICY_TYPE.OPTIONS.ADMIN_SELECTS.DESCRIPTION) {
+      setPolicyType({
+        policyType: POLICY_TYPE.OPTIONS.ADMIN_SELECTS.VALUE,
+        accessMethod: POLICY_TYPE.OPTIONS.ADMIN_SELECTS.ACCESS_METHOD,
+      }, index);
+      perLearnerCap({
+        perLearnerCap: false,
+      }, index);
+      setInvalidPolicyFields({ perLearnerCap: true }, index);
+    }
+    setValue(policyTypeValue);
+    setInvalidPolicyFields({ policyType: true }, index);
+  };
+
+  return (
+    <article className="mt-4.5">
+      <div>
+        <h3>{POLICY_TYPE.TITLE}</h3>
+      </div>
+      <Form.Group
+        className="mt-3.5"
+      >
+        <Form.Label className="mb-2.5">{POLICY_TYPE.LABEL}</Form.Label>
+        <Form.RadioSet
+          name={`display-policy-type-${index}`}
+          onChange={handleChange}
+          value={value || formData.policies[index]?.policyType}
+        >
+          {
+            Object.keys(POLICY_TYPE.OPTIONS).map((key) => (
+              <Form.Radio
+                value={POLICY_TYPE.OPTIONS[key].DESCRIPTION}
+                type="radio"
+                key={uuidv4()}
+                data-testid={POLICY_TYPE.OPTIONS[key].DESCRIPTION}
+                isInvalid={isPolicyTypeDefinedAndFalse}
+              >
+                {POLICY_TYPE.OPTIONS[key].DESCRIPTION}
+              </Form.Radio>
+            ))
+          }
+        </Form.RadioSet>
+        {isPolicyTypeDefinedAndFalse && (
+          <Form.Control.Feedback
+            type="invalid"
+          >
+            {POLICY_TYPE.ERROR}
+          </Form.Control.Feedback>
+        )}
+      </Form.Group>
+    </article>
+  );
+};
+
+ProvisioningFormPolicyType.propTypes = indexOnlyPropType;
+
+export default ProvisioningFormPolicyType;

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormPolicyType.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/ProvisioningFormPolicyType.jsx
@@ -52,15 +52,15 @@ const ProvisioningFormPolicyType = ({ index }) => {
           value={value || formData.policies[index]?.policyType}
         >
           {
-            Object.keys(POLICY_TYPE.OPTIONS).map((key) => (
+            Object.values(POLICY_TYPE.OPTIONS).map(({ DESCRIPTION }) => (
               <Form.Radio
-                value={POLICY_TYPE.OPTIONS[key].DESCRIPTION}
+                value={DESCRIPTION}
                 type="radio"
                 key={uuidv4()}
-                data-testid={POLICY_TYPE.OPTIONS[key].DESCRIPTION}
+                data-testid={DESCRIPTION}
                 isInvalid={isPolicyTypeDefinedAndFalse}
               >
-                {POLICY_TYPE.OPTIONS[key].DESCRIPTION}
+                {DESCRIPTION}
               </Form.Radio>
             ))
           }

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormPerLearnerCapContainer.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormPerLearnerCapContainer.test.jsx
@@ -69,4 +69,27 @@ describe('PerLearnerCapContainer', () => {
     fireEvent.click(input);
     expect(screen.queryByText(LEARNER_CAP_DETAIL.TITLE)).not.toBeTruthy();
   });
+  it('does not render learner cap if policy type is AssignedLearnerCreditAccessPolicy', () => {
+    const updatedState = {
+      ...initialStateValue,
+      multipleFunds: false,
+      formData: {
+        ...initialStateValue.formData,
+        policies: [
+          {
+            ...INITIAL_CATALOG_QUERIES.defaultQuery,
+            policyType: POLICY_TYPE.OPTIONS.ADMIN_SELECTS.VALUE,
+          },
+        ],
+      },
+    };
+
+    renderWithRouter(
+      <ProvisioningFormPerLearnerCapContainerWrapper
+        value={updatedState}
+        index={0}
+      />,
+    );
+    expect(screen.queryByText(LEARNER_CAP.TITLE)).not.toBeTruthy();
+  });
 });

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormPerLearnerCapContainer.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormPerLearnerCapContainer.test.jsx
@@ -5,7 +5,7 @@ import { ProvisioningContext, initialStateValue } from '../../../../testData/Pro
 import PROVISIONING_PAGE_TEXT, { INITIAL_CATALOG_QUERIES } from '../../../data/constants';
 import ProvisioningFormPerLearnerCapContainer from '../ProvisioningFormPerLearnerCapContainer';
 
-const { LEARNER_CAP_DETAIL, LEARNER_CAP } = PROVISIONING_PAGE_TEXT.FORM;
+const { LEARNER_CAP_DETAIL, LEARNER_CAP, POLICY_TYPE } = PROVISIONING_PAGE_TEXT.FORM;
 
 const ProvisioningFormPerLearnerCapContainerWrapper = ({
   value = initialStateValue,
@@ -16,19 +16,25 @@ const ProvisioningFormPerLearnerCapContainerWrapper = ({
   </ProvisioningContext>
 );
 
+const updatedInitialState = {
+  ...initialStateValue,
+  multipleFunds: false,
+  formData: {
+    ...initialStateValue.formData,
+    policies: [
+      {
+        ...INITIAL_CATALOG_QUERIES.defaultQuery,
+        policyType: POLICY_TYPE.OPTIONS.LEARNER_SELECTS.VALUE,
+      },
+    ],
+  },
+};
+
 describe('PerLearnerCapContainer', () => {
   beforeEach(() => {
     jest.resetAllMocks();
   });
   it('renders single policy state', () => {
-    const updatedInitialState = {
-      ...initialStateValue,
-      multipleFunds: false,
-      formData: {
-        ...initialStateValue.formData,
-        policies: INITIAL_CATALOG_QUERIES.defaultQuery,
-      },
-    };
     renderWithRouter(
       <ProvisioningFormPerLearnerCapContainerWrapper
         value={updatedInitialState}
@@ -40,14 +46,6 @@ describe('PerLearnerCapContainer', () => {
     expect(screen.getByText(LEARNER_CAP.SUB_TITLE)).toBeTruthy();
   });
   it('updates the state of form on change, true', () => {
-    const updatedInitialState = {
-      ...initialStateValue,
-      multipleFunds: false,
-      formData: {
-        ...initialStateValue.formData,
-        policies: INITIAL_CATALOG_QUERIES.defaultQuery,
-      },
-    };
     renderWithRouter(
       <ProvisioningFormPerLearnerCapContainerWrapper
         value={updatedInitialState}
@@ -60,14 +58,6 @@ describe('PerLearnerCapContainer', () => {
     expect(screen.getByText(LEARNER_CAP_DETAIL.TITLE)).toBeTruthy();
   });
   it('updates the state of form on change, false', () => {
-    const updatedInitialState = {
-      ...initialStateValue,
-      multipleFunds: false,
-      formData: {
-        ...initialStateValue.formData,
-        policies: INITIAL_CATALOG_QUERIES.defaultQuery,
-      },
-    };
     renderWithRouter(
       <ProvisioningFormPerLearnerCapContainerWrapper
         value={updatedInitialState}

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormPolicyContainer.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormPolicyContainer.test.jsx
@@ -1,11 +1,12 @@
 /* eslint-disable react/prop-types */
 import { renderWithRouter } from '@edx/frontend-enterprise-utils';
-import { screen } from '@testing-library/react';
+import { screen, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import ProvisioningFormPolicyContainer from '../ProvisioningFormPolicyContainer';
 import { ProvisioningContext, initialStateValue } from '../../../../testData/Provisioning';
 import PROVISIONING_PAGE_TEXT, { INITIAL_CATALOG_QUERIES } from '../../../data/constants';
 
-const { ACCOUNT_DETAIL } = PROVISIONING_PAGE_TEXT.FORM;
+const { ACCOUNT_DETAIL, POLICY_TYPE } = PROVISIONING_PAGE_TEXT.FORM;
 
 const ProvisioningFormPolicyContainerWrapper = ({
   value = initialStateValue,
@@ -63,5 +64,30 @@ describe('ProvisioningFormPolicyContainer', () => {
     expect(screen.getAllByText(ACCOUNT_DETAIL.TITLE).length).toEqual(INITIAL_CATALOG_QUERIES.multipleQueries.length);
     expect(screen.getByText(INITIAL_CATALOG_QUERIES.multipleQueries[0].catalogQueryTitle)).toBeTruthy();
     expect(screen.getByText(INITIAL_CATALOG_QUERIES.multipleQueries[1].catalogQueryTitle)).toBeTruthy();
+  });
+  it('renders policy type and selects AssignedLearnerCreditAccessPolicy', async () => {
+    const updatedInitialState = {
+      ...initialStateValue,
+      multipleFunds: false,
+      formData: {
+        ...initialStateValue.formData,
+        policies: INITIAL_CATALOG_QUERIES.defaultQuery,
+      },
+    };
+    renderWithRouter(
+      <ProvisioningFormPolicyContainerWrapper
+        value={updatedInitialState}
+        sampleCatalogQuery={INITIAL_CATALOG_QUERIES.defaultQuery}
+      />,
+    );
+    expect(screen.getByText(POLICY_TYPE.TITLE)).toBeTruthy();
+    expect(screen.getByText(POLICY_TYPE.LABEL)).toBeTruthy();
+    const learnerOption = screen.getByTestId(POLICY_TYPE.OPTIONS.ADMIN_SELECTS.DESCRIPTION);
+    await act(async () => {
+      userEvent.click(learnerOption);
+    });
+    await waitFor(() => {
+      expect(learnerOption.checked).toBeTruthy();
+    });
   });
 });

--- a/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormPolicyType.test.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/PolicyForm/tests/ProvisioningFormPolicyType.test.jsx
@@ -1,0 +1,55 @@
+/* eslint-disable react/prop-types */
+import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { fireEvent, screen } from '@testing-library/react';
+import { ProvisioningContext, initialStateValue } from '../../../../testData/Provisioning';
+import PROVISIONING_PAGE_TEXT, { INITIAL_CATALOG_QUERIES } from '../../../data/constants';
+import ProvisioningFormPolicyType from '../ProvisioningFormPolicyType';
+
+const { POLICY_TYPE } = PROVISIONING_PAGE_TEXT.FORM;
+
+const ProvisioningFormPolicyTypeWrapper = ({
+  value = initialStateValue,
+  index = 0,
+}) => (
+  <ProvisioningContext value={value}>
+    <ProvisioningFormPolicyType index={index} />
+  </ProvisioningContext>
+);
+
+describe('ProvisioningFormPolicyType', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+  it('renders', () => {
+    const updatedInitialState = {
+      ...initialStateValue,
+      multipleFunds: false,
+      formData: {
+        ...initialStateValue.formData,
+        policies: INITIAL_CATALOG_QUERIES.defaultQuery,
+      },
+    };
+    renderWithRouter(
+      <ProvisioningFormPolicyTypeWrapper
+        value={updatedInitialState}
+        index={0}
+      />,
+    );
+
+    expect(screen.getByText(POLICY_TYPE.TITLE)).toBeTruthy();
+    expect(screen.getByText(POLICY_TYPE.LABEL)).toBeTruthy();
+
+    const policyTypeOptions = Object.keys(POLICY_TYPE.OPTIONS);
+    const policyTypeButtons = [];
+    // Retrieves a list of input elements based on test ids
+    for (let i = 0; i < policyTypeOptions.length; i++) {
+      policyTypeButtons.push(screen.getByTestId(POLICY_TYPE.OPTIONS[policyTypeOptions[i]].DESCRIPTION));
+    }
+
+    // Clicks on each input element and checks if it is checked
+    for (let i = 0; i < policyTypeButtons.length; i++) {
+      fireEvent.click(policyTypeButtons[i]);
+      expect(policyTypeButtons[i].checked).toBeTruthy();
+    }
+  });
+});

--- a/src/Configuration/Provisioning/data/constants.js
+++ b/src/Configuration/Provisioning/data/constants.js
@@ -235,6 +235,23 @@ const PROVISIONING_PAGE_TEXT = {
         },
       },
     },
+    POLICY_TYPE: {
+      TITLE: 'Budget distribution mode',
+      LABEL: 'How is content selected?',
+      OPTIONS: {
+        LEARNER_SELECTS: {
+          DESCRIPTION: 'Learner selects content or LMS',
+          VALUE: 'PerLearnerSpendCreditAccessPolicy',
+          ACCESS_METHOD: 'direct',
+        },
+        ADMIN_SELECTS: {
+          DESCRIPTION: 'Admin selects content',
+          VALUE: 'AssignedLearnerCreditAccessPolicy',
+          ACCESS_METHOD: 'assigned',
+        },
+      },
+      ERROR: 'Please select an option.',
+    },
   },
 };
 

--- a/src/Configuration/Provisioning/data/hooks.js
+++ b/src/Configuration/Provisioning/data/hooks.js
@@ -190,6 +190,8 @@ export default function useProvisioningContext() {
 
   const setPerLearnerCap = (perLearnerCapAmount, index) => updateFormDataState(perLearnerCapAmount, true, index);
 
+  const setPolicyType = (policyType, index) => updateFormDataState(policyType, true, index);
+
   const setHasEdits = (hasEditsBoolean) => updateRootDataState({ hasEdits: hasEditsBoolean });
 
   const hydrateCatalogQueryData = useCallback(async () => {
@@ -376,5 +378,6 @@ export default function useProvisioningContext() {
     setInvalidPolicyFields,
     resetInvalidFields,
     setHasEdits,
+    setPolicyType,
   };
 }

--- a/src/Configuration/Provisioning/data/tests/utils.test.js
+++ b/src/Configuration/Provisioning/data/tests/utils.test.js
@@ -416,6 +416,7 @@ describe('determineInvalidFields', () => {
       catalogQueryMetadata: false,
       perLearnerCap: false,
       perLearnerCapAmount: false,
+      policyType: false,
     }]];
     const emptyPolicyDataset = {
       ...emptyDataSet,

--- a/src/Configuration/Provisioning/data/utils.js
+++ b/src/Configuration/Provisioning/data/utils.js
@@ -109,7 +109,7 @@ export async function determineInvalidFields(formData) {
   }
   policies.forEach((policy) => {
     const {
-      accountName, accountValue, catalogQueryMetadata, perLearnerCap, perLearnerCapAmount,
+      accountName, accountValue, catalogQueryMetadata, perLearnerCap, perLearnerCapAmount, policyType,
     } = policy;
     const policyData = {
       accountName: !!accountName,
@@ -117,6 +117,7 @@ export async function determineInvalidFields(formData) {
       catalogQueryMetadata: !!catalogQueryMetadata?.catalogQuery?.id,
       perLearnerCap: perLearnerCap !== undefined || perLearnerCap === false,
       perLearnerCapAmount: !!perLearnerCapAmount || perLearnerCap === false,
+      policyType: !!policyType,
     };
     allInvalidPolicyFields.push(policyData);
   });
@@ -434,7 +435,9 @@ export function transformSubsidyData(formData) {
  * catalogUuid: String,
  * subsidyUuid: String,
  * perLearnerSpendLimit: Number,
- * spendLimit: Number
+ * spendLimit: Number,
+ * accessMethod: String,
+ * policyType: String,
  * }} - Object fields required to create a new policy
  * @returns {Promise<Object>} - Returns a promise that resolves to the response data from the API
  */
@@ -446,6 +449,8 @@ export async function createPolicy({
   subsidyUuid,
   perLearnerSpendLimit,
   spendLimit,
+  accessMethod,
+  policyType,
 }) {
   const data = LmsApiService.postSubsidyAccessPolicy(
     displayName,
@@ -455,6 +460,8 @@ export async function createPolicy({
     subsidyUuid,
     perLearnerSpendLimit,
     spendLimit,
+    accessMethod,
+    policyType,
   );
   return data;
 }
@@ -513,6 +520,8 @@ export function transformPolicyData(formData, catalogCreationResponse, subsidyCr
     subsidyUuid: subsidyCreationResponse[0].uuid,
     perLearnerSpendLimit: policy.perLearnerCap ? parseInt(policy.perLearnerCapAmount, 10) * 100 : null,
     spendLimit: parseInt(policy.accountValue, 10) * 100,
+    policyType: policy.policyType,
+    accessMethod: policy.accessMethod,
   }));
   return payloads;
 }

--- a/src/Configuration/testData/Provisioning/ProvisioningContextWrapper.jsx
+++ b/src/Configuration/testData/Provisioning/ProvisioningContextWrapper.jsx
@@ -60,6 +60,8 @@ export const hydratedInitialState = {
             uuid: '4ev3r',
           },
         },
+        policyType: 'PerLearnerSpendCreditAccessPolicy',
+        accessMethod: 'direct',
       },
     ],
   },

--- a/src/data/services/EnterpriseApiService.js
+++ b/src/data/services/EnterpriseApiService.js
@@ -52,9 +52,9 @@ class LmsApiService {
     subsidyUuid,
     perLearnerSpendLimit,
     spendLimit,
-    accessMethod = 'direct',
+    accessMethod,
+    policyType,
     active = true,
-    policyType = 'PerLearnerSpendCreditAccessPolicy',
   ) => LmsApiService.apiClient().post(
     `${getConfig().ENTERPRISE_ACCESS_BASE_URL}/api/v1/subsidy-access-policies/`,
     {


### PR DESCRIPTION
# Description
With the addition of a top-down assignment option to a policy, modifications are required in the provisioning tool. This involves adding a new form field for budget distribution mode selection during the plan creation step for single and dual budgets. Modify the progressive disclosure logic to show the learner spend limit question only if 'Learner selects content or LMS' is selected. If the user selects 'Admin selects content', hide the learner spend limit question.

[JIRA Ticket](https://2u-internal.atlassian.net/browse/ENT-7958)

# UI
https://github.com/openedx/frontend-app-support-tools/assets/71999631/8a78b64f-3fa0-40ba-8408-e47cda649ef2

