### PR TITLE
fix: can create new plans with test plan unchecked

### DIFF
--- a/src/Configuration/Provisioning/ProvisioningContext.jsx
+++ b/src/Configuration/Provisioning/ProvisioningContext.jsx
@@ -20,6 +20,8 @@ const ProvisioningContextProvider = ({ children }) => {
       // `policies` is a list of all policies/budgets inputs for this plan. After form completion, length should be 1 if
       // multipleFunds = false, and 2 and multipleFunds = true.
       policies: [],
+      // `internalOnly` backs the "Test plan" checkbox.  A true value means the plan will not be customer facing.
+      internalOnly: false,
     },
     // `showInvalidField` indicates when form fields are valid/invalid, possibly triggering invalid attributes to be set
     // on various form field containers.

--- a/src/Configuration/Provisioning/ProvisioningForm/ProvisioningFormInternalOnly.jsx
+++ b/src/Configuration/Provisioning/ProvisioningForm/ProvisioningFormInternalOnly.jsx
@@ -11,11 +11,9 @@ const ProvisioningFormInternalOnly = () => {
   const { INTERNAL_ONLY } = PROVISIONING_PAGE_TEXT.FORM;
   const [formData, isEditMode, hasEdits] = selectProvisioningContext('formData', 'isEditMode', 'hasEdits');
 
-  let submittedFormInternalOnly;
-  if (isEditMode) {
-    submittedFormInternalOnly = formData.internalOnly;
-  }
-  const [value, setValue] = useState(submittedFormInternalOnly || false);
+  // formData.internalOnly is always defined, whether it's hydrated from an API call (isEditMode = true) or not
+  // (isEditMode = false) in which case ProvisioningContextProvider supplies a default.
+  const [value, setValue] = useState(formData.internalOnly || false);
 
   const handleChange = (e) => {
     const checkedState = e.target.checked;

--- a/src/Configuration/Provisioning/data/tests/utils.test.js
+++ b/src/Configuration/Provisioning/data/tests/utils.test.js
@@ -554,7 +554,7 @@ describe('transformSubsidyData', () => {
   const transformedSinglePolicyData = {
     enterpriseUUID,
     financialIdentifier: '00kc1230abc1234321',
-    internalOnly: 'No',
+    internalOnly: false,
     isoStartDate: '2023-04-18T00:00:00.000Z',
     isoEndDate: '2023-04-21T00:00:00.000Z',
     revenueCategory: 'partner-no-rev-prepay',

--- a/src/Configuration/testData/Provisioning/ProvisioningContextWrapper.jsx
+++ b/src/Configuration/testData/Provisioning/ProvisioningContextWrapper.jsx
@@ -21,6 +21,7 @@ export const initialStateValue = {
   },
   formData: {
     policies: [],
+    internalOnly: false,
   },
   showInvalidField: {
     subsidy: [],

--- a/src/Configuration/testData/constants.js
+++ b/src/Configuration/testData/constants.js
@@ -188,7 +188,7 @@ export const sampleMultiplePolicyFormData = {
   financialIdentifier: '00kc1230abc1234321',
   startDate: '2023-04-18',
   endDate: '2023-04-21',
-  internalOnly: 'Yes',
+  internalOnly: true,
   subsidyRevReq: 'partner-no-rev-prepay',
   subsidyUuid: '123testSubsidyUuid',
   subsidyTitle: 'Test Subsidy',
@@ -212,7 +212,7 @@ export const sampleSinglePolicyPredefinedCatalogQueryFormData = {
   financialIdentifier: '00kc1230abc1234321',
   startDate: '2023-04-18',
   endDate: '2023-04-21',
-  internalOnly: 'No',
+  internalOnly: false,
   subsidyRevReq: 'partner-no-rev-prepay',
   subsidyTitle: 'Test Subsidy',
 };
@@ -235,7 +235,7 @@ export const sampleSinglePolicyCustomCatalogQueryFormData = {
   financialIdentifier: '00kc1230abc1234321',
   startDate: '2023-04-06',
   endDate: '2023-04-27',
-  internalOnly: 'Yes',
+  internalOnly: true,
   subsidyRevReq: 'partner-no-rev-prepay',
   subsidyTitle: 'Test Subsidy',
 };
@@ -258,7 +258,7 @@ export const sampleSingleEmptyData = {
   financialIdentifier: '00kc1230abc1234321',
   startDate: '2023-04-06',
   endDate: '2023-04-27',
-  internalOnly: 'Yes',
+  internalOnly: true,
   subsidyRevReq: 'partner-no-rev-prepay',
   subsidyTitle: 'Test Subsidy',
 };


### PR DESCRIPTION
Somehow we let a regression slip through manual QA testing and unit testing which prevented non-test plans from being created.  The provisioning tool would POST to create a subsidy, but failed to supply a `default_internal_only` request parameter, which is required.  This change adds a default value for formData.internalOnly on context initialization to prevent the field from ever being empty.

ENT-8107

testing done
===
1. create a new plan without checking the Test Plan checkbox.
2. create a new plan, checking the Test Plan checkbox.
3. edit an existing plan, unchecking the Test Plan checkbox and saving.
4. edit an existing plan, checking the Test Plan checkbox and saving.