### PR TITLE
feat: add users table

### DIFF
--- a/src/Configuration/Customers/CustomerDataTable/CustomerDetails.jsx
+++ b/src/Configuration/Customers/CustomerDataTable/CustomerDetails.jsx
@@ -12,7 +12,7 @@ import { useCopyToClipboard } from '../data/utils';
 const { HOME } = ROUTES.CONFIGURATION.SUB_DIRECTORY.CUSTOMERS;
 
 export const CustomerDetailLink = ({ row }) => {
-  const { showToast, copyToClipboard, setShowToast } = useCopyToClipboard();
+  const { showToast, copyToClipboard, setShowToast } = useCopyToClipboard(row.original.uuid);
   const { ADMIN_PORTAL_BASE_URL } = getConfig();
 
   return (

--- a/src/Configuration/Customers/CustomerDetailView/CustomerCard.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/CustomerCard.jsx
@@ -5,11 +5,10 @@ import {
 import { Launch, ContentCopy } from '@openedx/paragon/icons';
 import { getConfig } from '@edx/frontend-platform';
 import { formatDate, useCopyToClipboard } from '../data/utils';
-import DJANGO_ADMIN_BASE_URL from '../data/constants';
 import CustomerDetailModal from './CustomerDetailModal';
 
 const CustomerCard = ({ enterpriseCustomer }) => {
-  const { ADMIN_PORTAL_BASE_URL } = getConfig();
+  const { ADMIN_PORTAL_BASE_URL, DJANGO_ADMIN_LMS_BASE_URL } = getConfig();
   const { showToast, copyToClipboard, setShowToast } = useCopyToClipboard();
   const [isDetailsOpen, openDetails, closeDetails] = useToggle(false);
 
@@ -28,7 +27,7 @@ const CustomerCard = ({ enterpriseCustomer }) => {
               <Button
                 className="text-dark-500"
                 as="a"
-                href={`${DJANGO_ADMIN_BASE_URL}/admin/enterprise/enterprisecustomer/${enterpriseCustomer.uuid}/change`}
+                href={`${DJANGO_ADMIN_LMS_BASE_URL}/admin/enterprise/enterprisecustomer/${enterpriseCustomer.uuid}/change`}
                 variant="inverse-primary"
                 target="_blank"
                 rel="noopener noreferrer"

--- a/src/Configuration/Customers/CustomerDetailView/CustomerCard.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/CustomerCard.jsx
@@ -14,7 +14,7 @@ import DJANGO_ADMIN_BASE_URL from '../data/constants';
 
 const CustomerCard = ({ enterpriseCustomer }) => {
   const { ADMIN_PORTAL_BASE_URL } = getConfig();
-  const { showToast, copyToClipboard, setShowToast } = useCopyToClipboard();
+  const { showToast, copyToClipboard, setShowToast } = useCopyToClipboard(enterpriseCustomer.uuid);
 
   return (
     <div>

--- a/src/Configuration/Customers/CustomerDetailView/CustomerIntegrations.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/CustomerIntegrations.jsx
@@ -16,7 +16,8 @@ const CustomerIntegrations = ({
     <div>
       {(activeSSO || activeIntegrations || apiCredentialsEnabled) && (
       <div>
-        <h2>Associated Integrations</h2>
+        <h2>Associated integrations</h2>
+        <hr />
         {activeSSO && activeSSO.map((sso) => (
           <CustomerViewCard
             slug={slug}

--- a/src/Configuration/Customers/CustomerDetailView/CustomerPlanContainer.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/CustomerPlanContainer.jsx
@@ -48,6 +48,7 @@ const CustomerPlanContainer = ({ slug }) => {
               Show inactive
             </Form.Switch>
           </div>
+          <hr />
           {renderActivePoliciesCard}
           {renderActiveSubscriptions}
           {showInactive ? (

--- a/src/Configuration/Customers/CustomerDetailView/CustomerViewContainer.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/CustomerViewContainer.jsx
@@ -11,6 +11,7 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import CustomerCard from './CustomerCard';
 import { getEnterpriseCustomer } from '../data/utils';
 import CustomerIntegrations from './CustomerIntegrations';
+import EnterpriseCustomerUsersTable from './EnterpriseCustomerUsersTable';
 
 const CustomerViewContainer = () => {
   const { id } = useParams();
@@ -65,6 +66,7 @@ const CustomerViewContainer = () => {
             activeSSO={enterpriseCustomer.activeSsoConfigurations}
             apiCredentialsEnabled={enterpriseCustomer.enableGenerationOfApiCredentials}
           />
+          <EnterpriseCustomerUsersTable />
         </Stack>
       </Container>
     </div>

--- a/src/Configuration/Customers/CustomerDetailView/EnterpriseCustomerUserDetail.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/EnterpriseCustomerUserDetail.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Icon, IconButton, Stack, Chip
+} from '@openedx/paragon';
+import { Person, Check, Timelapse } from '@openedx/paragon/icons';
+
+export const EnterpriseCustomerUserDetail = ({
+  row,
+}) => {
+  let memberDetails;
+  let memberDetailIcon = (
+    <IconButton
+      isActive
+      invertColors
+      src={Person}
+      iconAs={Icon}
+      className="border rounded-circle mr-3"
+      alt="members detail column icon"
+      style={{ opacity: 1, flexShrink: 0 }}
+    />
+  );
+
+  if (row.original.enterpriseCustomerUser?.username) {
+    memberDetails = (
+      <div className="mb-n3">
+        <p className="font-weight-bold mb-0">
+          {row.original.enterpriseCustomerUser?.username}
+        </p>
+        <p>{row.original.enterpriseCustomerUser?.email}</p>
+      </div>
+    );
+  } else {
+    console.log(row.original)
+    memberDetails = (
+      <p className="align-middle mb-0">
+        {row.original.pendingEnterpriseCustomerUser?.userEmail}
+      </p>
+    );
+  }
+  return (
+    <Stack gap={0} direction="horizontal">
+      {memberDetailIcon}
+      {memberDetails}
+    </Stack>
+  );
+};
+
+export const AdministratorCell = ({ row }) => {
+  return (
+    <div>
+      {row.original?.roleAssignments?.includes("enterprise_admin") ? <Check /> : null}
+    </div>
+  )
+}
+
+export const LearnerCell = ({ row }) => {
+  if (!row.original?.pendingEnterpriseCustomerUser) {
+    return (
+      <div>
+        {row.original?.roleAssignments?.includes("enterprise_learner") ? <Check /> : null}
+      </div>
+    )
+  }
+
+  return (
+    <Chip
+      iconBefore={Timelapse}
+    >
+      Pending
+    </Chip>
+  )
+};
+
+
+EnterpriseCustomerUserDetail.propTypes = {
+  row: PropTypes.shape({
+    original: PropTypes.shape({
+      memberDetails: PropTypes.shape({
+        userEmail: PropTypes.string.isRequired,
+        userName: PropTypes.string,
+      }),
+      status: PropTypes.string,
+      recentAction: PropTypes.string.isRequired,
+      memberEnrollments: PropTypes.string,
+    }).isRequired,
+  }).isRequired,
+};

--- a/src/Configuration/Customers/CustomerDetailView/EnterpriseCustomerUserDetail.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/EnterpriseCustomerUserDetail.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  Icon, IconButton, Stack, Chip
+  Icon, IconButton, Stack, Chip,
 } from '@openedx/paragon';
 import { Person, Check, Timelapse } from '@openedx/paragon/icons';
 
@@ -9,7 +9,7 @@ export const EnterpriseCustomerUserDetail = ({
   row,
 }) => {
   let memberDetails;
-  let memberDetailIcon = (
+  const memberDetailIcon = (
     <IconButton
       isActive
       invertColors
@@ -31,7 +31,6 @@ export const EnterpriseCustomerUserDetail = ({
       </div>
     );
   } else {
-    console.log(row.original)
     memberDetails = (
       <p className="align-middle mb-0">
         {row.original.pendingEnterpriseCustomerUser?.userEmail}
@@ -47,20 +46,29 @@ export const EnterpriseCustomerUserDetail = ({
 };
 
 export const AdministratorCell = ({ row }) => {
+  if (row.original?.pendingEnterpriseCustomerUser?.isPendingAdmin) {
+    return (
+      <Chip
+        iconBefore={Timelapse}
+      >
+        Pending
+      </Chip>
+    );
+  }
   return (
     <div>
-      {row.original?.roleAssignments?.includes("enterprise_admin") ? <Check /> : null}
+      {row.original?.roleAssignments?.includes('enterprise_admin') ? <Check data-testid="admin check" aria-label="admin check" /> : null}
     </div>
-  )
-}
+  );
+};
 
 export const LearnerCell = ({ row }) => {
-  if (!row.original?.pendingEnterpriseCustomerUser) {
+  if (!row.original?.pendingEnterpriseCustomerUser?.isPendingLearner) {
     return (
       <div>
-        {row.original?.roleAssignments?.includes("enterprise_learner") ? <Check /> : null}
+        {row.original?.roleAssignments?.includes('enterprise_learner') ? <Check data-testid="learner check" aria-label="learner check" /> : null}
       </div>
-    )
+    );
   }
 
   return (
@@ -69,20 +77,43 @@ export const LearnerCell = ({ row }) => {
     >
       Pending
     </Chip>
-  )
+  );
 };
-
 
 EnterpriseCustomerUserDetail.propTypes = {
   row: PropTypes.shape({
     original: PropTypes.shape({
-      memberDetails: PropTypes.shape({
-        userEmail: PropTypes.string.isRequired,
-        userName: PropTypes.string,
+      enterpriseCustomerUser: PropTypes.shape({
+        email: PropTypes.string.isRequired,
+        username: PropTypes.string,
       }),
-      status: PropTypes.string,
-      recentAction: PropTypes.string.isRequired,
-      memberEnrollments: PropTypes.string,
+      pendingEnterpriseCustomerUser: PropTypes.shape({
+        isPendingAdmin: PropTypes.bool,
+        userEmail: PropTypes.string,
+      }),
+      roleAssignments: PropTypes.arrayOf(PropTypes.string),
+    }).isRequired,
+  }).isRequired,
+};
+
+AdministratorCell.propTypes = {
+  row: PropTypes.shape({
+    original: PropTypes.shape({
+      pendingEnterpriseCustomerUser: PropTypes.shape({
+        isPendingAdmin: PropTypes.bool,
+      }),
+      roleAssignments: PropTypes.arrayOf(PropTypes.string),
+    }).isRequired,
+  }).isRequired,
+};
+
+LearnerCell.propTypes = {
+  row: PropTypes.shape({
+    original: PropTypes.shape({
+      pendingEnterpriseCustomerUser: PropTypes.shape({
+        isPendingLearner: PropTypes.bool,
+      }),
+      roleAssignments: PropTypes.arrayOf(PropTypes.string),
     }).isRequired,
   }).isRequired,
 };

--- a/src/Configuration/Customers/CustomerDetailView/EnterpriseCustomerUsersTable.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/EnterpriseCustomerUsersTable.jsx
@@ -1,0 +1,64 @@
+import { useParams } from 'react-router-dom';
+import { Container, DataTable, TextFilter } from '@openedx/paragon';
+import { EnterpriseCustomerUserDetail, LearnerCell, AdministratorCell } from './EnterpriseCustomerUserDetail';
+import useEnterpriseUsersTableData from '../data/hooks/useCustomerUsersTableData';
+
+const EnterpriseCustomerUsersTable = () => {
+  const { id } = useParams();
+  const {
+    isLoading,
+    enterpriseUsersTableData,
+    fetchEnterpriseUsersData,
+  } = useEnterpriseUsersTableData(id);
+  return (
+    <Container>
+      <h2>Associated users ({ enterpriseUsersTableData.itemCount })</h2>
+      <hr />
+        <DataTable
+          isLoading={isLoading}
+          isExpandable
+          isSortable
+          manualSortBy
+          isPaginated
+          manualPagination
+          isFilterable
+          manualFilters
+          initialState={{
+            pageSize: 8,
+            pageIndex: 0,
+            sortBy: [],
+            filters: [],
+          }}
+          defaultColumnValues={{ Filter: TextFilter }}
+          fetchData={fetchEnterpriseUsersData}
+          data={enterpriseUsersTableData.results}
+          itemCount={enterpriseUsersTableData.itemCount}
+          pageCount={enterpriseUsersTableData.pageCount}
+          columns={[
+            {
+              id: 'userDetails',
+              Header: 'User details',
+              accessor: 'userDetails',
+              Cell: EnterpriseCustomerUserDetail,
+            },
+            {
+              id: 'administrator',
+              Header: 'Administrator',
+              accessor: 'administrator',
+              disableFilters: true,
+              Cell: AdministratorCell,
+            },
+            {
+              id: 'learner',
+              Header: 'Learner',
+              accessor: 'learner',
+              disableFilters: true,
+              Cell: LearnerCell,
+            },
+          ]}
+        />
+    </Container>
+  );
+};
+
+export default EnterpriseCustomerUsersTable;

--- a/src/Configuration/Customers/CustomerDetailView/EnterpriseCustomerUsersTable.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/EnterpriseCustomerUsersTable.jsx
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router-dom';
-import { Container, DataTable, TextFilter } from '@openedx/paragon';
+import { DataTable, TextFilter } from '@openedx/paragon';
 import { EnterpriseCustomerUserDetail, LearnerCell, AdministratorCell } from './EnterpriseCustomerUserDetail';
-import useEnterpriseUsersTableData from '../data/hooks/useCustomerUsersTableData';
+import useCustomerUsersTableData from '../data/hooks/useCustomerUsersTableData';
 
 const EnterpriseCustomerUsersTable = () => {
   const { id } = useParams();
@@ -9,55 +9,53 @@ const EnterpriseCustomerUsersTable = () => {
     isLoading,
     enterpriseUsersTableData,
     fetchEnterpriseUsersData,
-  } = useEnterpriseUsersTableData(id);
+  } = useCustomerUsersTableData(id);
   return (
-    <Container>
-      <h2>Associated users ({ enterpriseUsersTableData.itemCount })</h2>
+    <div>
+      <h2>Associated users ({enterpriseUsersTableData.itemCount})</h2>
       <hr />
-        <DataTable
-          isLoading={isLoading}
-          isExpandable
-          isSortable
-          manualSortBy
-          isPaginated
-          manualPagination
-          isFilterable
-          manualFilters
-          initialState={{
-            pageSize: 8,
-            pageIndex: 0,
-            sortBy: [],
-            filters: [],
-          }}
-          defaultColumnValues={{ Filter: TextFilter }}
-          fetchData={fetchEnterpriseUsersData}
-          data={enterpriseUsersTableData.results}
-          itemCount={enterpriseUsersTableData.itemCount}
-          pageCount={enterpriseUsersTableData.pageCount}
-          columns={[
-            {
-              id: 'userDetails',
-              Header: 'User details',
-              accessor: 'userDetails',
-              Cell: EnterpriseCustomerUserDetail,
-            },
-            {
-              id: 'administrator',
-              Header: 'Administrator',
-              accessor: 'administrator',
-              disableFilters: true,
-              Cell: AdministratorCell,
-            },
-            {
-              id: 'learner',
-              Header: 'Learner',
-              accessor: 'learner',
-              disableFilters: true,
-              Cell: LearnerCell,
-            },
-          ]}
-        />
-    </Container>
+      <DataTable
+        isLoading={isLoading}
+        isExpandable
+        isPaginated
+        manualPagination
+        isFilterable
+        manualFilters
+        initialState={{
+          pageSize: 8,
+          pageIndex: 0,
+          sortBy: [],
+          filters: [],
+        }}
+        defaultColumnValues={{ Filter: TextFilter }}
+        fetchData={fetchEnterpriseUsersData}
+        data={enterpriseUsersTableData.results}
+        itemCount={enterpriseUsersTableData.itemCount}
+        pageCount={enterpriseUsersTableData.pageCount}
+        columns={[
+          {
+            id: 'details',
+            Header: 'User details',
+            accessor: 'details',
+            Cell: EnterpriseCustomerUserDetail,
+          },
+          {
+            id: 'administrator',
+            Header: 'Administrator',
+            accessor: 'administrator',
+            disableFilters: true,
+            Cell: AdministratorCell,
+          },
+          {
+            id: 'learner',
+            Header: 'Learner',
+            accessor: 'learner',
+            disableFilters: true,
+            Cell: LearnerCell,
+          },
+        ]}
+      />
+    </div>
   );
 };
 

--- a/src/Configuration/Customers/CustomerDetailView/tests/CustomerViewIntegrations.test.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/tests/CustomerViewIntegrations.test.jsx
@@ -49,7 +49,7 @@ describe('CustomerViewIntegrations', () => {
       </IntlProvider>,
     );
     await waitFor(() => {
-      expect(screen.getByText('Associated Integrations')).toBeInTheDocument();
+      expect(screen.getByText('Associated integrations')).toBeInTheDocument();
 
       expect(screen.getByText('SSO')).toBeInTheDocument();
       expect(screen.getByText('Orange cats rule')).toBeInTheDocument();

--- a/src/Configuration/Customers/CustomerDetailView/tests/EnterpriseCustomerUserDetail.test.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/tests/EnterpriseCustomerUserDetail.test.jsx
@@ -1,0 +1,94 @@
+/* eslint-disable react/prop-types */
+import {
+  screen,
+  render,
+} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  EnterpriseCustomerUserDetail,
+  AdministratorCell,
+  LearnerCell,
+} from '../EnterpriseCustomerUserDetail';
+
+describe('EnterpriseCustomerUserDetail', () => {
+  it('renders enterprise customer detail', () => {
+    const enterpriseCustomerUser = {
+      original: {
+        enterpriseCustomerUser: {
+          username: 'ash ketchum',
+          email: 'ash@ketchum.org',
+        },
+      },
+    };
+    render(<EnterpriseCustomerUserDetail row={enterpriseCustomerUser} />);
+    expect(screen.getByText('ash ketchum')).toBeInTheDocument();
+    expect(screen.getByText('ash@ketchum.org')).toBeInTheDocument();
+  });
+
+  it('renders pending enterprise customer detail', () => {
+    const pendingEnterpriseCustomerUser = {
+      original: {
+        pendingEnterpriseCustomerUser: {
+          userEmail: 'pending@customer.org',
+        },
+      },
+    };
+    render(<EnterpriseCustomerUserDetail row={pendingEnterpriseCustomerUser} />);
+    expect(screen.getByText('pending@customer.org')).toBeInTheDocument();
+  });
+
+  it('renders AdministratorCell there is a pending admin', () => {
+    const pendingAdmin = {
+      original: {
+        pendingEnterpriseCustomerUser: {
+          isPendingAdmin: true,
+        },
+        roleAssignments: ['enterprise_learner'],
+      },
+    };
+    render(<AdministratorCell row={pendingAdmin} />);
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+  });
+
+  it('renders AdministratorCell there is a registered admin', () => {
+    const adminRow = {
+      original: {
+        pendingEnterpriseCustomerUser: {
+          isPendingAdmin: false,
+        },
+        roleAssignments: ['enterprise_admin'],
+      },
+    };
+    render(<AdministratorCell row={adminRow} />);
+    expect(screen.queryByText('Pending')).not.toBeInTheDocument();
+  });
+
+  it('renders LearnerCell when there is a registered learner and not pending', () => {
+    const learnerRow = {
+      original: {
+        pendingEnterpriseCustomerUser: null,
+        enterpriseCustomerUser: {
+          username: 'ash ketchum',
+          email: 'ash@ketchum.org',
+        },
+        roleAssignments: ['enterprise_learner'],
+      },
+    };
+    render(<LearnerCell row={learnerRow} />);
+    expect(screen.queryByText('Pending')).not.toBeInTheDocument();
+  });
+
+  it('renders LearnerCell for pending user', () => {
+    const pendingLearnerRow = {
+      original: {
+        pendingEnterpriseCustomerUser: {
+          isPendingLearner: true,
+          userEmail: 'pending@customer.org',
+        },
+        enterpriseCustomerUser: null,
+      },
+    };
+    render(<LearnerCell row={pendingLearnerRow} />);
+    expect(screen.queryByText('Pending')).toBeInTheDocument();
+  });
+});

--- a/src/Configuration/Customers/CustomerDetailView/tests/EnterpriseCustomerUsersTable.test.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/tests/EnterpriseCustomerUsersTable.test.jsx
@@ -1,0 +1,83 @@
+/* eslint-disable react/prop-types */
+import { screen, render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import EnterpriseCustomerUsersTable from '../EnterpriseCustomerUsersTable';
+import useCustomerUsersTableData from '../../data/hooks/useCustomerUsersTableData';
+
+const mockFetchEnterpriseUsersData = jest.fn();
+const mockData = {
+  isLoading: false,
+  enterpriseUsersTableData: {
+    itemCount: 2,
+    pageCount: 1,
+    results: [
+      {
+        enterpriseCustomerUser: {
+          username: 'ash ketchum',
+          email: 'ash@ketchum.org',
+        },
+        pendingEnterpriseCustomerUser: null,
+        roleAssignments: ['enterprise_learner'],
+      },
+      {
+        enterpriseCustomerUser: {
+          username: 'misty',
+          email: 'misty@pokemon.org',
+        },
+        pendingEnterpriseCustomerUser: null,
+        roleAssignments: ['enterprise_admin'],
+      },
+    ],
+  },
+  fetchEnterpriseUsersData: mockFetchEnterpriseUsersData,
+};
+
+jest.mock('../../data/hooks/useCustomerUsersTableData');
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ id: 'test-uuid' }),
+}));
+
+describe('EnterpriseCustomerUsersTable', () => {
+  it('renders the datatable with data', () => {
+    useCustomerUsersTableData.mockReturnValue(mockData);
+
+    render(
+      <IntlProvider locale="en">
+        <EnterpriseCustomerUsersTable />
+      </IntlProvider>,
+    );
+    expect(screen.getByText('Search user details')).toBeInTheDocument();
+    expect(screen.getByText('User details')).toBeInTheDocument();
+    expect(screen.getByText('Administrator')).toBeInTheDocument();
+    expect(screen.getByText('Learner')).toBeInTheDocument();
+    expect(screen.getByText('ash ketchum')).toBeInTheDocument();
+    expect(screen.getByText('ash@ketchum.org')).toBeInTheDocument();
+    expect(screen.getByTestId('learner check'));
+
+    expect(screen.getByText('misty')).toBeInTheDocument();
+    expect(screen.getByText('misty@pokemon.org')).toBeInTheDocument();
+    expect(screen.getByTestId('admin check')).toBeInTheDocument();
+  });
+
+  it('passes proper sorting and filter args to fetchEnterpriseUsersData', async () => {
+    render(
+      <IntlProvider locale="en">
+        <EnterpriseCustomerUsersTable />
+      </IntlProvider>,
+    );
+    await userEvent.type(screen.getByText('Search user details'), 'ash');
+    await waitFor(() => {
+      expect(mockFetchEnterpriseUsersData).toHaveBeenCalledWith({
+        filters: [{ id: 'details', value: 'ash' }],
+        pageIndex: 0,
+        pageSize: 8,
+        sortBy: [],
+      });
+    });
+  });
+});

--- a/src/Configuration/Customers/data/hooks/useCustomerUsersTableData.js
+++ b/src/Configuration/Customers/data/hooks/useCustomerUsersTableData.js
@@ -1,0 +1,77 @@
+import {
+  useCallback, useMemo, useState,
+} from 'react';
+import _ from 'lodash';
+import { camelCaseObject } from '@edx/frontend-platform/utils';
+import { logError } from '@edx/frontend-platform/logging';
+import debounce from 'lodash.debounce';
+
+import LmsApiService from '../../../../data/services/EnterpriseApiService';
+
+const useEnterpriseUsersTableData = (enterpriseUuid) => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [enterpriseUsersTableData, setEnterpriseUsersTableData] = useState({
+    itemCount: 0,
+    pageCount: 0,
+    results: [],
+  });
+  const fetchEnterpriseUsersData = useCallback((args) => {
+    const fetch = async () => {
+      try {
+        setIsLoading(true);
+        const options = {};
+
+        args.sortBy.filter((sort) => {
+          const { id, desc } = sort;
+          if (id === 'administrator') {
+            options.ordering = desc ? id : `-${id}`;
+          }
+          if (id === 'userDetails') {
+            options.ordering = desc ? id : `-${id}`;
+          }
+          if (id === 'learner') {
+            options.ordering = desc ? id : `-${id}`;
+          } 
+        });
+
+        args.filters.forEach((filter) => {
+          const { id, value } = filter;
+          if (id === 'username') {
+            options.user_query = value;
+          }
+        });
+      
+
+        options.page = args.pageIndex + 1;
+        const response = await LmsApiService.fetchEnterpriseCustomerUsers(enterpriseUuid, options);
+        const { data } = camelCaseObject(response);
+        console.log(args)
+        setEnterpriseUsersTableData({
+          itemCount: data.count,
+          pageCount: data.numPages,
+          results:data.results,
+        });
+      } catch (error) {
+        logError(error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    if (enterpriseUuid) {
+      fetch();
+    }
+  }, [enterpriseUuid]);
+
+  const debouncedFetchEnterpriseUsersData = useMemo(
+    () => debounce(fetchEnterpriseUsersData, 300),
+    [fetchEnterpriseUsersData],
+  );
+
+  return {
+    isLoading,
+    enterpriseUsersTableData,
+    fetchEnterpriseUsersData: debouncedFetchEnterpriseUsersData,
+  };
+};
+
+export default useEnterpriseUsersTableData;

--- a/src/Configuration/Customers/data/hooks/useCustomerUsersTableData.js
+++ b/src/Configuration/Customers/data/hooks/useCustomerUsersTableData.js
@@ -1,14 +1,13 @@
 import {
   useCallback, useMemo, useState,
 } from 'react';
-import _ from 'lodash';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { logError } from '@edx/frontend-platform/logging';
 import debounce from 'lodash.debounce';
 
 import LmsApiService from '../../../../data/services/EnterpriseApiService';
 
-const useEnterpriseUsersTableData = (enterpriseUuid) => {
+const useCustomerUsersTableData = (enterpriseUuid) => {
   const [isLoading, setIsLoading] = useState(true);
   const [enterpriseUsersTableData, setEnterpriseUsersTableData] = useState({
     itemCount: 0,
@@ -26,30 +25,30 @@ const useEnterpriseUsersTableData = (enterpriseUuid) => {
           if (id === 'administrator') {
             options.ordering = desc ? id : `-${id}`;
           }
-          if (id === 'userDetails') {
+          if (id === 'details') {
             options.ordering = desc ? id : `-${id}`;
           }
           if (id === 'learner') {
             options.ordering = desc ? id : `-${id}`;
-          } 
+          }
+          return null;
         });
 
         args.filters.forEach((filter) => {
           const { id, value } = filter;
-          if (id === 'username') {
+          if (id === 'details') {
             options.user_query = value;
           }
+          return null;
         });
-      
 
         options.page = args.pageIndex + 1;
         const response = await LmsApiService.fetchEnterpriseCustomerUsers(enterpriseUuid, options);
         const { data } = camelCaseObject(response);
-        console.log(args)
         setEnterpriseUsersTableData({
           itemCount: data.count,
           pageCount: data.numPages,
-          results:data.results,
+          results: data.results,
         });
       } catch (error) {
         logError(error);
@@ -74,4 +73,4 @@ const useEnterpriseUsersTableData = (enterpriseUuid) => {
   };
 };
 
-export default useEnterpriseUsersTableData;
+export default useCustomerUsersTableData;

--- a/src/data/services/EnterpriseApiService.js
+++ b/src/data/services/EnterpriseApiService.js
@@ -22,9 +22,18 @@ class LmsApiService {
 
   static integratedChannelsUrl = `${LmsApiService.baseUrl}/integrated_channels/api/v1/configs/`;
 
+  static enterpriseCustomerSupportUrl = `${LmsApiService.enterpriseAPIBaseUrl}enterprise-customer-support/`;
+
   static fetchEnterpriseCatalogQueries = () => LmsApiService.apiClient().get(LmsApiService.enterpriseCatalogQueriesUrl);
 
   static fetchEnterpriseCustomersBasicList = (enterpriseNameOrUuid) => LmsApiService.apiClient().get(`${LmsApiService.enterpriseCustomersBasicListUrl}${enterpriseNameOrUuid !== undefined ? `?name_or_uuid=${enterpriseNameOrUuid}` : ''}`);
+
+  static fetchEnterpriseCustomerUsers = (enterpriseUuid, options) => {
+    const queryParams = new URLSearchParams({
+      ...options,
+    });
+    return LmsApiService.apiClient().get(`${LmsApiService.enterpriseCustomerSupportUrl}${enterpriseUuid}?${queryParams}`);
+  };
 
   static postEnterpriseCustomerCatalog = (
     enterpriseCustomerUuid,


### PR DESCRIPTION
# Description
As part of the enterprise setup support tool update, this PR adds a table containing all admins and learners:

https://github.com/user-attachments/assets/7adfb5d8-5a84-488a-b69d-db35c03d9301

# Test Plan on Stage
1. checkout branch `knguyen2/ent-9166` and run `npm install`
2. at the root directory, add file `webpack.dev.config.js` with the following content:
```
const { createConfig } = require('@openedx/frontend-build');

module.exports = createConfig('webpack-dev', {
  devServer: {
    allowedHosts: 'all',
    https: true,
  },
});
```
4. replace the content in `.env.development` with this info:
```
NODE_ENV='development'
PORT=18450
FEATURE_CUSTOMER_SUPPORT_VIEW='true'
ADMIN_PORTAL_BASE_URL='https://portal.stage.edx.org'
ACCESS_TOKEN_COOKIE_NAME='stage-edx-jwt-cookie-header-payload'
BASE_URL='https://localhost.stage.edx.org:18450'
FEATURE_CUSTOMER_SUPPORT_VIEW='true'
FEATURE_CONFIGURATION_MANAGEMENT='true'
FEATURE_CONFIGURATION_ENTERPRISE_PROVISION='true'
FEATURE_CONFIGURATION_EDIT_ENTERPRISE_PROVISION='true'
CREDENTIALS_BASE_URL='https://credentials.stage.edx.org'
CSRF_TOKEN_API_PATH='/csrf/api/v1/token'
ECOMMERCE_BASE_URL='https://ecommerce.stage.edx.org'
ENTERPRISE_ACCESS_BASE_URL='https://enterprise-access.stage.edx.org'
LANGUAGE_PREFERENCE_COOKIE_NAME='openedx-language-preference'
LMS_BASE_URL='https://courses.stage.edx.org'
LICENSE_MANAGER_URL='https://license-manager.stage.edx.org'
SUPPORT_CONFLUENCE='https://support-tools.edx.org'
SUPPORT_CUSTOMER_REQUEST='https://support-tools.edx.org'
DISCOVERY_API_BASE_URL='https://discovery.stage.edx.org'
LOGIN_URL='https://courses.stage.edx.org/login'
LOGOUT_URL='https://courses.stage.edx.org/logout'
LOGO_URL=https://edx-cdn.org/v3/default/logo.svg
LOGO_TRADEMARK_URL=https://edx-cdn.org/v3/default/logo-trademark.svg
LOGO_WHITE_URL=https://edx-cdn.org/v3/default/logo-white.svg/
FAVICON_URL=https://edx-cdn.org/v3/default/favicon.ico
MARKETING_SITE_BASE_URL='https://stage.edx.org'
ORDER_HISTORY_URL='https://orders.stage.edx.org/orders'
REFRESH_ACCESS_TOKEN_ENDPOINT='https://courses.stage.edx.org/login_refresh'
SEGMENT_KEY=null
SITE_NAME='edX'
SUBSIDY_BASE_URL='https://enterprise-subsidy.stage.edx.org'
USER_INFO_COOKIE_NAME='edx-user-info'
PUBLISHER_BASE_URL='https://publisher.stage.edx.org/'
APP_ID='support-tools'
MFE_CONFIG_API_URL='https://courses.stage.edx.org/api/mfe_config/v1'
```
5. use a testing enterprise such as https://localhost.stage.edx.org:18450/enterprise-configuration/customers/66b5922b-a22b-4a7b-b587-d4af0378bd6f/view

6. verify that you can search by a user's username or email. 

7. verify that admins are ordered first and alphabetized followed by learners and alphabetized.
![Screenshot 2024-09-02 at 7 17 31 PM](https://github.com/user-attachments/assets/a8a05ec9-e338-4d75-8fc8-76379421ae05)

https://2u-internal.atlassian.net/browse/ENT-9166