### PR TITLE
feat: add zero state for customer view headers

### DIFF
--- a/src/Configuration/Customers/CustomerDetailView/CustomerIntegrations.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/CustomerIntegrations.jsx
@@ -16,6 +16,10 @@ const CustomerIntegrations = ({
     integrationCount++;
   }
 
+  if (!integrationCount) {
+    return null;
+  }
+
   return (
     <div>
       {(integrationCount > 0) && (

--- a/src/Configuration/Customers/CustomerDetailView/CustomerPlanContainer.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/CustomerPlanContainer.jsx
@@ -1,23 +1,25 @@
-import { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Form, Skeleton } from '@openedx/paragon';
-import useAllAssociatedPlans from '../data/hooks/useAllAssociatedPlans';
 import LearnerCreditPlanCard from './LearnerCreditPlanCard';
 import SubscriptionPlanCard from './SubscriptionPlanCard';
 
-const CustomerPlanContainer = ({ slug }) => {
-  const { id } = useParams();
-  const {
-    activePolicies,
-    activeSubscriptions,
-    countOfActivePlans,
-    countOfAllPlans,
-    inactivePolicies,
-    inactiveSubscriptions,
-    isLoading,
-  } = useAllAssociatedPlans(id);
+const CustomerPlanContainer = ({
+  slug,
+  activePolicies,
+  activeSubscriptions,
+  countOfActivePlans,
+  countOfAllPlans,
+  inactivePolicies,
+  inactiveSubscriptions,
+  isLoading,
+}) => {
   const [showInactive, setShowInactive] = useState(false);
+  useEffect(() => {
+    if (!countOfActivePlans && countOfAllPlans) {
+      setShowInactive(true);
+    }
+  }, []);
   const renderActivePoliciesCard = activePolicies.map(policy => (
     <LearnerCreditPlanCard key={policy.uuid} isActive slug={slug} policy={policy} />
   ));
@@ -31,19 +33,13 @@ const CustomerPlanContainer = ({ slug }) => {
     <SubscriptionPlanCard key={subscription.uuid} isActive={false} slug={slug} subscription={subscription} />
   ));
 
-  const hasActivePlans = activePolicies.length > 0 || renderActiveSubscriptions.length > 0;
-
-  if (!hasActivePlans) {
-    return null;
-  }
-
   return (
     <div>
       {!isLoading ? (
         <div>
           <div className="d-flex justify-content-between">
             <h2>Associated subsidy plans ({showInactive ? countOfAllPlans : countOfActivePlans})</h2>
-            {(countOfAllPlans !== countOfActivePlans) && (
+            {(countOfAllPlans > countOfActivePlans && countOfActivePlans) ? (
               <Form.Switch
                 className="ml-2.5 mt-2.5"
                 checked={showInactive}
@@ -54,7 +50,7 @@ const CustomerPlanContainer = ({ slug }) => {
               >
                 Show inactive
               </Form.Switch>
-            )}
+            ) : null}
           </div>
           <hr />
           {renderActivePoliciesCard}
@@ -73,6 +69,35 @@ const CustomerPlanContainer = ({ slug }) => {
 
 CustomerPlanContainer.propTypes = {
   slug: PropTypes.string.isRequired,
+  activePolicies: PropTypes.arrayOf(PropTypes.shape({
+    uuid: PropTypes.string.isRequired,
+    subsidyActiveDatetime: PropTypes.string.isRequired,
+    subsidyExpirationDatetime: PropTypes.string.isRequired,
+    policyType: PropTypes.string.isRequired,
+    created: PropTypes.string.isRequired,
+  })).isRequired,
+  activeSubscriptions: PropTypes.arrayOf(PropTypes.shape({
+    uuid: PropTypes.string.isRequired,
+    startDate: PropTypes.string.isRequired,
+    expirationDate: PropTypes.string.isRequired,
+    created: PropTypes.string.isRequired,
+  })).isRequired,
+  countOfActivePlans: PropTypes.number.isRequired,
+  countOfAllPlans: PropTypes.number.isRequired,
+  inactivePolicies: PropTypes.arrayOf(PropTypes.shape({
+    uuid: PropTypes.string.isRequired,
+    subsidyActiveDatetime: PropTypes.string.isRequired,
+    subsidyExpirationDatetime: PropTypes.string.isRequired,
+    policyType: PropTypes.string.isRequired,
+    created: PropTypes.string.isRequired,
+  })).isRequired,
+  inactiveSubscriptions: PropTypes.arrayOf(PropTypes.shape({
+    uuid: PropTypes.string.isRequired,
+    startDate: PropTypes.string.isRequired,
+    expirationDate: PropTypes.string.isRequired,
+    created: PropTypes.string.isRequired,
+  })).isRequired,
+  isLoading: PropTypes.bool.isRequired,
 };
 
 export default CustomerPlanContainer;

--- a/src/Configuration/Customers/CustomerDetailView/CustomerPlanContainer.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/CustomerPlanContainer.jsx
@@ -30,23 +30,31 @@ const CustomerPlanContainer = ({ slug }) => {
   const renderInActiveSubscriptions = inactiveSubscriptions.map(subscription => (
     <SubscriptionPlanCard key={subscription.uuid} isActive={false} slug={slug} subscription={subscription} />
   ));
+
+  const hasActivePlans = activePolicies.length > 0 || renderActiveSubscriptions.length > 0;
+
+  if (!hasActivePlans) {
+    return null;
+  }
+
   return (
     <div>
       {!isLoading ? (
         <div>
           <div className="d-flex justify-content-between">
             <h2>Associated subsidy plans ({showInactive ? countOfAllPlans : countOfActivePlans})</h2>
-            <Form.Switch
-              className="ml-2.5 mt-2.5"
-              checked={showInactive}
-              disabled={countOfAllPlans === countOfActivePlans}
-              onChange={() => {
-                setShowInactive(prevState => !prevState);
-              }}
-              data-testid="show-removed-toggle"
-            >
-              Show inactive
-            </Form.Switch>
+            {(countOfAllPlans !== countOfActivePlans) && (
+              <Form.Switch
+                className="ml-2.5 mt-2.5"
+                checked={showInactive}
+                onChange={() => {
+                  setShowInactive(prevState => !prevState);
+                }}
+                data-testid="show-removed-toggle"
+              >
+                Show inactive
+              </Form.Switch>
+            )}
           </div>
           <hr />
           {renderActivePoliciesCard}

--- a/src/Configuration/Customers/CustomerDetailView/CustomerViewContainer.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/CustomerViewContainer.jsx
@@ -13,12 +13,14 @@ import { getEnterpriseCustomer } from '../data/utils';
 import CustomerIntegrations from './CustomerIntegrations';
 import EnterpriseCustomerUsersTable from './EnterpriseCustomerUsersTable';
 import CustomerPlanContainer from './CustomerPlanContainer';
+import useAllAssociatedPlans from '../data/hooks/useAllAssociatedPlans';
 
 const CustomerViewContainer = () => {
   const { id } = useParams();
   const [enterpriseCustomer, setEnterpriseCustomer] = useState({});
   const [isLoading, setIsLoading] = useState(true);
   const intl = useIntl();
+  const associatedPlans = useAllAssociatedPlans(id);
 
   const fetchData = useCallback(
     async () => {
@@ -37,6 +39,23 @@ const CustomerViewContainer = () => {
   useEffect(() => {
     fetchData();
   }, []);
+
+  const renderPlanContainer = () => {
+    if (!isLoading && !associatedPlans.isLoading && associatedPlans.countOfAllPlans) {
+      return (
+        <Stack gap={2}>
+          <CustomerPlanContainer slug={enterpriseCustomer.slug} {...associatedPlans} />
+        </Stack>
+      );
+    }
+    if (!associatedPlans.isLoading && !associatedPlans.countOfAllPlans) {
+      return false;
+    }
+    if (associatedPlans.isLoading) {
+      return <Skeleton height={230} />;
+    }
+    return null;
+  };
 
   return (
     <div>
@@ -64,11 +83,9 @@ const CustomerViewContainer = () => {
         </Stack>
       </Container>
       <Container className="mt-4">
-        <Stack gap={2}>
-          {!isLoading ? <CustomerPlanContainer slug={enterpriseCustomer.slug} /> : <Skeleton height={230} />}
-        </Stack>
+        {renderPlanContainer()}
       </Container>
-      <Container className="mt-4">
+      <Container className="mt-4 mb-4">
         <Stack gap={2}>
           <CustomerIntegrations
             slug={enterpriseCustomer.slug}

--- a/src/Configuration/Customers/CustomerDetailView/EnterpriseCustomerUsersTable.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/EnterpriseCustomerUsersTable.jsx
@@ -9,57 +9,60 @@ const EnterpriseCustomerUsersTable = () => {
     isLoading,
     enterpriseUsersTableData,
     fetchEnterpriseUsersData,
+    showTable,
   } = useCustomerUsersTableData(id);
-
-  if (!enterpriseUsersTableData.itemCount) {
-    return null;
-  }
 
   return (
     <div>
-      <h2>Associated users ({enterpriseUsersTableData.itemCount})</h2>
-      <hr />
-      <DataTable
-        isLoading={isLoading}
-        isExpandable
-        isPaginated
-        manualPagination
-        isFilterable
-        manualFilters
-        initialState={{
-          pageSize: 8,
-          pageIndex: 0,
-          sortBy: [],
-          filters: [],
-        }}
-        defaultColumnValues={{ Filter: TextFilter }}
-        fetchData={fetchEnterpriseUsersData}
-        data={enterpriseUsersTableData.results}
-        itemCount={enterpriseUsersTableData.itemCount}
-        pageCount={enterpriseUsersTableData.pageCount}
-        columns={[
-          {
-            id: 'details',
-            Header: 'User details',
-            accessor: 'details',
-            Cell: EnterpriseCustomerUserDetail,
-          },
-          {
-            id: 'administrator',
-            Header: 'Administrator',
-            accessor: 'administrator',
-            disableFilters: true,
-            Cell: AdministratorCell,
-          },
-          {
-            id: 'learner',
-            Header: 'Learner',
-            accessor: 'learner',
-            disableFilters: true,
-            Cell: LearnerCell,
-          },
-        ]}
-      />
+      {showTable ? (
+        <div>
+          <h2>Associated users {enterpriseUsersTableData.itemCount > 0
+            && <span>({enterpriseUsersTableData.itemCount})</span>}
+          </h2>
+          <hr />
+          <DataTable
+            isLoading={isLoading}
+            isExpandable
+            isPaginated
+            manualPagination
+            isFilterable
+            manualFilters
+            initialState={{
+              pageSize: 8,
+              pageIndex: 0,
+              sortBy: [],
+              filters: [],
+            }}
+            defaultColumnValues={{ Filter: TextFilter }}
+            fetchData={fetchEnterpriseUsersData}
+            data={enterpriseUsersTableData.results}
+            itemCount={enterpriseUsersTableData.itemCount}
+            pageCount={enterpriseUsersTableData.pageCount}
+            columns={[
+              {
+                id: 'details',
+                Header: 'User details',
+                accessor: 'details',
+                Cell: EnterpriseCustomerUserDetail,
+              },
+              {
+                id: 'administrator',
+                Header: 'Administrator',
+                accessor: 'administrator',
+                disableFilters: true,
+                Cell: AdministratorCell,
+              },
+              {
+                id: 'learner',
+                Header: 'Learner',
+                accessor: 'learner',
+                disableFilters: true,
+                Cell: LearnerCell,
+              },
+            ]}
+          />
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/src/Configuration/Customers/CustomerDetailView/EnterpriseCustomerUsersTable.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/EnterpriseCustomerUsersTable.jsx
@@ -10,6 +10,11 @@ const EnterpriseCustomerUsersTable = () => {
     enterpriseUsersTableData,
     fetchEnterpriseUsersData,
   } = useCustomerUsersTableData(id);
+
+  if (!enterpriseUsersTableData.itemCount) {
+    return null;
+  }
+
   return (
     <div>
       <h2>Associated users ({enterpriseUsersTableData.itemCount})</h2>

--- a/src/Configuration/Customers/CustomerDetailView/tests/CustomerPlanContainer.test.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/tests/CustomerPlanContainer.test.jsx
@@ -99,4 +99,26 @@ describe('CustomerPlanContainer', () => {
     await waitFor(() => expect(screen.getByText('Associated subsidy plans (3)')).toBeInTheDocument());
     expect(screen.getByText('Inactive')).toBeInTheDocument();
   });
+  it('does not render CustomerPlanContainer data', async () => {
+    getConfig.mockImplementation(() => ({
+      ADMIN_PORTAL_BASE_URL: 'http://www.testportal.com',
+      ENTERPRISE_ACCESS_BASE_URL: 'http:www.enterprise-access.com',
+      LICENSE_MANAGER_URL: 'http:www.license-manager.com',
+    }));
+    useAllAssociatedPlans.mockReturnValue({
+      isLoading: false,
+      activePolicies: [],
+      activeSubscriptions: [],
+      countOfActivePlans: 0,
+      countOfAllPlans: 0,
+      inactiveSubscriptions: [],
+      inactivePolicies: [],
+    });
+    render(
+      <IntlProvider locale="en">
+        <CustomerPlanContainer slug={CUSTOMER_SLUG} />
+      </IntlProvider>,
+    );
+    expect(screen.queryByText('Associated subsidy plans (0)')).not.toBeInTheDocument();
+  });
 });

--- a/src/Configuration/Customers/CustomerDetailView/tests/CustomerPlanContainer.test.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/tests/CustomerPlanContainer.test.jsx
@@ -5,7 +5,6 @@ import userEvent from '@testing-library/user-event';
 import { getConfig } from '@edx/frontend-platform';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 
-import useAllAssociatedPlans from '../../data/hooks/useAllAssociatedPlans';
 import { formatDate } from '../../data/utils';
 import CustomerPlanContainer from '../CustomerPlanContainer';
 
@@ -17,11 +16,6 @@ jest.mock('../../data/utils', () => ({
 
 jest.mock('@edx/frontend-platform', () => ({
   getConfig: jest.fn(),
-}));
-
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useParams: () => ({ id: 'test-uuid' }),
 }));
 
 const CUSTOMER_SLUG = 'test-slug';
@@ -44,7 +38,7 @@ describe('CustomerPlanContainer', () => {
       ENTERPRISE_ACCESS_BASE_URL: 'http:www.enterprise-access.com',
       LICENSE_MANAGER_URL: 'http:www.license-manager.com',
     }));
-    useAllAssociatedPlans.mockReturnValue({
+    const mockProps = {
       isLoading: false,
       activePolicies: [{
         subsidyActiveDatetime: '2024-08-23T20:02:57.651943Z',
@@ -71,10 +65,10 @@ describe('CustomerPlanContainer', () => {
         policyType: 'learnerCredit',
         isSubsidyActive: false,
       }],
-    });
+    };
     render(
       <IntlProvider locale="en">
-        <CustomerPlanContainer slug={CUSTOMER_SLUG} />
+        <CustomerPlanContainer slug={CUSTOMER_SLUG} {...mockProps} />
       </IntlProvider>,
     );
     const djangoLinks = screen.getAllByRole('link', { name: 'Open in Django' });
@@ -98,27 +92,5 @@ describe('CustomerPlanContainer', () => {
     userEvent.click(toggle);
     await waitFor(() => expect(screen.getByText('Associated subsidy plans (3)')).toBeInTheDocument());
     expect(screen.getByText('Inactive')).toBeInTheDocument();
-  });
-  it('does not render CustomerPlanContainer data', async () => {
-    getConfig.mockImplementation(() => ({
-      ADMIN_PORTAL_BASE_URL: 'http://www.testportal.com',
-      ENTERPRISE_ACCESS_BASE_URL: 'http:www.enterprise-access.com',
-      LICENSE_MANAGER_URL: 'http:www.license-manager.com',
-    }));
-    useAllAssociatedPlans.mockReturnValue({
-      isLoading: false,
-      activePolicies: [],
-      activeSubscriptions: [],
-      countOfActivePlans: 0,
-      countOfAllPlans: 0,
-      inactiveSubscriptions: [],
-      inactivePolicies: [],
-    });
-    render(
-      <IntlProvider locale="en">
-        <CustomerPlanContainer slug={CUSTOMER_SLUG} />
-      </IntlProvider>,
-    );
-    expect(screen.queryByText('Associated subsidy plans (0)')).not.toBeInTheDocument();
   });
 });

--- a/src/Configuration/Customers/CustomerDetailView/tests/CustomerViewIntegrations.test.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/tests/CustomerViewIntegrations.test.jsx
@@ -63,4 +63,20 @@ describe('CustomerViewIntegrations', () => {
       expect(screen.getByText('API')).toBeInTheDocument();
     });
   });
+  it('does not render cards', async () => {
+    formatDate.mockReturnValue('September 15, 2024');
+    render(
+      <IntlProvider locale="en">
+        <CustomerIntegrations
+          slug="marcel-the-shell"
+          activeIntegrations={mockIntegratedChannelData}
+          activeSSO={[]}
+          apiCredentialsEnabled={false}
+        />
+      </IntlProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.queryByText('Associated integrations (0)')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/Configuration/Customers/CustomerDetailView/tests/EnterpriseCustomerUsersTable.test.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/tests/EnterpriseCustomerUsersTable.test.jsx
@@ -80,4 +80,24 @@ describe('EnterpriseCustomerUsersTable', () => {
       });
     });
   });
+
+  it('does not render user table section', () => {
+    const emptyResults = {
+      isLoading: false,
+      enterpriseUsersTableData: {
+        itemCount: 0,
+        pageCount: 1,
+        results: [],
+      },
+      fetchEnterpriseUsersData: mockFetchEnterpriseUsersData,
+    };
+    useCustomerUsersTableData.mockReturnValue(emptyResults);
+    render(
+      <IntlProvider locale="en">
+        <EnterpriseCustomerUsersTable />
+      </IntlProvider>,
+    );
+    expect(screen.queryByText('Search user details')).not.toBeInTheDocument();
+    expect(screen.queryByText('Associated users (0)')).not.toBeInTheDocument();
+  });
 });

--- a/src/Configuration/Customers/CustomerDetailView/tests/EnterpriseCustomerUsersTable.test.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/tests/EnterpriseCustomerUsersTable.test.jsx
@@ -33,6 +33,7 @@ const mockData = {
     ],
   },
   fetchEnterpriseUsersData: mockFetchEnterpriseUsersData,
+  showTable: true,
 };
 
 jest.mock('../../data/hooks/useCustomerUsersTableData');

--- a/src/Configuration/Customers/data/hooks/useCustomerUsersTableData.js
+++ b/src/Configuration/Customers/data/hooks/useCustomerUsersTableData.js
@@ -1,5 +1,5 @@
 import {
-  useCallback, useMemo, useState,
+  useCallback, useMemo, useState, useEffect,
 } from 'react';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { logError } from '@edx/frontend-platform/logging';
@@ -9,6 +9,7 @@ import LmsApiService from '../../../../data/services/EnterpriseApiService';
 
 const useCustomerUsersTableData = (enterpriseUuid) => {
   const [isLoading, setIsLoading] = useState(true);
+  const [showTable, setShowTable] = useState(false);
   const [enterpriseUsersTableData, setEnterpriseUsersTableData] = useState({
     itemCount: 0,
     pageCount: 0,
@@ -66,10 +67,23 @@ const useCustomerUsersTableData = (enterpriseUuid) => {
     [fetchEnterpriseUsersData],
   );
 
+  useEffect(() => {
+    const args = {
+      pageIndex: 0,
+      filters: [],
+      sortBy: [],
+    };
+    fetchEnterpriseUsersData(args);
+    if (enterpriseUsersTableData.itemCount) {
+      setShowTable(true);
+    }
+  }, [fetchEnterpriseUsersData, enterpriseUsersTableData.itemCount]);
+
   return {
     isLoading,
     enterpriseUsersTableData,
     fetchEnterpriseUsersData: debouncedFetchEnterpriseUsersData,
+    showTable,
   };
 };
 


### PR DESCRIPTION
# Description
Adds logic to handle zero states in the customer view page.

1. Hide the “Show inactive” toggle instead of disabling it if a customer does not have inactive plans. 
2. Hide the "Associated subsidy plan" header if the customer does not have inactive or active plans. 
3. Hide the "Associated integrations" header if the customer does not have active integrations.
4.  Hide the "Associated users" header if the customer does not have users.

# Test Plan on Stage
1. checkout branch `knguyen2/ent-9447` and run `npm install`
2. at the root directory, add file `webpack.dev.config.js` with the following content:
```
const { createConfig } = require('@openedx/frontend-build');

module.exports = createConfig('webpack-dev', {
  devServer: {
    allowedHosts: 'all',
    https: true,
  },
});
```
3. replace the content in `.env.development` with this info:
```
NODE_ENV='development'
PORT=18450
FEATURE_CUSTOMER_SUPPORT_VIEW='true'
ADMIN_PORTAL_BASE_URL='https://portal.stage.edx.org'
ACCESS_TOKEN_COOKIE_NAME='stage-edx-jwt-cookie-header-payload'
BASE_URL='https://localhost.stage.edx.org:18450'
FEATURE_CONFIGURATION_MANAGEMENT='true'
FEATURE_CONFIGURATION_ENTERPRISE_PROVISION='true'
FEATURE_CONFIGURATION_EDIT_ENTERPRISE_PROVISION='true'
CREDENTIALS_BASE_URL='https://credentials.stage.edx.org'
CSRF_TOKEN_API_PATH='/csrf/api/v1/token'
ECOMMERCE_BASE_URL='https://ecommerce.stage.edx.org'
ENTERPRISE_ACCESS_BASE_URL='https://enterprise-access.stage.edx.org'
LANGUAGE_PREFERENCE_COOKIE_NAME='openedx-language-preference'
LMS_BASE_URL='https://courses.stage.edx.org'
LICENSE_MANAGER_URL='https://license-manager-internal.stage.edx.org'
SUPPORT_CONFLUENCE='https://support-tools.edx.org'
SUPPORT_CUSTOMER_REQUEST='https://support-tools.edx.org'
DISCOVERY_API_BASE_URL='https://discovery.stage.edx.org'
LOGIN_URL='https://courses.stage.edx.org/login'
LOGOUT_URL='https://courses.stage.edx.org/logout'
LOGO_URL=https://edx-cdn.org/v3/default/logo.svg
LOGO_TRADEMARK_URL=https://edx-cdn.org/v3/default/logo-trademark.svg
LOGO_WHITE_URL=https://edx-cdn.org/v3/default/logo-white.svg/
FAVICON_URL=https://edx-cdn.org/v3/default/favicon.ico
MARKETING_SITE_BASE_URL='https://stage.edx.org'
ORDER_HISTORY_URL='https://orders.stage.edx.org/orders'
REFRESH_ACCESS_TOKEN_ENDPOINT='https://courses.stage.edx.org/login_refresh'
SEGMENT_KEY=null
SITE_NAME='edX'
SUBSIDY_BASE_URL='https://enterprise-subsidy.stage.edx.org'
USER_INFO_COOKIE_NAME='edx-user-info'
PUBLISHER_BASE_URL='https://publisher.stage.edx.org/'
APP_ID='support-tools'
MFE_CONFIG_API_URL='https://courses.stage.edx.org/api/mfe_config/v1'
```
4. verify that you do not see the “Show inactive” toggle for the following customer: https://support-tools.stage.edx.org/enterprise-configuration/customers/66b5922b-a22b-4a7b-b587-d4af0378bd6f/view
5. verify that you do not see the “Associated subsidy plans” header for the following customer: https://support-tools.stage.edx.org/enterprise-configuration/customers/beafadc5-69cc-48ce-a9a1-532067d9af0f/view
6. verify that you do not see the “Associated integrations” header for the following customer: https://support-tools.stage.edx.org/enterprise-configuration/customers/5d78a4d4-87a3-4db4-b665-2bcaf922edba/view
7. verify that you do not see the “Associated users” header for the following customer: https://support-tools.stage.edx.org/enterprise-configuration/customers/beafadc5-69cc-48ce-a9a1-532067d9af0f/view

https://2u-internal.atlassian.net/browse/ENT-9447
