### PR TITLE
feat: remove PII from urls

### DIFF
--- a/src/ProgramEnrollments/ProgramInspector/ProgramInspector.jsx
+++ b/src/ProgramEnrollments/ProgramInspector/ProgramInspector.jsx
@@ -49,7 +49,7 @@ export default function ProgramInspector() {
       if (newLink === location.search) {
         setClickEventCall(!clickEventCall);
       } else {
-        setQuery(newLink)
+        setQuery(newLink);
       }
     }
   };
@@ -68,36 +68,39 @@ export default function ProgramInspector() {
         setError(response.error);
         setActiveOrgKey(response.org_keys);
         setLearnerProgramEnrollment(response.learner_program_enrollments);
-        let name = response?.learner_program_enrollments?.user?.username;
+        const name = response?.learner_program_enrollments?.user?.username;
         return name;
-      }).then((username) => {
-        if (username) {
-          getUser(username).then(
-            res => navigate(`?edx_user_id=${res.id}`)
-          )
+      }).then((name) => {
+        if (name) {
+          getUser(name).then(
+            res => navigate(`?edx_user_id=${res.id}`),
+          );
         }
       }).catch(err => {
+        console.error(err);
         setError('An error occured while fetching user id');
-        navigate('/programs')
-      });;
+        navigate('/programs');
+      });
     }
   };
 
   useEffect(() => {
-    if (query)
+    if (query) {
       fetchInspectorData(query);
+    }
   }, [query]);
 
   useEffect(() => {
-    let userId;
-    if (userId = new URLSearchParams(location.search).get('edx_user_id')) {
+    const userId = new URLSearchParams(location.search).get('edx_user_id');
+    if (userId) {
       getUser(userId).then(res => {
         setUsername(res.username);
-        setQuery(`?edx_user=${res.username}&org_key=${activeOrgKey}&external_user_key=${externalUserKey}`)
+        setQuery(`?edx_user=${res.username}&org_key=${activeOrgKey}&external_user_key=${externalUserKey}`);
       }).catch(err => {
+        console.error(err);
         setError('An error occured while fetching user id');
-        navigate('/programs')
-      })
+        navigate('/programs');
+      });
     }
   }, []);
 

--- a/src/ProgramEnrollments/ProgramInspector/ProgramInspector.jsx
+++ b/src/ProgramEnrollments/ProgramInspector/ProgramInspector.jsx
@@ -75,7 +75,7 @@ export default function ProgramInspector() {
       })
         .catch(err => {
           console.error(err);
-          setError('Five errors occurred');
+          setError('An error occured while fetching user id');
           navigate('/programs');
         });
     }

--- a/src/ProgramEnrollments/ProgramInspector/ProgramInspector.jsx
+++ b/src/ProgramEnrollments/ProgramInspector/ProgramInspector.jsx
@@ -70,17 +70,14 @@ export default function ProgramInspector() {
         setLearnerProgramEnrollment(response.learner_program_enrollments);
         const name = response?.learner_program_enrollments?.user?.username;
         return name;
-      }).then((name) => {
-        if (name) {
-          getUser(name).then(
-            res => navigate(`?edx_user_id=${res.id}`),
-          );
-        }
-      }).catch(err => {
-        console.error(err);
-        setError('An error occured while fetching user id');
-        navigate('/programs');
-      });
+      }).then((name) => getUser(name)).then((res) => {
+        navigate(`?edx_user_id=${res.id}`);
+      })
+        .catch(err => {
+          console.error(err);
+          setError('Five errors occurred');
+          navigate('/programs');
+        });
     }
   };
 

