### PR TITLE
feat: add manual pagination

### DIFF
--- a/src/Configuration/Customers/CustomerDataTable/tests/CustomersPage.test.jsx
+++ b/src/Configuration/Customers/CustomerDataTable/tests/CustomersPage.test.jsx
@@ -6,25 +6,29 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 import CustomersPage from '../CustomersPage';
 import LmsApiService from '../../../../data/services/EnterpriseApiService';
 
-const mockData = [{
-  name: 'Ubuntu',
-  slug: 'test-ubuntu',
-  uuid: 'test-enterprise-uuid',
-  activeIntegrations: [{
-    channelCode: 'test-channel',
-    created: 'jan 1, 1992',
-    modified: 'jan 2, 1992',
-    displayName: 'test channel',
-    active: true,
+const mockData = {
+  count: 1,
+  numPages: 1,
+  results: [{
+    name: 'Ubuntu',
+    slug: 'test-ubuntu',
+    uuid: 'test-enterprise-uuid',
+    activeIntegrations: [{
+      channelCode: 'test-channel',
+      created: 'jan 1, 1992',
+      modified: 'jan 2, 1992',
+      displayName: 'test channel',
+      active: true,
+    }],
+    activeSsoConfigurations: [{
+      created: 'jan 1, 1992',
+      modified: 'jan 2, 1992',
+      displayName: 'test channel',
+      active: true,
+    }],
+    enableGenerationOfApiCredentials: true,
   }],
-  activeSsoConfigurations: [{
-    created: 'jan 1, 1992',
-    modified: 'jan 2, 1992',
-    displayName: 'test channel',
-    active: true,
-  }],
-  enableGenerationOfApiCredentials: true,
-}];
+};
 
 jest.mock('lodash.debounce', () => jest.fn((fn) => fn));
 jest

--- a/src/Configuration/Customers/CustomerDetailView/CustomerViewContainer.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/CustomerViewContainer.jsx
@@ -25,8 +25,8 @@ const CustomerViewContainer = () => {
   const fetchData = useCallback(
     async () => {
       try {
-        const response = await getEnterpriseCustomer({ uuid: id });
-        setEnterpriseCustomer(response[0]);
+        const { results } = await getEnterpriseCustomer({ uuid: id });
+        setEnterpriseCustomer(results[0]);
       } catch (error) {
         logError(error);
       } finally {

--- a/src/Configuration/Customers/CustomerDetailView/tests/CustomerViewContainer.test.jsx
+++ b/src/Configuration/Customers/CustomerDetailView/tests/CustomerViewContainer.test.jsx
@@ -23,13 +23,15 @@ jest.mock('../../data/utils', () => ({
 
 describe('CustomerViewContainer', () => {
   it('renders data', async () => {
-    getEnterpriseCustomer.mockReturnValue([{
-      uuid: 'test-id',
-      name: 'Test Customer Name',
-      slug: 'customer-6',
-      created: '2024-07-23T20:02:57.651943Z',
-      modified: '2024-07-23T20:02:57.651943Z',
-    }]);
+    getEnterpriseCustomer.mockReturnValue({
+      results: [{
+        uuid: 'test-id',
+        name: 'Test Customer Name',
+        slug: 'customer-6',
+        created: '2024-07-23T20:02:57.651943Z',
+        modified: '2024-07-23T20:02:57.651943Z',
+      }],
+    });
     formatDate.mockReturnValue('July 23, 2024');
     render(
       <IntlProvider locale="en">


### PR DESCRIPTION
# Description
Adds manual pagination

1. checkout branch `knguyen2/ent-9546`
2. at the root directory, add file `webpack.dev.config.js` with the following content:
```
const { createConfig } = require('@openedx/frontend-build');

module.exports = createConfig('webpack-dev', {
  devServer: {
    allowedHosts: 'all',
    https: true,
  },
});
```
3. replace the content in `.env.development` with this info:
```
NODE_ENV='development'
PORT=18450
FEATURE_CUSTOMER_SUPPORT_VIEW='true'
ADMIN_PORTAL_BASE_URL='https://portal.stage.edx.org'
ACCESS_TOKEN_COOKIE_NAME='stage-edx-jwt-cookie-header-payload'
BASE_URL='https://localhost.stage.edx.org:18450'
FEATURE_CONFIGURATION_MANAGEMENT='true'
FEATURE_CONFIGURATION_ENTERPRISE_PROVISION='true'
FEATURE_CONFIGURATION_EDIT_ENTERPRISE_PROVISION='true'
CREDENTIALS_BASE_URL='https://credentials.stage.edx.org'
CSRF_TOKEN_API_PATH='/csrf/api/v1/token'
ECOMMERCE_BASE_URL='https://ecommerce.stage.edx.org'
ENTERPRISE_ACCESS_BASE_URL='https://enterprise-access.stage.edx.org'
LANGUAGE_PREFERENCE_COOKIE_NAME='openedx-language-preference'
LMS_BASE_URL='https://courses.stage.edx.org'
LICENSE_MANAGER_URL='https://license-manager.stage.edx.org'
LICENSE_MANAGER_DJANGO_URL='https://license-manager-internal.stage.edx.org'
SUPPORT_CONFLUENCE='https://support-tools.edx.org'
SUPPORT_CUSTOMER_REQUEST='https://support-tools.edx.org'
DISCOVERY_API_BASE_URL='https://discovery.stage.edx.org'
LOGIN_URL='https://courses.stage.edx.org/login'
LOGOUT_URL='https://courses.stage.edx.org/logout'
LOGO_URL=https://edx-cdn.org/v3/default/logo.svg
LOGO_TRADEMARK_URL=https://edx-cdn.org/v3/default/logo-trademark.svg
LOGO_WHITE_URL=https://edx-cdn.org/v3/default/logo-white.svg/
FAVICON_URL=https://edx-cdn.org/v3/default/favicon.ico
MARKETING_SITE_BASE_URL='https://stage.edx.org'
ORDER_HISTORY_URL='https://orders.stage.edx.org/orders'
REFRESH_ACCESS_TOKEN_ENDPOINT='https://courses.stage.edx.org/login_refresh'
SEGMENT_KEY=null
SITE_NAME='edX'
SUBSIDY_BASE_URL='https://enterprise-subsidy.stage.edx.org'
SUBSIDY_BASE_DJANGO_URL='https://enterprise-subsidy-internal.stage.edx.org'
USER_INFO_COOKIE_NAME='edx-user-info'
PUBLISHER_BASE_URL='https://publisher.stage.edx.org/'
APP_ID='support-tools'
MFE_CONFIG_API_URL='https://courses.stage.edx.org/api/mfe_config/v1'
```
3. run `npm run start`
4. verify that you see the customer list at this link https://localhost.stage.edx.org:18450/enterprise-configuration/customers and can search by customer name in the search box