### PR TITLE
fix: Resolve email encoding for the payload

### DIFF
--- a/src/users/data/api.js
+++ b/src/users/data/api.js
@@ -542,7 +542,15 @@ export async function postTogglePasswordStatus(user, comment) {
 
 export async function postResetPassword(email) {
   try {
-    const { data } = await getAuthenticatedHttpClient().post(AppUrls.getResetPasswordUrl(), `email_from_support_tools=${encodeURIComponent(email)}`);
+    const { data } = await getAuthenticatedHttpClient().post(
+      AppUrls.getResetPasswordUrl(),
+      { email_from_support_tools: email },
+      {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      },
+    );
     return data;
   } catch (error) {
     return {

--- a/src/users/data/api.js
+++ b/src/users/data/api.js
@@ -542,7 +542,7 @@ export async function postTogglePasswordStatus(user, comment) {
 
 export async function postResetPassword(email) {
   try {
-    const { data } = await getAuthenticatedHttpClient().post(AppUrls.getResetPasswordUrl(), `email_from_support_tools=${email}`);
+    const { data } = await getAuthenticatedHttpClient().post(AppUrls.getResetPasswordUrl(), `email_from_support_tools=${encodeURIComponent(email)}`);
     return data;
   } catch (error) {
     return {

--- a/src/users/data/api.test.js
+++ b/src/users/data/api.test.js
@@ -551,10 +551,17 @@ describe('API', () => {
   describe('Reset Password', () => {
     const resetPasswordApiUrl = `${getConfig().LMS_BASE_URL}/account/password`;
 
-    it('Reset Password Response', async () => {
+    test.each([
+      'email@example.com',
+      'email.name+test@example.com',
+      'email_name-test@example.com',
+    ])('Reset Password Response for %s', async (email) => {
       const expectedResponse = {};
-      mockAdapter.onPost(resetPasswordApiUrl, `email_from_support_tools=${encodeURIComponent(testEmail)}`).reply(200, expectedResponse);
-      const response = await api.postResetPassword(testEmail);
+      mockAdapter.onPost(
+        resetPasswordApiUrl,
+        `email_from_support_tools=${encodeURIComponent(email)}`,
+      ).reply(200, expectedResponse);
+      const response = await api.postResetPassword(email);
       expect(response).toEqual(expectedResponse);
     });
   });

--- a/src/users/data/api.test.js
+++ b/src/users/data/api.test.js
@@ -553,7 +553,7 @@ describe('API', () => {
 
     it('Reset Password Response', async () => {
       const expectedResponse = {};
-      mockAdapter.onPost(resetPasswordApiUrl, `email_from_support_tools=${testEmail}`).reply(200, expectedResponse);
+      mockAdapter.onPost(resetPasswordApiUrl, `email_from_support_tools=${encodeURIComponent(testEmail)}`).reply(200, expectedResponse);
       const response = await api.postResetPassword(testEmail);
       expect(response).toEqual(expectedResponse);
     });


### PR DESCRIPTION
**Description:**
This PR addresses an issue with email encoding when sending data to the API. Previously, email addresses containing special characters—such as the + symbol—were being misinterpreted due to incorrect string handling in the request payload. This fix ensures that email addresses are properly encoded before being sent, preserving their integrity during API communication.

**Support ticket:**
https://2u-internal.atlassian.net/browse/INF-1888

**Testing instruction:**
Submit a password reset request via the Support Tool using an email address that contains a '+' character, and verify that the reset password API call completes successfully.