### PR TITLE
fix: some issues with program inspector

### DIFF
--- a/src/ProgramEnrollments/ProgramInspector/ProgramInspector.jsx
+++ b/src/ProgramEnrollments/ProgramInspector/ProgramInspector.jsx
@@ -24,7 +24,6 @@ export default function ProgramInspector() {
   const [activeOrgKey, setActiveOrgKey] = useState(params.get('org_key'));
   const [orgKeyList, setOrgKeyList] = useState(undefined);
   const [externalUserKey, setExternalUserKey] = useState(params.get('external_user_key'));
-
   const [query, setQuery] = useState(null);
 
   const getOrgKeyList = () => (orgKeyList
@@ -45,7 +44,8 @@ export default function ProgramInspector() {
       const newQuery = `?edx_user=${
         username || ''
       }&org_key=${activeOrgKey}&external_user_key=${externalUserKey || ''}`;
-      setQuery(newQuery);
+      navigate('/programs');
+      setQuery({ uri: newQuery });
     }
   };
 
@@ -65,20 +65,24 @@ export default function ProgramInspector() {
         setLearnerProgramEnrollment(response.learner_program_enrollments);
         const name = response?.learner_program_enrollments?.user?.username;
         return name;
-      }).then((name) => getUser(name)).then((res) => {
-        navigate(`?edx_user_id=${res.id}`);
-      })
-        .catch(err => {
+      }).then((name) => {
+        if (!name) {
+          return null;
+        }
+        return getUser(name).then((res) => {
+          navigate(`?edx_user_id=${res.id}`);
+        }).catch(err => {
           console.error(err);
           setError('An error occurred while fetching user id');
           navigate('/programs');
         });
+      });
     }
   };
 
   useEffect(() => {
     if (query) {
-      fetchInspectorData(query);
+      fetchInspectorData(query.uri);
     }
   }, [query]);
 
@@ -87,7 +91,7 @@ export default function ProgramInspector() {
     if (userId) {
       getUser(userId).then(res => {
         setUsername(res.username);
-        setQuery(`?edx_user=${res.username}&org_key=${activeOrgKey}&external_user_key=${externalUserKey}`);
+        setQuery({ uri: `?edx_user=${res.username}&org_key=${activeOrgKey}&external_user_key=${externalUserKey}` });
       }).catch(err => {
         console.error(err);
         setError('An error occurred while fetching user id');

--- a/src/ProgramEnrollments/ProgramInspector/ProgramInspector.test.jsx
+++ b/src/ProgramEnrollments/ProgramInspector/ProgramInspector.test.jsx
@@ -228,7 +228,7 @@ describe('Program Inspector', () => {
     await waitFor(() => {
       wrapper.update();
       expect(wrapper.find('Alert').at(0).text()).toEqual('An error occurred while fetching user id');
-      expect(mockedNavigator).toHaveBeenCalledTimes(2);
+      expect(mockedNavigator).toHaveBeenCalledTimes(3);
     });
   });
 


### PR DESCRIPTION


This PR resolves some issues (introduced in [452](https://github.com/openedx/frontend-app-support-tools/pull/452)) with the ProgramInspector :-

1. If a network request fails for a search, running the same search won't retry the request, as the query state has not changed. We change the query from a string type to object type to circumvent this. This is also in line with the earlier behavior (from before [452](https://github.com/openedx/frontend-app-support-tools/pull/452))

2. Remove existing search params whenever a new search is made. Not doing this causes older params to linger for a while until the new search updates the params (asynchronously). Depending on the network, this might take some time.

3. Fix the error message when the getProgramEnrollments call "fails" (e.g when searching for a non-existent user).