### PR TITLE
feat: adds info tool tip in view susbidies column

### DIFF
--- a/src/Configuration/Customers/CustomerDataTable/CustomersPage.jsx
+++ b/src/Configuration/Customers/CustomerDataTable/CustomersPage.jsx
@@ -6,10 +6,12 @@ import React, {
 import PropTypes from 'prop-types';
 import debounce from 'lodash.debounce';
 import {
-  Container, DataTable, TextFilter,
+  Container, DataTable, Icon, OverlayTrigger, TextFilter, Tooltip,
 } from '@openedx/paragon';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { camelCaseObject } from '@edx/frontend-platform';
 import { logError } from '@edx/frontend-platform/logging';
+import { InfoOutline } from '@openedx/paragon/icons';
 
 import {
   CustomerDetailLink,
@@ -23,6 +25,23 @@ import CustomerDetailRowSubComponent from './CustomerDetailSubComponent';
 const expandAllRowsHandler = ({ getToggleAllRowsExpandedProps }) => (
   <button type="button" className="btn btn-link btn-inline font-weight-bold" {...getToggleAllRowsExpandedProps()}>
     View subsidies
+    <OverlayTrigger
+      key="other-subsidies-tooltip"
+      placement="top"
+      overlay={(
+        <Tooltip id="other-subsidies-tooltip">
+          <div>
+            <FormattedMessage
+              id="configuration.customersPage.viewSubsidiesColumn.tooltip"
+              defaultMessage="A checkmark indicates an active subsidy."
+              description="Tooltip for the View subsidies column header in the Customers table"
+            />
+          </div>
+        </Tooltip>
+      )}
+    >
+      <Icon size="xs" src={InfoOutline} className="ml-1 d-inline-flex" />
+    </OverlayTrigger>
   </button>
 );
 


### PR DESCRIPTION
# Description
Adds a tool tip in the View subsidies column to inform the user what a checkmark in the table indicates.
https://2u-internal.atlassian.net/browse/ENT-9614

# UI
![Screenshot 2024-10-09 at 12 17 18 PM](https://github.com/user-attachments/assets/af0f97e0-66ab-41c0-aca5-7115a1e6a4ce)
![Screenshot 2024-10-09 at 12 18 41 PM](https://github.com/user-attachments/assets/2f9b4c29-8a3a-4c3f-a487-4ceda9f45575)

# Testing
1. check out branch and run `npm run start`
2. navigate to http://localhost:18450/enterprise-configuration/customers and verify that the message in the tool tip