### PR TITLE
fix: fix copy functionality on customer record card

### DIFF
--- a/src/Configuration/Customers/CustomerDetailView/CustomerCard.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/CustomerCard.jsx
@@ -9,7 +9,7 @@ import CustomerDetailModal from './CustomerDetailModal';
 
 const CustomerCard = ({ enterpriseCustomer }) => {
   const { ADMIN_PORTAL_BASE_URL, DJANGO_ADMIN_LMS_BASE_URL } = getConfig();
-  const { showToast, copyToClipboard, setShowToast } = useCopyToClipboard();
+  const { showToast, copyToClipboard, setShowToast } = useCopyToClipboard(enterpriseCustomer.uuid);
   const [isDetailsOpen, openDetails, closeDetails] = useToggle(false);
 
   return (
@@ -64,7 +64,7 @@ const CustomerCard = ({ enterpriseCustomer }) => {
               key="ContentCopy"
               src={ContentCopy}
               data-testid="copy"
-              onClick={() => copyToClipboard(enterpriseCustomer.uuid)}
+              onClick={() => copyToClipboard()}
             />
           </div>
           <p className="small mb-1">

--- a/src/Configuration/Customers/CustomerDetailView/tests/CustomerCard.test.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/tests/CustomerCard.test.jsx
@@ -1,9 +1,10 @@
 /* eslint-disable react/prop-types */
-import { screen, render } from '@testing-library/react';
+import { screen, render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 import { IntlProvider } from '@edx/frontend-platform/i18n';
-import { formatDate } from '../../data/utils';
+import { formatDate, useCopyToClipboard } from '../../data/utils';
 import CustomerCard from '../CustomerCard';
 
 jest.mock('../../data/utils', () => ({
@@ -25,7 +26,7 @@ const mockData = {
 };
 
 describe('CustomerCard', () => {
-  it('renders customer card data', () => {
+  it('renders customer card data', async () => {
     formatDate.mockReturnValue('July 23, 2024');
     render(
       <IntlProvider locale="en">
@@ -36,5 +37,9 @@ describe('CustomerCard', () => {
     expect(screen.getByText('/customer-6/')).toBeInTheDocument();
     expect(screen.getByText('Created July 23, 2024 • Last modified July 23, 2024')).toBeInTheDocument();
     expect(screen.getByText('Test Customer Name'));
+    const copy = screen.getByTestId('copy');
+    userEvent.click(copy);
+    await waitFor(() => expect(useCopyToClipboard).toHaveBeenCalledWith('test-id'));
+    await waitFor(() => expect(screen.getByText('Copied to clipboard')).toBeInTheDocument());
   });
 });


### PR DESCRIPTION
# Description
Fix copy functionality in the customer record card. The copy button icon should copy a customer uuid instead of `undefined`.

https://github.com/user-attachments/assets/ce11219c-35aa-4e6c-b2a9-35e5362be2b3

# Test Plan on Stage
1. checkout branch `knguyen2/ent-9458` and run `npm install`
2. at the root directory, add file `webpack.dev.config.js` with the following content:
```
const { createConfig } = require('@openedx/frontend-build');

module.exports = createConfig('webpack-dev', {
  devServer: {
    allowedHosts: 'all',
    https: true,
  },
});
```
3. replace the content in `.env.development` with this info:
```
NODE_ENV='development'
PORT=18450
FEATURE_CUSTOMER_SUPPORT_VIEW='true'
ADMIN_PORTAL_BASE_URL='https://portal.stage.edx.org'
ACCESS_TOKEN_COOKIE_NAME='stage-edx-jwt-cookie-header-payload'
BASE_URL='https://localhost.stage.edx.org:18450'
FEATURE_CONFIGURATION_MANAGEMENT='true'
FEATURE_CONFIGURATION_ENTERPRISE_PROVISION='true'
FEATURE_CONFIGURATION_EDIT_ENTERPRISE_PROVISION='true'
CREDENTIALS_BASE_URL='https://credentials.stage.edx.org'
CSRF_TOKEN_API_PATH='/csrf/api/v1/token'
ECOMMERCE_BASE_URL='https://ecommerce.stage.edx.org'
ENTERPRISE_ACCESS_BASE_URL='https://enterprise-access.stage.edx.org'
LANGUAGE_PREFERENCE_COOKIE_NAME='openedx-language-preference'
LMS_BASE_URL='https://courses.stage.edx.org'
LICENSE_MANAGER_URL='https://license-manager-internal.stage.edx.org'
SUPPORT_CONFLUENCE='https://support-tools.edx.org'
SUPPORT_CUSTOMER_REQUEST='https://support-tools.edx.org'
DISCOVERY_API_BASE_URL='https://discovery.stage.edx.org'
LOGIN_URL='https://courses.stage.edx.org/login'
LOGOUT_URL='https://courses.stage.edx.org/logout'
LOGO_URL=https://edx-cdn.org/v3/default/logo.svg
LOGO_TRADEMARK_URL=https://edx-cdn.org/v3/default/logo-trademark.svg
LOGO_WHITE_URL=https://edx-cdn.org/v3/default/logo-white.svg/
FAVICON_URL=https://edx-cdn.org/v3/default/favicon.ico
MARKETING_SITE_BASE_URL='https://stage.edx.org'
ORDER_HISTORY_URL='https://orders.stage.edx.org/orders'
REFRESH_ACCESS_TOKEN_ENDPOINT='https://courses.stage.edx.org/login_refresh'
SEGMENT_KEY=null
SITE_NAME='edX'
SUBSIDY_BASE_URL='https://enterprise-subsidy.stage.edx.org'
USER_INFO_COOKIE_NAME='edx-user-info'
PUBLISHER_BASE_URL='https://publisher.stage.edx.org/'
APP_ID='support-tools'
MFE_CONFIG_API_URL='https://courses.stage.edx.org/api/mfe_config/v1'
```
4. visit link https://localhost.stage.edx.org:18450/enterprise-configuration/customers/02982884-1f1f-4103-b6d7-3a602c1afcbd/view and confirm that when you click on the copy icon in the customer card and paste the copied text, you should see the uuid.

https://2u-internal.atlassian.net/browse/ENT-9458
