### PR TITLE
fix: update logic to show subsidy cards

### DIFF
--- a/src/Configuration/Customers/CustomerDetailView/CustomerPlanContainer.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/CustomerPlanContainer.jsx
@@ -14,7 +14,7 @@ const CustomerPlanContainer = ({
 }) => {
   const [showInactive, setShowInactive] = useState(false);
   const countOfActivePlans = activeSubscriptions.length + activeSubsidies.length;
-  const countOfInactivePlans = inactiveSubscriptions.length + activeSubsidies.length;
+  const countOfInactivePlans = inactiveSubscriptions.length + inactiveSubsidies.length;
   const countOfAllPlans = countOfActivePlans + countOfInactivePlans;
   useEffect(() => {
     if (!countOfActivePlans && countOfAllPlans) {

--- a/src/Configuration/Customers/CustomerDetailView/CustomerViewContainer.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/CustomerViewContainer.jsx
@@ -41,14 +41,16 @@ const CustomerViewContainer = () => {
   }, [fetchData]);
 
   const renderPlanContainer = () => {
-    if (!isLoading && !associatedPlans.isLoading && associatedPlans.countOfAllPlans) {
+    if (!isLoading && !associatedPlans.isLoading
+      && (associatedPlans.activeSubsidies.length > 0 || associatedPlans.activeSubscriptions.length > 0)) {
       return (
         <Stack gap={2}>
           <CustomerPlanContainer slug={enterpriseCustomer.slug} {...associatedPlans} />
         </Stack>
       );
     }
-    if (!associatedPlans.isLoading && !associatedPlans.countOfAllPlans) {
+    if (!associatedPlans.isLoading
+      && (!associatedPlans.activeSubsidies.length || !associatedPlans.activeSubscriptions.length)) {
       return false;
     }
     if (associatedPlans.isLoading) {

--- a/src/Configuration/Customers/CustomerDetailView/tests/CustomerPlanContainer.test.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/tests/CustomerPlanContainer.test.jsx
@@ -53,8 +53,6 @@ describe('CustomerPlanContainer', () => {
         expirationDate: '2024-09-02T20:02:57.651943Z',
         uuid: 'test-uuid',
       }],
-      countOfActivePlans: 2,
-      countOfAllPlans: 3,
       inactiveSubscriptions: [],
       inactiveSubsidies: [{
         activeDatetime: '2024-08-23T20:02:57.651943Z',


### PR DESCRIPTION
Updates logic to show subsidy cards.

https://2u-internal.atlassian.net/browse/ENT-9540
https://2u-internal.atlassian.net/browse/ENT-9476

1. checkout branch `knguyen2/ent-9450`
2. at the root directory, add file `webpack.dev.config.js` with the following content:
```
const { createConfig } = require('@openedx/frontend-build');

module.exports = createConfig('webpack-dev', {
  devServer: {
    allowedHosts: 'all',
    https: true,
  },
});
```
3. replace the content in `.env.development` with this info:
```
NODE_ENV='development'
PORT=18450
FEATURE_CUSTOMER_SUPPORT_VIEW='true'
ADMIN_PORTAL_BASE_URL='https://portal.stage.edx.org'
ACCESS_TOKEN_COOKIE_NAME='stage-edx-jwt-cookie-header-payload'
BASE_URL='https://localhost.stage.edx.org:18450'
FEATURE_CONFIGURATION_MANAGEMENT='true'
FEATURE_CONFIGURATION_ENTERPRISE_PROVISION='true'
FEATURE_CONFIGURATION_EDIT_ENTERPRISE_PROVISION='true'
CREDENTIALS_BASE_URL='https://credentials.stage.edx.org'
CSRF_TOKEN_API_PATH='/csrf/api/v1/token'
ECOMMERCE_BASE_URL='https://ecommerce.stage.edx.org'
ENTERPRISE_ACCESS_BASE_URL='https://enterprise-access.stage.edx.org'
LANGUAGE_PREFERENCE_COOKIE_NAME='openedx-language-preference'
LMS_BASE_URL='https://courses.stage.edx.org'
LICENSE_MANAGER_URL='https://license-manager.stage.edx.org'
LICENSE_MANAGER_DJANGO_URL='https://license-manager-internal.stage.edx.org'
SUPPORT_CONFLUENCE='https://support-tools.edx.org'
SUPPORT_CUSTOMER_REQUEST='https://support-tools.edx.org'
DISCOVERY_API_BASE_URL='https://discovery.stage.edx.org'
LOGIN_URL='https://courses.stage.edx.org/login'
LOGOUT_URL='https://courses.stage.edx.org/logout'
LOGO_URL=https://edx-cdn.org/v3/default/logo.svg
LOGO_TRADEMARK_URL=https://edx-cdn.org/v3/default/logo-trademark.svg
LOGO_WHITE_URL=https://edx-cdn.org/v3/default/logo-white.svg/
FAVICON_URL=https://edx-cdn.org/v3/default/favicon.ico
MARKETING_SITE_BASE_URL='https://stage.edx.org'
ORDER_HISTORY_URL='https://orders.stage.edx.org/orders'
REFRESH_ACCESS_TOKEN_ENDPOINT='https://courses.stage.edx.org/login_refresh'
SEGMENT_KEY=null
SITE_NAME='edX'
SUBSIDY_BASE_URL='https://enterprise-subsidy.stage.edx.org'
SUBSIDY_BASE_DJANGO_URL='https://enterprise-subsidy-internal.stage.edx.org'
USER_INFO_COOKIE_NAME='edx-user-info'
PUBLISHER_BASE_URL='https://publisher.stage.edx.org/'
APP_ID='support-tools'
MFE_CONFIG_API_URL='https://courses.stage.edx.org/api/mfe_config/v1'
```
3. run `npm run start`
4. go to link https://localhost.stage.edx.org:18450/enterprise-configuration/customers/66b5922b-a22b-4a7b-b587-d4af0378bd6f/view and verify that you can see the subsidy card
