### PR TITLE
fix: small text changes

### DIFF
--- a/src/Configuration/Provisioning/SubsidyDetailView/PolicyDetailView/tests/PolicyContainer.test.jsx
+++ b/src/Configuration/Provisioning/SubsidyDetailView/PolicyDetailView/tests/PolicyContainer.test.jsx
@@ -27,7 +27,7 @@ describe('PolicyContainer', () => {
     expect(screen.getByText('Budget details')).toBeInTheDocument();
     expect(screen.getByText('I love Executive Education Only')).toBeInTheDocument();
     expect(screen.getByText('Executive Education')).toBeInTheDocument();
-    expect(screen.getByText('Learner selects content or LMS')).toBeInTheDocument();
+    expect(screen.getByText('Browse and Enroll or LMS')).toBeInTheDocument();
     expect(screen.getByText('Create learner spend limits?')).toBeInTheDocument();
     expect(screen.getByText('Per learner spend limit ($)')).toBeInTheDocument();
     expect(screen.getByText('$2,500')).toBeInTheDocument();

--- a/src/Configuration/Provisioning/SubsidyDetailView/PolicyDetailView/tests/PolicyDistributionDetail.test.jsx
+++ b/src/Configuration/Provisioning/SubsidyDetailView/PolicyDetailView/tests/PolicyDistributionDetail.test.jsx
@@ -24,7 +24,7 @@ describe('PolicyDistributionDetail', () => {
     );
     expect(screen.getByText('Budget distribution mode')).toBeInTheDocument();
     expect(screen.getByText('How is content selected?')).toBeInTheDocument();
-    expect(screen.getByText('Learner selects content or LMS')).toBeInTheDocument();
+    expect(screen.getByText('Browse and Enroll or LMS')).toBeInTheDocument();
     expect(screen.getByText('Not editable')).toBeInTheDocument();
   });
   it('renders Admin selects option', () => {
@@ -45,7 +45,7 @@ describe('PolicyDistributionDetail', () => {
         <PolicyDistributionDetail policyType={policyType} />
       </ProvisioningContext>,
     );
-    expect(screen.getByText('Admin selects content')).toBeInTheDocument();
+    expect(screen.getByText('Admin assign')).toBeInTheDocument();
     expect(screen.getByText('Not editable')).toBeInTheDocument();
   });
 });

--- a/src/Configuration/Provisioning/data/constants.js
+++ b/src/Configuration/Provisioning/data/constants.js
@@ -260,12 +260,12 @@ const PROVISIONING_PAGE_TEXT = {
       LABEL: 'How is content selected?',
       OPTIONS: {
         LEARNER_SELECTS: {
-          DESCRIPTION: 'Learner selects content or LMS',
+          DESCRIPTION: 'Browse and Enroll or LMS',
           VALUE: 'PerLearnerSpendCreditAccessPolicy',
           ACCESS_METHOD: 'direct',
         },
         ADMIN_SELECTS: {
-          DESCRIPTION: 'Admin selects content',
+          DESCRIPTION: 'Admin assign',
           VALUE: 'AssignedLearnerCreditAccessPolicy',
           ACCESS_METHOD: 'assigned',
         },


### PR DESCRIPTION
With the release of Groups, the budget distribution mode text needs to be updated. For ‘Learner selects content or LMS', it should be ‘Browse and Enroll or LMS’. For ‘Admin selects content’, it should be 'Admin assign’

[Jira ticket](https://2u-internal.atlassian.net/browse/ENT-9091)