### PR TITLE
docs: Mark repo as unmaintained since 2u-phoenix disbanded

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -12,7 +12,7 @@ metadata:
       icon: 'Web'
   openedx.org/release: "master"    
 spec:
-  owner: group:2u-phoenix
+  owner: group:openedx-unmaintained
   type: 'service'
   lifecycle: 'production'
   dependsOn:


### PR DESCRIPTION
The @openedx/2u-phoenix team is empty. Are there new members, or should we delete the team and mark its repos as unmaintained?