### PR TITLE
fix: fixes datatable bottom padding

### DIFF
--- a/src/Configuration/Customers/CustomerDataTable/CustomersPage.jsx
+++ b/src/Configuration/Customers/CustomerDataTable/CustomersPage.jsx
@@ -85,7 +85,7 @@ const CustomersPage = () => {
   return (
     <Container className="mt-5">
       <h1>Customers</h1>
-      <section className="mt-5">
+      <section className="mt-5 mb-5">
         <DataTable
           isLoading={isLoading}
           isExpandable

--- a/src/Configuration/Provisioning/DashboardDataTable/DashboardDataTable.jsx
+++ b/src/Configuration/Provisioning/DashboardDataTable/DashboardDataTable.jsx
@@ -45,7 +45,7 @@ const DashboardDataTable = () => {
   ), [fetchData]);
 
   return (
-    <section className="mt-5">
+    <section className="mt-5 mb-5">
       <DataTable
         isLoading={isLoading}
         isPaginated


### PR DESCRIPTION
Adds bottom padding to the `Customers` and `Learner Credit Plans` tables.
https://2u-internal.atlassian.net/browse/ENT-9596

<img width="1503" alt="Screenshot 2025-02-21 at 8 26 54 AM" src="https://github.com/user-attachments/assets/1415eda6-8b0a-48dd-a1ef-eb323309140f" />
<img width="1503" alt="Screenshot 2025-02-06 at 11 32 28 AM" src="https://github.com/user-attachments/assets/1d95548a-6e4d-4d61-9b3b-81bc62ee7c0a" />

