### PR TITLE
ENT-7820 Learner Credit table sorting

### DIFF
--- a/src/Configuration/Provisioning/DashboardDataTable/tests/DashboardDataTable.test.jsx
+++ b/src/Configuration/Provisioning/DashboardDataTable/tests/DashboardDataTable.test.jsx
@@ -1,21 +1,21 @@
 /* eslint-disable react/prop-types */
 import { renderWithRouter } from '@edx/frontend-enterprise-utils';
 import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { camelCaseObject } from '@edx/frontend-platform';
 import { DashboardContext, initialStateValue } from '../../../testData/Dashboard';
 import DashboardDataTable from '../DashboardDataTable';
 import { sampleDataTableData } from '../../../testData/constants';
+import SubsidyApiService from '../../../../data/services/SubsidyApiService';
 
 // Mock the debounce function
 jest.mock('lodash.debounce', () => jest.fn((fn) => fn));
 
 // Mock the subsidy list
 const mockGetAllSubsidiesData = sampleDataTableData(10);
-jest.mock('../../../../data/services/SubsidyApiService', () => ({
-  getAllSubsidies: () => Promise.resolve({
-    data: mockGetAllSubsidiesData,
-  }),
-}));
+const apiMock = jest
+  .spyOn(SubsidyApiService, 'getAllSubsidies')
+  .mockImplementation(() => Promise.resolve({ data: mockGetAllSubsidiesData }));
 
 // Mock the enterprise customers list
 const mockCustomerData = camelCaseObject(mockGetAllSubsidiesData).results.map((subsidy) => ({
@@ -45,5 +45,26 @@ describe('DashboardDatatable', () => {
     renderWithRouter(<DashboardDatatableWrapper />);
     expect(screen.getByText('loading')).toBeTruthy();
     await waitFor(() => expect(screen.getByText('Enterprise Customer 1')).toBeTruthy());
+  });
+});
+
+describe('DashboardDatatable SortBy', () => {
+  it('sorts the data asc and desc', async () => {
+    renderWithRouter(<DashboardDatatableWrapper />);
+    const tableHeader = screen.getByText('Start date');
+
+    userEvent.click(tableHeader);
+    await waitFor(() => expect(apiMock).toHaveBeenCalledWith(
+      expect.objectContaining(
+        { sortBy: 'active_datetime' },
+      ),
+    ));
+
+    userEvent.click(tableHeader);
+    await waitFor(() => expect(apiMock).toHaveBeenCalledWith(
+      expect.objectContaining(
+        { sortBy: 'active_datetime' },
+      ),
+    ));
   });
 });

--- a/src/Configuration/Provisioning/data/tests/utils.test.js
+++ b/src/Configuration/Provisioning/data/tests/utils.test.js
@@ -477,7 +477,7 @@ describe('sortDatatableData', () => {
     expect(sortDataTableData({ sortBy: {} })).toEqual(output);
   });
   it('returns a sort by expirationDateTime if isActive is passed as the id', () => {
-    const output = 'expirationDatetime';
+    const output = 'expiration_datetime';
 
     // desc is true
     expect(sortDataTableData({

--- a/src/Configuration/Provisioning/data/utils.js
+++ b/src/Configuration/Provisioning/data/utils.js
@@ -1,6 +1,7 @@
 import { useContextSelector } from 'use-context-selector';
 import PropTypes from 'prop-types';
 import { camelCaseObject, getConfig } from '@edx/frontend-platform';
+import snakeCase from 'lodash.snakecase';
 import dayjs from './dayjs';
 import { ProvisioningContext } from '../ProvisioningContext';
 import LmsApiService from '../../../data/services/EnterpriseApiService';
@@ -650,10 +651,13 @@ export function sortDataTableData({ sortBy }) {
   if (!sortByObject) {
     return null;
   }
-  if (sortByObject.id === 'isActive') {
-    return sortByObject.desc ? '-expirationDatetime' : 'expirationDatetime';
+  let sortString = sortByObject.id;
+  if (sortString === 'isActive') {
+    sortString = 'expirationDatetime';
   }
-  return sortByObject.desc ? `-${sortByObject.id}` : sortByObject.id;
+  sortString = snakeCase(sortString);
+  sortString = sortByObject.desc ? `-${sortString}` : sortString;
+  return sortString;
 }
 
 /**

--- a/src/data/services/SubsidyApiService.js
+++ b/src/data/services/SubsidyApiService.js
@@ -1,6 +1,5 @@
 import { getConfig, snakeCaseObject } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
-import snakeCase from 'lodash.snakecase';
 
 class SubsidyApiService {
   static apiClient = getAuthenticatedHttpClient;
@@ -14,7 +13,7 @@ class SubsidyApiService {
     const subsidiesURL = `${getConfig().SUBSIDY_BASE_URL}/api/v1/subsidies/`;
     const optionalUrlParams = new URLSearchParams(snakeCaseObject({
       pageSize,
-      sortBy: sortBy ? snakeCase(sortBy) : 'uuid',
+      sortBy: sortBy || 'uuid',
       ...filteredData,
     })).toString();
     return SubsidyApiService.apiClient().get(`${subsidiesURL}?page=${pageIndex}&${optionalUrlParams}`);


### PR DESCRIPTION
There were a couple issues with the `sortDataTableData` method.

1. It wasn't returning the result of the ternary, so needed to set the result to a var and return the var
2. `lodash.snakecase` was stripping out the `-` which is used for sorting in reverse. Moved the `snakecase` call before the `-` was prepended.

Added some test for asc and desc sorting.