### PR TITLE
build: remove unused reactifex packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
       },
       "devDependencies": {
         "@edx/browserslist-config": "^1.1.0",
-        "@edx/reactifex": "^1.0.3",
         "@openedx/frontend-build": "^14.3.3",
         "@testing-library/dom": "^9.3.4",
         "@testing-library/jest-dom": "^5.17.0",
@@ -56,8 +55,7 @@
         "glob": "7.1.6",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "react-test-renderer": "^17.0.2",
-        "reactifex": "1.1.1"
+        "react-test-renderer": "^17.0.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2227,26 +2225,6 @@
       "license": "AGPL-3.0",
       "bin": {
         "atlas": "atlas"
-      }
-    },
-    "node_modules/@edx/reactifex": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^0.21.1",
-        "yargs": "^17.1.1"
-      },
-      "bin": {
-        "edx_reactifex": "main.js"
-      }
-    },
-    "node_modules/@edx/reactifex/node_modules/axios": {
-      "version": "0.21.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/@edx/typescript-config": {
@@ -15726,14 +15704,6 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
-      }
-    },
-    "node_modules/reactifex": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "reactifex": "main.js"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
   },
   "devDependencies": {
     "@edx/browserslist-config": "^1.1.0",
-    "@edx/reactifex": "^1.0.3",
     "@openedx/frontend-build": "^14.3.3",
     "@testing-library/dom": "^9.3.4",
     "@testing-library/jest-dom": "^5.17.0",
@@ -77,7 +76,6 @@
     "glob": "7.1.6",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "react-test-renderer": "^17.0.2",
-    "reactifex": "1.1.1"
+    "react-test-renderer": "^17.0.2"
   }
 }


### PR DESCRIPTION
Remove reactifex and @edx/reactifex packages from devDependencies as they are no longer
needed. Translation extraction functionality has been verified to work
correctly without these dependencies.

Co-Authored-By: Claude <noreply@anthropic.com>
