### PR TITLE
feat: update expand all text on enterprise customer datatable

### DIFF
--- a/src/Configuration/Customers/CustomerDataTable/CustomersPage.jsx
+++ b/src/Configuration/Customers/CustomerDataTable/CustomersPage.jsx
@@ -4,6 +4,7 @@ import React, {
   useCallback,
   useEffect,
 } from 'react';
+import PropTypes from 'prop-types';
 import debounce from 'lodash.debounce';
 import {
   Container, DataTable, TextFilter,
@@ -19,6 +20,12 @@ import {
 } from './CustomerDetails';
 import LmsApiService from '../../../data/services/EnterpriseApiService';
 import CustomerDetailRowSubComponent from './CustomerDetailSubComponent';
+
+const expandAllRowsHandler = ({ getToggleAllRowsExpandedProps }) => (
+  <button type="button" className="btn btn-link btn-inline font-weight-bold" {...getToggleAllRowsExpandedProps()}>
+    View subsidies
+  </button>
+);
 
 const CustomersPage = () => {
   const [enterpriseList, setEnterpriseList] = useState([]);
@@ -67,7 +74,7 @@ const CustomersPage = () => {
           columns={[
             {
               id: 'expander',
-              Header: DataTable.ExpandAll,
+              Header: expandAllRowsHandler,
               Cell: DataTable.ExpandRow,
             },
             {
@@ -102,6 +109,10 @@ const CustomersPage = () => {
       </section>
     </Container>
   );
+};
+
+expandAllRowsHandler.propTypes = {
+  getToggleAllRowsExpandedProps: PropTypes.func.isRequired,
 };
 
 export default CustomersPage;

--- a/src/Configuration/Customers/CustomerDataTable/tests/CustomersPage.test.jsx
+++ b/src/Configuration/Customers/CustomerDataTable/tests/CustomersPage.test.jsx
@@ -47,7 +47,7 @@ describe('CustomersPage', () => {
       expect(screen.getByText('SSO Check')).toBeInTheDocument();
       expect(screen.getByText('API Check')).toBeInTheDocument();
     });
-
+    expect(screen.getByText('View subsidies')).toBeInTheDocument();
     expect(screen.getByText('Customers')).toBeInTheDocument();
     expect(screen.getByText('Customer details')).toBeInTheDocument();
     expect(screen.getByText('SSO')).toBeInTheDocument();


### PR DESCRIPTION
# Description
Updates the "Expand all" text on the enterprise customer datatable to say "View subsidies"
<img width="1287" alt="Screenshot 2024-09-16 at 12 02 57 PM" src="https://github.com/user-attachments/assets/701b69b0-b947-4b0b-8cfe-90ea989a1763">


# Test Plan on Stage
1. checkout branch `knguyen2/ent-9458`
2. at the root directory, add file `webpack.dev.config.js` with the following content:
```
const { createConfig } = require('@openedx/frontend-build');

module.exports = createConfig('webpack-dev', {
  devServer: {
    allowedHosts: 'all',
    https: true,
  },
});
```
3. replace the content in `.env.development` with this info:
```
NODE_ENV='development'
PORT=18450
FEATURE_CUSTOMER_SUPPORT_VIEW='true'
ADMIN_PORTAL_BASE_URL='https://portal.stage.edx.org'
ACCESS_TOKEN_COOKIE_NAME='stage-edx-jwt-cookie-header-payload'
BASE_URL='https://localhost.stage.edx.org:18450'
FEATURE_CONFIGURATION_MANAGEMENT='true'
FEATURE_CONFIGURATION_ENTERPRISE_PROVISION='true'
FEATURE_CONFIGURATION_EDIT_ENTERPRISE_PROVISION='true'
CREDENTIALS_BASE_URL='https://credentials.stage.edx.org'
CSRF_TOKEN_API_PATH='/csrf/api/v1/token'
ECOMMERCE_BASE_URL='https://ecommerce.stage.edx.org'
ENTERPRISE_ACCESS_BASE_URL='https://enterprise-access.stage.edx.org'
LANGUAGE_PREFERENCE_COOKIE_NAME='openedx-language-preference'
LMS_BASE_URL='https://courses.stage.edx.org'
LICENSE_MANAGER_URL='https://license-manager-internal.stage.edx.org'
SUPPORT_CONFLUENCE='https://support-tools.edx.org'
SUPPORT_CUSTOMER_REQUEST='https://support-tools.edx.org'
DISCOVERY_API_BASE_URL='https://discovery.stage.edx.org'
LOGIN_URL='https://courses.stage.edx.org/login'
LOGOUT_URL='https://courses.stage.edx.org/logout'
LOGO_URL=https://edx-cdn.org/v3/default/logo.svg
LOGO_TRADEMARK_URL=https://edx-cdn.org/v3/default/logo-trademark.svg
LOGO_WHITE_URL=https://edx-cdn.org/v3/default/logo-white.svg/
FAVICON_URL=https://edx-cdn.org/v3/default/favicon.ico
MARKETING_SITE_BASE_URL='https://stage.edx.org'
ORDER_HISTORY_URL='https://orders.stage.edx.org/orders'
REFRESH_ACCESS_TOKEN_ENDPOINT='https://courses.stage.edx.org/login_refresh'
SEGMENT_KEY=null
SITE_NAME='edX'
SUBSIDY_BASE_URL='https://enterprise-subsidy.stage.edx.org'
USER_INFO_COOKIE_NAME='edx-user-info'
PUBLISHER_BASE_URL='https://publisher.stage.edx.org/'
APP_ID='support-tools'
MFE_CONFIG_API_URL='https://courses.stage.edx.org/api/mfe_config/v1'
```
4. Verify that you see "View subsidies" in the datatable at this link: https://localhost.stage.edx.org:18450/enterprise-configuration/customers

Figma: https://www.figma.com/design/TP5hGfoYmohr21MwgUgCZN/Enterprise-Setup?node-id=1262-6407&t=FoB8SkaXyjmkuX0Y-1
https://2u-internal.atlassian.net/browse/ENT-9458