--- a/src/ProgramEnrollments/ProgramInspector/ProgramInspector.jsx
+++ b/src/ProgramEnrollments/ProgramInspector/ProgramInspector.jsx
@@ -24,7 +24,6 @@ export default function ProgramInspector() {
   const [activeOrgKey, setActiveOrgKey] = useState(params.get('org_key'));
   const [orgKeyList, setOrgKeyList] = useState(undefined);
   const [externalUserKey, setExternalUserKey] = useState(params.get('external_user_key'));
-  const [clickEventCall, setClickEventCall] = useState(false);
 
   const [query, setQuery] = useState(null);
 
@@ -43,14 +42,10 @@ export default function ProgramInspector() {
       setSsoRecords([]);
       navigate('/programs');
     } else {
-      const newLink = `?edx_user=${
+      const newQuery = `?edx_user=${
         username || ''
       }&org_key=${activeOrgKey}&external_user_key=${externalUserKey || ''}`;
-      if (newLink === location.search) {
-        setClickEventCall(!clickEventCall);
-      } else {
-        setQuery(newLink);
-      }
+      setQuery(newQuery);
     }
   };
 
@@ -75,7 +70,7 @@ export default function ProgramInspector() {
       })
         .catch(err => {
           console.error(err);
-          setError('An error occured while fetching user id');
+          setError('An error occurred while fetching user id');
           navigate('/programs');
         });
     }
@@ -95,7 +90,7 @@ export default function ProgramInspector() {
         setQuery(`?edx_user=${res.username}&org_key=${activeOrgKey}&external_user_key=${externalUserKey}`);
       }).catch(err => {
         console.error(err);
-        setError('An error occured while fetching user id');
+        setError('An error occurred while fetching user id');
         navigate('/programs');
       });
     }

--- a/src/ProgramEnrollments/ProgramInspector/ProgramInspector.jsx
+++ b/src/ProgramEnrollments/ProgramInspector/ProgramInspector.jsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import {
   Alert, Col, Row, Button, Input,
 } from '@openedx/paragon';
-import { getSsoRecords } from '../../users/data/api';
+import { getSsoRecords, getUser } from '../../users/data/api';
 import EnrollmentDetails from './EnrollmentDetails';
 import SingleSignOnRecordCard from '../../users/SingleSignOnRecordCard';
 import {
@@ -26,6 +26,8 @@ export default function ProgramInspector() {
   const [externalUserKey, setExternalUserKey] = useState(params.get('external_user_key'));
   const [clickEventCall, setClickEventCall] = useState(false);
 
+  const [query, setQuery] = useState(null);
+
   const getOrgKeyList = () => (orgKeyList
     ? orgKeyList.map((data) => ({
       value: data,
@@ -41,13 +43,13 @@ export default function ProgramInspector() {
       setSsoRecords([]);
       navigate('/programs');
     } else {
-      const newLink = `/programs?edx_user=${
+      const newLink = `?edx_user=${
         username || ''
       }&org_key=${activeOrgKey}&external_user_key=${externalUserKey || ''}`;
-      if (newLink === location.pathname + location.search) {
+      if (newLink === location.search) {
         setClickEventCall(!clickEventCall);
       } else {
-        navigate(newLink);
+        setQuery(newLink)
       }
     }
   };
@@ -66,13 +68,38 @@ export default function ProgramInspector() {
         setError(response.error);
         setActiveOrgKey(response.org_keys);
         setLearnerProgramEnrollment(response.learner_program_enrollments);
-      });
+        let name = response?.learner_program_enrollments?.user?.username;
+        return name;
+      }).then((username) => {
+        if (username) {
+          getUser(username).then(
+            res => navigate(`?edx_user_id=${res.id}`)
+          )
+        }
+      }).catch(err => {
+        setError('An error occured while fetching user id');
+        navigate('/programs')
+      });;
     }
   };
 
   useEffect(() => {
-    fetchInspectorData(location.search);
-  }, [location.search, clickEventCall]);
+    if (query)
+      fetchInspectorData(query);
+  }, [query]);
+
+  useEffect(() => {
+    let userId;
+    if (userId = new URLSearchParams(location.search).get('edx_user_id')) {
+      getUser(userId).then(res => {
+        setUsername(res.username);
+        setQuery(`?edx_user=${res.username}&org_key=${activeOrgKey}&external_user_key=${externalUserKey}`)
+      }).catch(err => {
+        setError('An error occured while fetching user id');
+        navigate('/programs')
+      })
+    }
+  }, []);
 
   useEffect(() => {
     if (!orgKeyList) {

--- a/src/ProgramEnrollments/ProgramInspector/ProgramInspector.test.jsx
+++ b/src/ProgramEnrollments/ProgramInspector/ProgramInspector.test.jsx
@@ -48,6 +48,11 @@ describe('Program Inspector', () => {
     externalKey: 'testuser',
   };
 
+  const updateWrapperState = async (w) => {
+    await new Promise((res) => { setTimeout(() => res(), 0); });
+    w.update();
+  };
+
   beforeEach(() => {
     ssoMock = jest
       .spyOn(ssoAndUserApi, 'getSsoRecords')
@@ -213,9 +218,7 @@ describe('Program Inspector', () => {
 
     wrapper = mount(<ProgramEnrollmentsWrapper />);
 
-    await new Promise((res) => { setTimeout(() => res(), 100); });
-    wrapper.update();
-
+    await updateWrapperState(wrapper);
     expect(wrapper.find('Alert').at(0).text()).toEqual('An error occured while fetching user id');
 
     wrapper.find(
@@ -225,11 +228,8 @@ describe('Program Inspector', () => {
       { target: { value: 'AnonyMouse' } },
     );
     wrapper.find('button.btn-primary').simulate('click');
-
-    await new Promise((res) => { setTimeout(() => res(), 100); });
-    wrapper.update();
-
-    expect(wrapper.find('Alert').at(0).text()).toEqual('Five errors occurred');
+    await updateWrapperState(wrapper);
+    expect(wrapper.find('Alert').at(0).text()).toEqual('An error occured while fetching user id');
   });
 
   it('check if SSO is present', async () => {

--- a/src/ProgramEnrollments/ProgramInspector/ProgramInspector.test.jsx
+++ b/src/ProgramEnrollments/ProgramInspector/ProgramInspector.test.jsx
@@ -11,9 +11,10 @@ import {
   programInspectorErrorResponse,
 } from './data/test/programInspector';
 import ssoRecordsData from '../../users/data/test/ssoRecords';
-import * as ssoApi from '../../users/data/api';
+import * as ssoAndUserApi from '../../users/data/api';
 import samlProvidersResponseValues from './data/test/samlProviders';
 import verifiedNameHistory from '../../users/data/test/verifiedNameHistory';
+import UserSummaryData from '../../users/data/test/userSummary';
 
 const mockedNavigator = jest.fn();
 
@@ -38,6 +39,7 @@ describe('Program Inspector', () => {
   let samlMock;
   let ssoMock;
   let verifiedNameMock;
+  let getUserMock;
 
   const data = {
     username: 'verified',
@@ -47,14 +49,17 @@ describe('Program Inspector', () => {
 
   beforeEach(() => {
     ssoMock = jest
-      .spyOn(ssoApi, 'getSsoRecords')
+      .spyOn(ssoAndUserApi, 'getSsoRecords')
       .mockImplementationOnce(() => Promise.resolve(ssoRecordsData));
     samlMock = jest
       .spyOn(api, 'getSAMLProviderList')
       .mockImplementationOnce(() => Promise.resolve(samlProvidersResponseValues));
     verifiedNameMock = jest
-      .spyOn(ssoApi, 'getVerifiedNameHistory')
+      .spyOn(ssoAndUserApi, 'getVerifiedNameHistory')
       .mockImplementationOnce(() => Promise.resolve(verifiedNameHistory));
+    getUserMock = jest
+      .spyOn(ssoAndUserApi, 'getUser')
+      .mockImplementationOnce(() => Promise.resolve(UserSummaryData.userData));
     jest.clearAllMocks();
   });
 
@@ -68,6 +73,7 @@ describe('Program Inspector', () => {
     samlMock.mockReset();
     ssoMock.mockReset();
     verifiedNameMock.mockReset();
+    getUserMock.mockReset();
   });
 
   it('default render', async () => {
@@ -86,6 +92,7 @@ describe('Program Inspector', () => {
     apiMock = jest
       .spyOn(api, 'getProgramEnrollmentsInspector')
       .mockImplementationOnce(() => Promise.resolve(programInspectorSuccessResponse));
+
     wrapper = mount(<ProgramEnrollmentsWrapper />);
 
     wrapper.find("input[name='username']").simulate(
@@ -98,9 +105,12 @@ describe('Program Inspector', () => {
     );
     wrapper.find('button.btn-primary').simulate('click');
 
-    expect(mockedNavigator).toHaveBeenCalledWith(
-      `/programs?edx_user=${data.username}&org_key=${data.orgKey}&external_user_key=`,
-    );
+    await waitFor(() => {
+      expect(mockedNavigator).toHaveBeenCalledWith(
+        `?edx_user_id=${UserSummaryData.userData.id}`,
+      );
+    });
+
     waitFor(() => {
       expect(wrapper.find('.inspector-name-row p.h5').at(0).text()).toEqual(
         'Username',
@@ -137,9 +147,12 @@ describe('Program Inspector', () => {
     );
     wrapper.find('button.btn-primary').simulate('click');
 
-    expect(mockedNavigator).toHaveBeenCalledWith(
-      `/programs?edx_user=&org_key=${data.orgKey}&external_user_key=${data.externalKey}`,
-    );
+    await waitFor(() => {
+      expect(mockedNavigator).toHaveBeenCalledWith(
+        `?edx_user_id=${UserSummaryData.userData.id}`,
+      );
+    });
+
     waitFor(() => {
       expect(wrapper.find('.inspector-name-row p.h5').at(0).text()).toEqual(
         'Username',

--- a/src/ProgramEnrollments/ProgramInspector/ProgramInspector.test.jsx
+++ b/src/ProgramEnrollments/ProgramInspector/ProgramInspector.test.jsx
@@ -214,7 +214,7 @@ describe('Program Inspector', () => {
 
     await waitFor(() => {
       wrapper.update();
-      expect(wrapper.find('Alert').at(0).text()).toEqual('An error occured while fetching user id');
+      expect(wrapper.find('Alert').at(0).text()).toEqual('An error occurred while fetching user id');
     });
 
     wrapper.find(
@@ -227,7 +227,7 @@ describe('Program Inspector', () => {
 
     await waitFor(() => {
       wrapper.update();
-      expect(wrapper.find('Alert').at(0).text()).toEqual('An error occured while fetching user id');
+      expect(wrapper.find('Alert').at(0).text()).toEqual('An error occurred while fetching user id');
       expect(mockedNavigator).toHaveBeenCalledTimes(2);
     });
   });

--- a/src/users/UserPage.jsx
+++ b/src/users/UserPage.jsx
@@ -1,6 +1,6 @@
 import { camelCaseObject } from '@edx/frontend-platform';
 import React, {
-  useCallback, useContext, useEffect, useState, useLayoutEffect,
+  useCallback, useContext, useEffect, useState,
 } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import PageLoading from '../components/common/PageLoading';
@@ -11,7 +11,7 @@ import { isEmail, isValidUsername, isValidLMSUserID } from '../utils/index';
 import { getAllUserData } from './data/api';
 import UserSearch from './UserSearch';
 import LearnerInformation from './LearnerInformation';
-import { LEARNER_INFO_TAB, TAB_PATH_MAP } from '../SupportToolsTab/constants';
+import { TAB_PATH_MAP } from '../SupportToolsTab/constants';
 import CancelRetirement from './account-actions/CancelRetirement';
 
 // Supports urls such as /users/?username={username}, /users/?email={email} and /users/?lms_user_id={lms_user_id}
@@ -46,11 +46,12 @@ export default function UserPage() {
   }
 
   function getUpdatedURL(result) {
-    let lms_id = result?.user?.id;
+    const lmsId = result?.user?.id;
 
-    if (lms_id) {
-      return `${TAB_PATH_MAP['learner-information']}/?lms_user_id=${lms_id}`;
+    if (lmsId) {
+      return `${TAB_PATH_MAP['learner-information']}/?lms_user_id=${lmsId}`;
     }
+    return `${TAB_PATH_MAP['learner-information']}`;
   }
 
   function processSearchResult(searchValue, result) {

--- a/src/users/UserPage.jsx
+++ b/src/users/UserPage.jsx
@@ -45,19 +45,12 @@ export default function UserPage() {
     }
   }
 
-  function getUpdatedURL(value) {
-    const updatedHistory = `${TAB_PATH_MAP['learner-information']}/?PARAM_NAME=${value}`;
-    let identifierType = '';
+  function getUpdatedURL(result) {
+    let lms_id = result?.user?.id;
 
-    if (isEmail(value)) {
-      identifierType = 'email';
-    } else if (isValidLMSUserID(value)) {
-      identifierType = 'lms_user_id';
-    } else if (isValidUsername(value)) {
-      identifierType = 'username';
+    if (lms_id) {
+      return `${TAB_PATH_MAP['learner-information']}/?lms_user_id=${lms_id}`;
     }
-
-    return updatedHistory.replace('PARAM_NAME', identifierType);
   }
 
   function processSearchResult(searchValue, result) {
@@ -69,7 +62,7 @@ export default function UserPage() {
       navigate(`${TAB_PATH_MAP['learner-information']}`, { replace: true });
       document.title = 'Support Tools | edX';
     } else {
-      pushHistoryIfChanged(getUpdatedURL(searchValue));
+      pushHistoryIfChanged(getUpdatedURL(result));
       document.title = `Support Tools | edX | ${searchValue}`;
     }
 
@@ -137,16 +130,7 @@ export default function UserPage() {
     } else if (params.get('lms_user_id') && params.get('lms_user_id') !== userIdentifier) {
       handleFetchSearchResults(params.get('lms_user_id'));
     }
-  }, [params.get('username'), params.get('email'), params.get('lms_user_id')]);
-
-  // To change the url with appropriate query param if query param info is not present in URL
-  useLayoutEffect(() => {
-    if (userIdentifier
-      && location.pathname.indexOf(TAB_PATH_MAP[LEARNER_INFO_TAB]) !== -1
-      && !(params.get('email') || params.get('username') || params.get('lms_user_id'))) {
-      pushHistoryIfChanged(getUpdatedURL(userIdentifier));
-    }
-  });
+  }, []);
 
   return (
     <main className="mt-3 mb-5">

--- a/src/users/UserPage.jsx
+++ b/src/users/UserPage.jsx
@@ -14,7 +14,6 @@ import LearnerInformation from './LearnerInformation';
 import { TAB_PATH_MAP } from '../SupportToolsTab/constants';
 import CancelRetirement from './account-actions/CancelRetirement';
 
-// Supports urls such as /users/?username={username}, /users/?email={email} and /users/?lms_user_id={lms_user_id}
 export default function UserPage() {
   const location = useLocation();
   const navigate = useNavigate();

--- a/src/users/UserPage.test.jsx
+++ b/src/users/UserPage.test.jsx
@@ -43,7 +43,6 @@ describe('User Page', () => {
     jest.spyOn(ssoAndUserApi, 'getSsoRecords').mockImplementation(() => Promise.resolve(ssoRecordsData));
     jest.spyOn(ssoAndUserApi, 'getLicense').mockImplementation(() => Promise.resolve(licensesData));
     jest.spyOn(ssoAndUserApi, 'getEntitlements').mockImplementation(() => Promise.resolve(entitlementsData));
-    jest.spyOn(ssoAndUserApi, 'getEnrollments').mockImplementation(() => Promise.resolve(enrollmentsData));
     jest.spyOn(ssoAndUserApi, 'getEnterpriseCustomerUsers').mockImplementation(() => Promise.resolve(enterpriseCustomerUsersData));
 
     jest.clearAllMocks();

--- a/src/users/UserPage.test.jsx
+++ b/src/users/UserPage.test.jsx
@@ -51,14 +51,10 @@ describe('User Page', () => {
 
   it('default render', async () => {
     wrapper = mount(<UserPageWrapper />);
-
     wrapper.find(
       "input[name='userIdentifier']",
     ).instance().value = 'ANonyMouse';
     wrapper.find('.btn.btn-primary').simulate('click');
-
-    await new Promise((res) => { setTimeout(() => res(), 500); });
-    wrapper.update();
 
     await waitFor(() => {
       expect(mockedNavigator).toHaveBeenCalledWith(

--- a/src/users/UserPage.test.jsx
+++ b/src/users/UserPage.test.jsx
@@ -1,0 +1,69 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { waitFor } from '@testing-library/react';
+import UserMessagesProvider from '../userMessages/UserMessagesProvider';
+import UserPage from './UserPage';
+import * as ssoAndUserApi from './data/api';
+import UserSummaryData from './data/test/userSummary';
+import verifiedNameHistoryData from './data/test/verifiedNameHistory';
+import onboardingStatusData from './data/test/onboardingStatus';
+import { entitlementsData } from './data/test/entitlements';
+import enterpriseCustomerUsersData from './data/test/enterpriseCustomerUsers';
+import { enrollmentsData } from './data/test/enrollments';
+import ssoRecordsData from './data/test/ssoRecords';
+import licensesData from './data/test/licenses';
+
+const mockedNavigator = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigator,
+}));
+
+const UserPageWrapper = () => (
+  <MemoryRouter>
+    <IntlProvider locale="en">
+      <UserMessagesProvider>
+        <UserPage />
+      </UserMessagesProvider>
+    </IntlProvider>
+  </MemoryRouter>
+);
+
+describe('User Page', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    jest.spyOn(ssoAndUserApi, 'getAllUserData').mockImplementation(() => Promise.resolve({ user: UserSummaryData.userData, errors: [] }));
+    jest.spyOn(ssoAndUserApi, 'getVerifiedNameHistory').mockImplementation(() => Promise.resolve(verifiedNameHistoryData));
+    jest.spyOn(ssoAndUserApi, 'getEnrollments').mockImplementation(() => Promise.resolve(enrollmentsData));
+    jest.spyOn(ssoAndUserApi, 'getOnboardingStatus').mockImplementation(() => Promise.resolve(onboardingStatusData));
+    jest.spyOn(ssoAndUserApi, 'getSsoRecords').mockImplementation(() => Promise.resolve(ssoRecordsData));
+    jest.spyOn(ssoAndUserApi, 'getLicense').mockImplementation(() => Promise.resolve(licensesData));
+    jest.spyOn(ssoAndUserApi, 'getEntitlements').mockImplementation(() => Promise.resolve(entitlementsData));
+    jest.spyOn(ssoAndUserApi, 'getEnrollments').mockImplementation(() => Promise.resolve(enrollmentsData));
+    jest.spyOn(ssoAndUserApi, 'getEnterpriseCustomerUsers').mockImplementation(() => Promise.resolve(enterpriseCustomerUsersData));
+
+    jest.clearAllMocks();
+  });
+
+  it('default render', async () => {
+    wrapper = mount(<UserPageWrapper />);
+
+    wrapper.find(
+      "input[name='userIdentifier']",
+    ).instance().value = 'ANonyMouse';
+    wrapper.find('.btn.btn-primary').simulate('click');
+
+    await new Promise((res) => { setTimeout(() => res(), 500); });
+    wrapper.update();
+
+    await waitFor(() => {
+      expect(mockedNavigator).toHaveBeenCalledWith(
+        `/learner_information/?lms_user_id=${UserSummaryData.userData.id}`,
+      );
+    });
+  });
+});

--- a/src/users/UserPage.test.jsx
+++ b/src/users/UserPage.test.jsx
@@ -34,9 +34,9 @@ const UserPageWrapper = () => (
 
 describe('User Page', () => {
   let wrapper;
-
+  let mockedGetUserData;
   beforeEach(() => {
-    jest.spyOn(ssoAndUserApi, 'getAllUserData').mockImplementation(() => Promise.resolve({ user: UserSummaryData.userData, errors: [] }));
+    mockedGetUserData = jest.spyOn(ssoAndUserApi, 'getAllUserData').mockImplementation(() => Promise.resolve({ user: UserSummaryData.userData, errors: [] }));
     jest.spyOn(ssoAndUserApi, 'getVerifiedNameHistory').mockImplementation(() => Promise.resolve(verifiedNameHistoryData));
     jest.spyOn(ssoAndUserApi, 'getEnrollments').mockImplementation(() => Promise.resolve(enrollmentsData));
     jest.spyOn(ssoAndUserApi, 'getOnboardingStatus').mockImplementation(() => Promise.resolve(onboardingStatusData));
@@ -53,13 +53,14 @@ describe('User Page', () => {
     wrapper = mount(<UserPageWrapper />);
     wrapper.find(
       "input[name='userIdentifier']",
-    ).instance().value = 'ANonyMouse';
+    ).instance().value = 'AnonyMouse';
     wrapper.find('.btn.btn-primary').simulate('click');
 
     await waitFor(() => {
       expect(mockedNavigator).toHaveBeenCalledWith(
         `/learner_information/?lms_user_id=${UserSummaryData.userData.id}`,
       );
+      expect(mockedGetUserData).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
# [PROD-4319](https://2u-internal.atlassian.net/browse/PROD-4319)

This PR makes the following changes:-

1. Update the Learner Information Page to append lms_user_id in the query params even in the case when the search is through a username or email.
2. Update the Program Inspector page to append the edx_user_id in the query params instead of the edx_user, org_key and external_user_key params.

These changes are intended to remove PII like emails and usernames from the urls.